### PR TITLE
provide option to disable service workers on build

### DIFF
--- a/src/builder.cr
+++ b/src/builder.cr
@@ -1,6 +1,6 @@
 module Mint
   class Builder
-    def initialize(relative)
+    def initialize(relative, noServiceWorker)
       json = MintJson.parse_current
 
       terminal.measure "#{COG} Ensuring dependencies... " do
@@ -23,7 +23,7 @@ module Mint
       File.write "dist/index.js", index
 
       terminal.measure "#{COG} Writing index.html... " do
-        File.write "dist/index.html", IndexHtml.render(Environment::BUILD, relative)
+        File.write "dist/index.html", IndexHtml.render(Environment::BUILD, relative, noServiceWorker)
       end
 
       terminal.measure "#{COG} Writing manifest.json..." do
@@ -34,8 +34,10 @@ module Mint
         icons(json)
       end
 
-      terminal.measure "#{COG} Creating service worker..." do
-        File.write "dist/service-worker.js", ServiceWorker.generate
+      if !noServiceWorker
+        terminal.measure "#{COG} Creating service worker..." do
+          File.write "dist/service-worker.js", ServiceWorker.generate
+        end
       end
     end
 

--- a/src/builder.cr
+++ b/src/builder.cr
@@ -1,6 +1,6 @@
 module Mint
   class Builder
-    def initialize(relative, noServiceWorker)
+    def initialize(relative, no_service_worker)
       json = MintJson.parse_current
 
       terminal.measure "#{COG} Ensuring dependencies... " do
@@ -23,7 +23,7 @@ module Mint
       File.write "dist/index.js", index
 
       terminal.measure "#{COG} Writing index.html... " do
-        File.write "dist/index.html", IndexHtml.render(Environment::BUILD, relative, noServiceWorker)
+        File.write "dist/index.html", IndexHtml.render(Environment::BUILD, relative, no_service_worker)
       end
 
       terminal.measure "#{COG} Writing manifest.json..." do
@@ -34,7 +34,7 @@ module Mint
         icons(json)
       end
 
-      if !noServiceWorker
+      if !no_service_worker
         terminal.measure "#{COG} Creating service worker..." do
           File.write "dist/service-worker.js", ServiceWorker.generate
         end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -11,7 +11,7 @@ module Mint
         default: false,
         short: "r"
 
-      define_flag noServiceWorker : Bool,
+      define_flag no_service_worker : Bool,
         description: "If specified the service worker functionality will be disabled",
         long: "noServiceWorker",
         default: false,
@@ -19,7 +19,7 @@ module Mint
 
       def run
         execute "Building for production" do
-          Builder.new(flags.relative, flags.noServiceWorker)
+          Builder.new(flags.relative, flags.no_service_worker)
         end
       end
     end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -11,9 +11,15 @@ module Mint
         default: false,
         short: "r"
 
+      define_flag noServiceWorker : Bool,
+        description: "If specified the service worker functionality will be disabled",
+        long: "noServiceWorker",
+        default: false,
+        short: "s"
+
       def run
         execute "Building for production" do
-          Builder.new(flags.relative)
+          Builder.new(flags.relative, flags.noServiceWorker)
         end
       end
     end

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -15,11 +15,11 @@ module Mint
 
     getter json, env
 
-    def self.render(env, relative = false)
-      new(env, relative).to_s
+    def self.render(env, relative = false, noServiceWorker = false)
+      new(env, relative, noServiceWorker).to_s
     end
 
-    def initialize(@env : Environment, @relative : Bool)
+    def initialize(@env : Environment, @relative : Bool, @noServiceWorker : Bool)
       @json = MintJson.parse_current
     end
 
@@ -78,14 +78,16 @@ module Mint
               t.script(src: path_for("runtime.js")) { }
               t.script(src: path_for("live-reload.js")) { }
             else
-              t.script(type: "text/javascript") do
-                t.unsafe <<-JS
-                if ('serviceWorker' in navigator) {
-                  window.addEventListener('load', function() {
-                    navigator.serviceWorker.register('/service-worker.js')
-                  })
-                }
-                JS
+              if !@noServiceWorker
+                t.script(type: "text/javascript") do
+                  t.unsafe <<-JS
+                  if ('serviceWorker' in navigator) {
+                    window.addEventListener('load', function() {
+                      navigator.serviceWorker.register('/service-worker.js')
+                    })
+                  }
+                  JS
+                end
               end
             end
 

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -15,11 +15,11 @@ module Mint
 
     getter json, env
 
-    def self.render(env, relative = false, noServiceWorker = false)
-      new(env, relative, noServiceWorker).to_s
+    def self.render(env, relative = false, no_service_worker = false)
+      new(env, relative, no_service_worker).to_s
     end
 
-    def initialize(@env : Environment, @relative : Bool, @noServiceWorker : Bool)
+    def initialize(@env : Environment, @relative : Bool, @no_service_worker : Bool)
       @json = MintJson.parse_current
     end
 
@@ -78,7 +78,7 @@ module Mint
               t.script(src: path_for("runtime.js")) { }
               t.script(src: path_for("live-reload.js")) { }
             else
-              if !@noServiceWorker
+              if !@no_service_worker
                 t.script(type: "text/javascript") do
                   t.unsafe <<-JS
                   if ('serviceWorker' in navigator) {


### PR DESCRIPTION
This provides an option on build to disable the service workers:

    mint build -s | --noServiceWorker

It does not disable service workers for the documentation server.