### PR TITLE
feat: adding --auto-format flag for development server

### DIFF
--- a/src/commands/start.cr
+++ b/src/commands/start.cr
@@ -4,10 +4,14 @@ module Mint
       include Command
 
       define_help description: "Starts the development server."
+      define_flag auto_format : Bool,
+                  description: "Auto formats the source files when running development server.",
+                  default: false,
+                  required: false
 
       def run
         execute "Running the development server" do
-          Reactor.start
+          Reactor.start flags.auto_format
         end
       end
     end

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -2,13 +2,15 @@ module Mint
   # Reactor is the development server of Mint, it have the following features:
   # * Servers the compiled application script, index file and favicons
   # * Watches all source files (application and packages as well) and if any
-  #   changed it formats that file, removes its AST from the cache, parses it
+  #   changed it removes its AST from the cache, parses it
   #   again and then recompiles the application script
   # * Renders any error as HTML
   # * Keeps a cache of ASTs of the parsed files for faster recompilation
+  # * When --auto-format flag is passed all source files are watched and if
+  #   any changes it formats the file
   class Reactor
-    def self.start
-      new
+    def self.start(auto_format : Bool)
+      new auto_format
     end
 
     getter script
@@ -17,10 +19,11 @@ module Mint
     @cache = {} of String => Ast
     @pattern = [] of String
     @script = ""
+    @auto_format : Bool
 
     @error : String | Nil
 
-    def initialize
+    def initialize(@auto_format)
       @pattern = SourceFiles.all
       @error = nil
 
@@ -42,11 +45,13 @@ module Mint
           artifact =
             Parser.parse(file)
 
-          formatted =
-            Formatter.new(artifact).format
+          if @auto_format
+            formatted =
+              Formatter.new(artifact).format
 
-          if formatted != File.read(file)
-            File.write(file, formatted)
+            if formatted != File.read(file)
+              File.write(file, formatted)
+            end
           end
 
           artifact


### PR DESCRIPTION
### Feature
Adding `--auto-format` flag for a development server. By default its false, so files are not going to be formatted on save. Would love to get feedback as I don't have a lot of experience with Crystal.

Implements #12 
Fixes #10 