### PR TITLE
Add a .gitignore file to the initial project scaffold

### DIFF
--- a/src/scaffold.cr
+++ b/src/scaffold.cr
@@ -23,6 +23,12 @@ module Mint
       }
       MAIN
 
+    GIT_IGNORE =
+      <<-GIT_IGNORE
+      .mint
+      dist
+      GIT_IGNORE
+
     getter name
 
     def self.run(name : String)
@@ -41,6 +47,7 @@ module Mint
       terminal.print "#{COG} Writing initial files...\n\n"
       File.write(File.join("source", "Main.mint"), MAIN)
       File.write("mint.json", json.to_pretty_json)
+      File.write(".gitignore", GIT_IGNORE)
 
       Installer.new
     end


### PR DESCRIPTION
Ignore the `dist` folder because it's normally not add to the repositories.

Is the correct to ignore the `.mint` folder, I'm not sure?
