### PR TITLE
Read repository without .git extension

### DIFF
--- a/src/installer/repository.cr
+++ b/src/installer/repository.cr
@@ -18,7 +18,7 @@ module Mint
       @target : String | Nil
 
       def self.open(name = "", url = "", target = nil, version = nil)
-        if !url.ends_with?(".git")
+        if url.includes?("http") && !url.ends_with?(".git")
           url = "#{url}.git"
         end
 

--- a/src/installer/repository.cr
+++ b/src/installer/repository.cr
@@ -18,6 +18,10 @@ module Mint
       @target : String | Nil
 
       def self.open(name = "", url = "", target = nil, version = nil)
+        if !url.ends_with?(".git")
+          url = "#{url}.git"
+        end
+
         repository = new(name, url, target, version)
         repository.open
         repository


### PR DESCRIPTION
Seems unnecessary to modify `mint.json` repository URL to contain `.git`. Currently more user friendly