### PR TITLE
Add debounce to live reload

### DIFF
--- a/src/assets/live-reload.js
+++ b/src/assets/live-reload.js
@@ -12,7 +12,8 @@
   // On try close reconnect, it will happen during the development
   // of Mint.
   ws.onclose = () => {
-    connect(true);
+    // Debounce so we don't end up in an infinite restart loop
+    setTimeout(() => connect(true), 200);
   };
 
   // Reload on message


### PR DESCRIPTION
# Overview
This fixes a bug where the live refresh can infinitely reload the page on Firefox. It might also happen on other browsers, though I'm not sure. 

# Changes Made
On the websocket's `onclose`, change `connect(true)` -> `setInterval(() => connect(true), 200);`