### PR TITLE
Referencing children of a component

### DIFF
--- a/spec/compilers/argument
+++ b/spec/compilers/argument
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)(``, 0)
+      this.test(``, 0)
 
       return ``
     })()

--- a/spec/compilers/array_access
+++ b/spec/compilers/array_access
@@ -33,9 +33,9 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
-      this.test1.bind(this)()
+      this.test1()
 
       return ``
     })()

--- a/spec/compilers/array_literal
+++ b/spec/compilers/array_literal
@@ -23,7 +23,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/bool_literal_false
+++ b/spec/compilers/bool_literal_false
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/bool_literal_true
+++ b/spec/compilers/bool_literal_true
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/case
+++ b/spec/compilers/case
@@ -33,7 +33,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/case_with_enum_destructuring
+++ b/spec/compilers/case_with_enum_destructuring
@@ -69,7 +69,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)(new $$C_D(new $$A_B(``)))
+      this.test(new $$C_D(new $$A_B(``)))
 
       return ``
     })()

--- a/spec/compilers/catch
+++ b/spec/compilers/catch
@@ -25,7 +25,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Promise = new(class {
+const $Promise = new(class extends Module {
   reject(input) {
     return
   }
@@ -63,7 +63,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/component_instance_access
+++ b/spec/compilers/component_instance_access
@@ -1,0 +1,51 @@
+component Instance {
+  get name : String {
+    "Instance"
+  }
+
+  fun render : Html {
+    <div></div>
+  }
+}
+
+component Main {
+  fun handleClick : String {
+    instance.name
+  }
+
+  fun render : Html {
+    <div onClick={handleClick}>
+      <Instance as instance/>
+    </div>
+  }
+}
+--------------------------------------------------------------------------------
+class $Instance extends Component {
+  get name() {
+    return `Instance`
+  }
+
+  render() {
+    return _createElement("div", {})
+  }
+}
+
+$Instance.displayName = "Instance"
+
+class $Main extends Component {
+  handleClick() {
+    return this._instance.name
+  }
+
+  render() {
+    return _createElement("div", {
+      "onClick": (event => (this.handleClick.bind(this))(_normalizeEvent(event)))
+    }, [_createElement($Instance, {
+      ref: (instance) => {
+        this._instance = instance
+      }
+    })])
+  }
+}
+
+$Main.displayName = "Main"

--- a/spec/compilers/component_instance_access
+++ b/spec/compilers/component_instance_access
@@ -39,7 +39,7 @@ class $Main extends Component {
 
   render() {
     return _createElement("div", {
-      "onClick": (event => (this.handleClick.bind(this))(_normalizeEvent(event)))
+      "onClick": (event => (this.handleClick)(_normalizeEvent(event)))
     }, [_createElement($Instance, {
       ref: (instance) => {
         this._instance = instance

--- a/spec/compilers/dce_remove_module_function
+++ b/spec/compilers/dce_remove_module_function
@@ -14,7 +14,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Test = new(class {
+const $Test = new(class extends Module {
   test() {
     return ``
   }

--- a/spec/compilers/decode
+++ b/spec/compilers/decode
@@ -69,7 +69,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      let _0 = this.x.bind(this)();
+      let _0 = this.x();
 
       if (_0 instanceof Err) {
         let _error = _0.value

--- a/spec/compilers/decoder
+++ b/spec/compilers/decoder
@@ -109,7 +109,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      let _0 = this.x.bind(this)();
+      let _0 = this.x();
 
       if (_0 instanceof Err) {
         let _error = _0.value

--- a/spec/compilers/encode
+++ b/spec/compilers/encode
@@ -51,7 +51,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.encode.bind(this)()
+      this.encode()
 
       return ``
     })()

--- a/spec/compilers/enum
+++ b/spec/compilers/enum
@@ -102,11 +102,11 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.a.bind(this)()
+      this.a()
 
-      this.b.bind(this)()
+      this.b()
 
-      this.c.bind(this)()
+      this.c()
 
       return ``
     })()

--- a/spec/compilers/finally
+++ b/spec/compilers/finally
@@ -38,7 +38,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/function
+++ b/spec/compilers/function
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/function_call_simple
+++ b/spec/compilers/function_call_simple
@@ -22,12 +22,12 @@ class $Main extends Component {
   }
 
   test() {
-    return this.a.bind(this)()
+    return this.a()
   }
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/function_call_with_arguments
+++ b/spec/compilers/function_call_with_arguments
@@ -22,12 +22,12 @@ class $Main extends Component {
   }
 
   test() {
-    return this.call.bind(this)(`Hello`, true)
+    return this.call(`Hello`, true)
   }
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/function_with_where
+++ b/spec/compilers/function_with_where
@@ -24,7 +24,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/html_attribute_ref
+++ b/spec/compilers/html_attribute_ref
@@ -1,6 +1,6 @@
 component Main {
   fun render : Html {
-    <div ref={(element : Dom.Element) : Void => { void }}>
+    <div as input>
     </div>
   }
 }
@@ -8,11 +8,9 @@ component Main {
 class $Main extends Component {
   render() {
     return _createElement("div", {
-      "ref": (ref => {
-        ref ? ((element) => {
-          return null
-        }).call(this, ref) : null
-      })
+      ref: (element) => {
+        this._input = element
+      }
     })
   }
 }

--- a/spec/compilers/if
+++ b/spec/compilers/if
@@ -23,7 +23,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/inline_function_with_arguments
+++ b/spec/compilers/inline_function_with_arguments
@@ -26,7 +26,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/js_with_double_interpolation
+++ b/spec/compilers/js_with_double_interpolation
@@ -14,7 +14,7 @@ class $Main extends Component {
   }
 
   render() {
-    return "Hello" + this.test.bind(this)("World!")
+    return "Hello" + this.test("World!")
   }
 }
 

--- a/spec/compilers/js_with_interpolation
+++ b/spec/compilers/js_with_interpolation
@@ -14,7 +14,7 @@ class $Main extends Component {
   }
 
   render() {
-    return "Hello" + this.test.bind(this)()
+    return "Hello" + this.test()
   }
 }
 

--- a/spec/compilers/module
+++ b/spec/compilers/module
@@ -12,7 +12,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Html_Testing = new(class {
+const $Html_Testing = new(class extends Module {
   renderAll() {
     return _createElement("p", {}, [`It should work`])
   }

--- a/spec/compilers/module_access
+++ b/spec/compilers/module_access
@@ -17,13 +17,13 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Test = new(class {
+const $Test = new(class extends Module {
   a() {
     return `Hello`
   }
 
   b() {
-    return $Test.a.bind($Test)
+    return $Test.a
   }
 })
 

--- a/spec/compilers/module_call
+++ b/spec/compilers/module_call
@@ -14,7 +14,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Test = new(class {
+const $Test = new(class extends Module {
   a(value) {
     return value
   }

--- a/spec/compilers/module_call_piped
+++ b/spec/compilers/module_call_piped
@@ -15,7 +15,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Test = new(class {
+const $Test = new(class extends Module {
   a(value, x) {
     return value
   }

--- a/spec/compilers/next_call
+++ b/spec/compilers/next_call
@@ -47,7 +47,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/number_literal_negative
+++ b/spec/compilers/number_literal_negative
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/number_literal_simple
+++ b/spec/compilers/number_literal_simple
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/number_literal_with_decimal
+++ b/spec/compilers/number_literal_with_decimal
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/operation_chanined
+++ b/spec/compilers/operation_chanined
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/operation_simple
+++ b/spec/compilers/operation_simple
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/parallel_simple
+++ b/spec/compilers/parallel_simple
@@ -50,7 +50,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/parallel_with_catch
+++ b/spec/compilers/parallel_with_catch
@@ -33,7 +33,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Promise = new(class {
+const $Promise = new(class extends Module {
   reject(input) {
     return
   }
@@ -101,7 +101,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/parallel_with_catch_all
+++ b/spec/compilers/parallel_with_catch_all
@@ -31,7 +31,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Promise = new(class {
+const $Promise = new(class extends Module {
   reject(input) {
     return
   }
@@ -74,7 +74,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/parenthesized_expression
+++ b/spec/compilers/parenthesized_expression
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return ``
     })()

--- a/spec/compilers/record
+++ b/spec/compilers/record
@@ -54,7 +54,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/record_field
+++ b/spec/compilers/record_field
@@ -54,7 +54,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/record_update
+++ b/spec/compilers/record_update
@@ -54,7 +54,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_simple
+++ b/spec/compilers/sequence_simple
@@ -34,7 +34,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_using_argument
+++ b/spec/compilers/sequence_using_argument
@@ -54,7 +54,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_with_argument
+++ b/spec/compilers/sequence_with_argument
@@ -37,7 +37,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_with_catch
+++ b/spec/compilers/sequence_with_catch
@@ -33,7 +33,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Promise = new(class {
+const $Promise = new(class extends Module {
   reject(input) {
     return
   }
@@ -95,7 +95,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_with_finally
+++ b/spec/compilers/sequence_with_finally
@@ -38,7 +38,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_with_result_and_catch
+++ b/spec/compilers/sequence_with_result_and_catch
@@ -24,7 +24,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Result = new(class {
+const $Result = new(class extends Module {
   error(input) {
     return new Err(input)
   }
@@ -64,7 +64,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/sequence_with_result_and_catch_all
+++ b/spec/compilers/sequence_with_result_and_catch_all
@@ -24,7 +24,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Result = new(class {
+const $Result = new(class extends Module {
   error(input) {
     return new Err(input)
   }
@@ -57,7 +57,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      this.test.bind(this)()
+      this.test()
 
       return _createElement("div", {})
     })()

--- a/spec/compilers/state
+++ b/spec/compilers/state
@@ -33,7 +33,7 @@ class $Main extends Component {
   }
 
   render() {
-    return this.x.bind(this)()
+    return this.x()
   }
 }
 

--- a/spec/compilers/try_with_catch_all
+++ b/spec/compilers/try_with_catch_all
@@ -17,7 +17,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Result = new(class {
+const $Result = new(class extends Module {
   error(input) {
     return new Err(input)
   }

--- a/spec/compilers/try_with_catches
+++ b/spec/compilers/try_with_catches
@@ -17,7 +17,7 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $Result = new(class {
+const $Result = new(class extends Module {
   error(input) {
     return new Err(input)
   }

--- a/spec/compilers/variable_argument
+++ b/spec/compilers/variable_argument
@@ -14,7 +14,7 @@ class $Main extends Component {
   }
 
   render() {
-    return this.test.bind(this)(`X`)
+    return this.test(`X`)
   }
 }
 

--- a/spec/compilers/variable_component_function
+++ b/spec/compilers/variable_component_function
@@ -14,7 +14,7 @@ class $Main extends Component {
   }
 
   render() {
-    return this.a.bind(this)()
+    return this.a()
   }
 }
 

--- a/spec/compilers/variable_module_function
+++ b/spec/compilers/variable_module_function
@@ -16,13 +16,13 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $A = new(class {
+const $A = new(class extends Module {
   a() {
     return `Hello`
   }
 
   b() {
-    return $A.a.bind($A)
+    return $A.a
   }
 })
 

--- a/spec/compilers/variable_where
+++ b/spec/compilers/variable_where
@@ -19,7 +19,7 @@ class $Main extends Component {
   }
 
   render() {
-    return this.test.bind(this)()
+    return this.test()
   }
 }
 

--- a/spec/compilers/void
+++ b/spec/compilers/void
@@ -19,7 +19,7 @@ class $Main extends Component {
 
   render() {
     return (() => {
-      let x = this.test.bind(this)
+      let x = this.test
 
       return ``
     })()

--- a/spec/compilers/where
+++ b/spec/compilers/where
@@ -24,7 +24,7 @@ class $Main extends Component {
   }
 
   render() {
-    return this.test.bind(this)()
+    return this.test()
   }
 }
 

--- a/spec/compilers/with
+++ b/spec/compilers/with
@@ -13,12 +13,22 @@ component Main {
 }
 --------------------------------------------------------------------------------
 const $X = new(class {
+  constructor() {
+    this.a = this.a.bind(this)
+  }
+
   a() {
     return ``
   }
 })
 
 class $Main extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {}
+    this.render = this.render.bind(this)
+  }
+
   render() {
     return $X.a.bind($X)()
   }

--- a/spec/compilers/with
+++ b/spec/compilers/with
@@ -12,25 +12,15 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-const $X = new(class {
-  constructor() {
-    this.a = this.a.bind(this)
-  }
-
+const $X = new(class extends Module {
   a() {
     return ``
   }
 })
 
 class $Main extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {}
-    this.render = this.render.bind(this)
-  }
-
   render() {
-    return $X.a.bind($X)()
+    return $X.a()
   }
 }
 

--- a/spec/parsers/html_component_spec.cr
+++ b/spec/parsers/html_component_spec.cr
@@ -6,6 +6,7 @@ describe "Html Component" do
   expect_error "<T.", Mint::Parser::HtmlComponentExpectedType
   expect_error "<T>", Mint::Parser::HtmlComponentExpectedClosingTag
   expect_error "<T", Mint::Parser::HtmlComponentExpectedClosingBracket
+  expect_error "<T as", Mint::Parser::HtmlComponentExpectedReference
   expect_error "<T a-s={a}>", Mint::Parser::HtmlAttributeExpectedEqualSign
   expect_error "<T a={a}b={b}>", Mint::Parser::HtmlComponentExpectedClosingTag
 

--- a/spec/parsers/html_element_spec.cr
+++ b/spec/parsers/html_element_spec.cr
@@ -8,6 +8,7 @@ describe "Html Element" do
 
   expect_error "<a", Mint::Parser::HtmlElementExpectedClosingBracket
   expect_error "<a::", Mint::Parser::HtmlElementExpectedStyle
+  expect_error "<a as", Mint::Parser::HtmlElementExpectedReference
   expect_error "<a::a", Mint::Parser::HtmlElementExpectedClosingBracket
   expect_error "<a::a ", Mint::Parser::HtmlElementExpectedClosingBracket
   expect_error "<a::a a={a}b={b}", Mint::Parser::HtmlElementExpectedClosingBracket

--- a/spec/type_checking/component
+++ b/spec/type_checking/component
@@ -23,7 +23,14 @@ component Main {
     true
   }
 }
-
+--------------------------------------------------ComponentReferenceNameConflict
+component Main {
+  fun render : Html {
+    <div as x>
+      <div as x/>
+    </div>
+  }
+}
 ----------------------------------------------------ComponentFunctionTypeMismatch
 component Main {
   fun componentDidUpdate (a : String) : String {

--- a/spec/type_checking/html_attribute_ref
+++ b/spec/type_checking/html_attribute_ref
@@ -1,9 +1,9 @@
 component Main {
   fun render : Html {
-    <div ref={(element : Dom.Element) : Void => { void }}/>
+    <div/>
   }
 }
----------------------------------------HtmlAttributeElementAttributeTypeMismatch
+---------------------------------------------------------HtmlElementRefForbidden
 component Main {
   fun render : Html {
     <div ref="Hello"/>

--- a/spec/type_checking/html_element_not_in_component
+++ b/spec/type_checking/html_element_not_in_component
@@ -20,3 +20,33 @@ component Main {
     X.render()
   }
 }
+------------------------------------------HtmlElementReferenceOutsideOfComponent
+module X {
+  fun render : Html {
+    <div as x/>
+  }
+}
+
+component Main {
+  fun render : Html {
+    X.render()
+  }
+}
+----------------------------------------HtmlComponentReferenceOutsideOfComponent
+module X {
+  fun render : Html {
+    <Test as x/>
+  }
+}
+
+component Test {
+  fun render : Html {
+    <div/>
+  }
+}
+
+component Main {
+  fun render : Html {
+    X.render()
+  }
+}

--- a/src/ast/component.cr
+++ b/src/ast/component.cr
@@ -4,9 +4,7 @@ module Mint
       getter properties, connects, styles, states, comments
       getter functions, gets, uses, name, comment, refs
 
-      property resolved_refs = {} of String => Component
-
-      def initialize(@refs : Array(Tuple(Variable, HtmlComponent)),
+      def initialize(@refs : Array(Tuple(Variable, Node)),
                      @properties : Array(Property),
                      @functions : Array(Function),
                      @comments : Array(Comment),

--- a/src/ast/component.cr
+++ b/src/ast/component.cr
@@ -2,9 +2,12 @@ module Mint
   class Ast
     class Component < Node
       getter properties, connects, styles, states, comments
-      getter functions, gets, uses, name, comment
+      getter functions, gets, uses, name, comment, refs
 
-      def initialize(@properties : Array(Property),
+      property resolved_refs = {} of String => Component
+
+      def initialize(@refs : Array(Tuple(Variable, HtmlComponent)),
+                     @properties : Array(Property),
                      @functions : Array(Function),
                      @comments : Array(Comment),
                      @connects : Array(Connect),

--- a/src/ast/html_component.cr
+++ b/src/ast/html_component.cr
@@ -1,11 +1,12 @@
 module Mint
   class Ast
     class HtmlComponent < Node
-      getter attributes, children, component, comments
+      getter attributes, children, component, comments, ref
 
       def initialize(@attributes : Array(HtmlAttribute),
                      @children : Array(HtmlContent),
                      @comments : Array(Comment),
+                     @ref : Variable | Nil,
                      @component : String,
                      @input : Data,
                      @from : Int32,

--- a/src/ast/html_element.cr
+++ b/src/ast/html_element.cr
@@ -1,12 +1,13 @@
 module Mint
   class Ast
     class HtmlElement < Node
-      getter attributes, children, style, tag, comments
+      getter attributes, children, style, tag, comments, ref
 
       def initialize(@attributes : Array(HtmlAttribute),
                      @children : Array(HtmlContent),
                      @comments : Array(Comment),
                      @style : Variable | Nil,
+                     @ref : Variable | Nil,
                      @tag : Variable,
                      @input : Data,
                      @from : Int32,

--- a/src/compilers/component.cr
+++ b/src/compilers/component.cr
@@ -33,15 +33,22 @@ module Mint
               .join(",\n")
 
           "new Record({\n#{values.indent}\n})"
+        else
+          "{}"
         end
+
+      binds =
+        node
+          .functions
+          .select { |item| checked.includes?(item) }
+          .map { |item| "this.#{item.name.value} = this.#{item.name.value}.bind(this)" }
+          .join("\n")
 
       constructor_contents =
-        "super(props)\nthis.state = #{state}"
+        "super(props)\nthis.state = #{state}\n#{binds}"
 
       constructor =
-        if state
-          "constructor(props) {\n#{constructor_contents.indent}\n}"
-        end
+        "constructor(props) {\n#{constructor_contents.indent}\n}"
 
       body =
         ([constructor] + gets + properties + states + store_stuff + functions)

--- a/src/compilers/component.cr
+++ b/src/compilers/component.cr
@@ -33,22 +33,15 @@ module Mint
               .join(",\n")
 
           "new Record({\n#{values.indent}\n})"
-        else
-          "{}"
         end
 
-      binds =
-        node
-          .functions
-          .select { |item| checked.includes?(item) }
-          .map { |item| "this.#{item.name.value} = this.#{item.name.value}.bind(this)" }
-          .join("\n")
-
       constructor_contents =
-        "super(props)\nthis.state = #{state}\n#{binds}"
+        "super(props)\nthis.state = #{state}"
 
       constructor =
-        "constructor(props) {\n#{constructor_contents.indent}\n}"
+        if state
+          "constructor(props) {\n#{constructor_contents.indent}\n}"
+        end
 
       body =
         ([constructor] + gets + properties + states + store_stuff + functions)

--- a/src/compilers/html_component.cr
+++ b/src/compilers/html_component.cr
@@ -15,11 +15,14 @@ module Mint
         node
           .attributes
           .map { |item| compile(item, false).as(String) }
-          .join(", ")
+
+      node.ref.try do |ref|
+        attributes << "ref: (instance) => { this._#{ref.value} = instance }"
+      end
 
       contents =
         ["$#{underscorize(node.component)}",
-         "{ #{attributes} }",
+         "{ #{attributes.join(", ")} }",
          children]
           .reject(&.empty?)
           .join(", ")

--- a/src/compilers/html_element.cr
+++ b/src/compilers/html_element.cr
@@ -75,6 +75,10 @@ module Mint
         attributes.push "style: {\n#{items}\n}" unless items.strip.empty?
       end
 
+      node.ref.try do |ref|
+        attributes << "ref: (element) => { this._#{ref.value} = element }"
+      end
+
       attributes =
         if attributes.empty?
           "{}"

--- a/src/compilers/module.cr
+++ b/src/compilers/module.cr
@@ -7,7 +7,22 @@ module Mint
       name =
         underscorize node.name
 
-      "const $#{name} = new(class {\n#{body.indent}\n})"
+      binds =
+        node
+          .functions
+          .select { |item| checked.includes?(item) }
+          .map { |item| "this.#{item.name.value} = this.#{item.name.value}.bind(this)" }
+          .join("\n")
+
+      <<-A
+      const $#{name} = new(class {
+        constructor() {
+        #{binds.indent}
+        }
+
+      #{body.indent}
+      })
+      A
     end
   end
 end

--- a/src/compilers/module.cr
+++ b/src/compilers/module.cr
@@ -7,19 +7,8 @@ module Mint
       name =
         underscorize node.name
 
-      binds =
-        node
-          .functions
-          .select { |item| checked.includes?(item) }
-          .map { |item| "this.#{item.name.value} = this.#{item.name.value}.bind(this)" }
-          .join("\n")
-
       <<-A
-      const $#{name} = new(class {
-        constructor() {
-        #{binds.indent}
-        }
-
+      const $#{name} = new(class extends Module {
       #{body.indent}
       })
       A

--- a/src/compilers/module_access.cr
+++ b/src/compilers/module_access.cr
@@ -7,12 +7,7 @@ module Mint
       variable =
         node.variable.value
 
-      case lookups[node]
-      when Ast::Function
-        "$#{name}.#{variable}.bind($#{name})"
-      else
-        "$#{name}.#{variable}"
-      end
+      "$#{name}.#{variable}"
     end
   end
 end

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -155,7 +155,6 @@ module Mint
         }
 
         const TestContext = Mint.TestContext;
-        const Component = Mint.Component;
         const ReactDOM = Mint.ReactDOM;
         const Provider = Mint.Provider;
         const Nothing = Mint.Nothing;
@@ -171,6 +170,49 @@ module Mint
 
         class DoError extends Error {}
 
+        const excludedMethods = [
+          'componentWillMount',
+          'UNSAFE_componentWillMount',
+          'render',
+          'getSnapshotBeforeUpdate',
+          'componentDidMount',
+          'componentWillReceiveProps',
+          'UNSAFE_componentWillReceiveProps',
+          'shouldComponentUpdate',
+          'componentWillUpdate',
+          'UNSAFE_componentWillUpdate',
+          'componentDidUpdate',
+          'componentWillUnmount',
+          'componentDidCatch',
+          'setState',
+          'forceUpdate',
+          'constructor'
+        ]
+
+        const bindFunctions = (target) => {
+          const descriptors =
+            Object.getOwnPropertyDescriptors(Reflect.getPrototypeOf(target))
+
+          for (let key in descriptors) {
+            if (excludedMethods[key]) { continue }
+            const value = descriptors[key].value
+            if (typeof value !== "function") { continue }
+            target[key] = value.bind(target)
+          }
+        }
+
+        class Module {
+          constructor() {
+            bindFunctions(this)
+          }
+        }
+
+        class Component extends Mint.Component {
+          constructor(props) {
+            super(props)
+            bindFunctions(this)
+          }
+        }
         #{body}
       })()
       RESULT

--- a/src/compilers/variable.cr
+++ b/src/compilers/variable.cr
@@ -9,6 +9,8 @@ module Mint
       end
 
       case item[0]
+      when Ast::Component
+        "this._#{node.value}"
       when Ast::Function
         entity = item[1]
         case entity

--- a/src/compilers/variable.cr
+++ b/src/compilers/variable.cr
@@ -9,7 +9,7 @@ module Mint
       end
 
       case item[0]
-      when Ast::Component
+      when Ast::Component, Ast::HtmlElement
         "this._#{node.value}"
       when Ast::Function
         entity = item[1]

--- a/src/compilers/variable.cr
+++ b/src/compilers/variable.cr
@@ -18,9 +18,9 @@ module Mint
           name =
             underscorize(entity.name)
 
-          "$#{name}.#{node.value}.bind($#{name})"
+          "$#{name}.#{node.value}"
         else
-          "this.#{node.value}.bind(this)"
+          "this.#{node.value}"
         end
       when Ast::Property, Ast::Get, Ast::State
         "this.#{node.value}"

--- a/src/formatters/html_component.cr
+++ b/src/formatters/html_component.cr
@@ -4,7 +4,15 @@ module Mint
       component =
         format node.component
 
-      format(prefix: component, tag: component, node: node)
+      ref =
+        node.ref.try do |variable|
+          name =
+            format variable
+
+          " as #{name}"
+        end || ""
+
+      format(prefix: component + ref, tag: component, node: node)
     end
   end
 end

--- a/src/formatters/html_element.cr
+++ b/src/formatters/html_element.cr
@@ -14,7 +14,15 @@ module Mint
           tag
         end
 
-      format(prefix: prefix, tag: tag, node: node)
+      ref =
+        node.ref.try do |variable|
+          name =
+            format variable
+
+          " as #{name}"
+        end || ""
+
+      format(prefix: prefix + ref, tag: tag, node: node)
     end
   end
 end

--- a/src/messages/component_reference_name_conflict.cr
+++ b/src/messages/component_reference_name_conflict.cr
@@ -1,0 +1,11 @@
+message ComponentReferenceNameConflict do
+  title "Type Error"
+
+  block do
+    text "There are multiple references with the name:"
+    bold "#{name}."
+  end
+
+  snippet node, "One reference is here:"
+  snippet other, "An other reference is here:"
+end

--- a/src/messages/html_component_expected_reference.cr
+++ b/src/messages/html_component_expected_reference.cr
@@ -1,0 +1,15 @@
+message HtmlComponentExpectedReference do
+  title "Syntax Error"
+
+  block do
+    text "I was looking for the"
+    bold "identifier"
+    text "of the component after the"
+    code "as"
+    text "keyword but found"
+    code got
+    text "instead."
+  end
+
+  snippet node
+end

--- a/src/messages/html_component_reference_outside_of_component.cr
+++ b/src/messages/html_component_reference_outside_of_component.cr
@@ -1,0 +1,9 @@
+message HtmlComponentReferenceOutsideOfComponent do
+  title "Type Error"
+
+  block do
+    text "Referencing components are not allowed outside of components."
+  end
+
+  snippet node
+end

--- a/src/messages/html_element_expected_reference.cr
+++ b/src/messages/html_element_expected_reference.cr
@@ -1,0 +1,15 @@
+message HtmlElementExpectedReference do
+  title "Syntax Error"
+
+  block do
+    text "I was looking for the"
+    bold "identifier"
+    text "of the element after the"
+    code "as"
+    text "keyword but found"
+    code got
+    text "instead."
+  end
+
+  snippet node
+end

--- a/src/messages/html_element_ref_forbidden.cr
+++ b/src/messages/html_element_ref_forbidden.cr
@@ -1,0 +1,13 @@
+message HtmlElementRefForbidden do
+  title "Type Error"
+
+  block do
+    text "The use of ref attribute is forbidden."
+  end
+
+  block do
+    text "If you want to save a reference to an element, use the as keyword."
+  end
+
+  snippet node
+end

--- a/src/messages/html_element_reference_outside_of_component.cr
+++ b/src/messages/html_element_reference_outside_of_component.cr
@@ -1,0 +1,9 @@
+message HtmlElementReferenceOutsideOfComponent do
+  title "Type Error"
+
+  block do
+    text "Referencing elements are not allowed outside of components."
+  end
+
+  snippet node
+end

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -3,7 +3,7 @@ module Mint
     getter input, position, file, ast, data, refs
 
     def initialize(@input : String, @file : String)
-      @refs = [] of {Ast::Variable, Ast::HtmlComponent}
+      @refs = [] of {Ast::Variable, Ast::HtmlComponent | Ast::HtmlElement}
       @data = Ast::Data.new(@input, @file)
       @ast = Ast.new
       @position = 0

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -1,8 +1,9 @@
 module Mint
   class Parser
-    getter input, position, file, ast, data
+    getter input, position, file, ast, data, refs
 
     def initialize(@input : String, @file : String)
+      @refs = [] of {Ast::Variable, Ast::HtmlComponent}
       @data = Ast::Data.new(@input, @file)
       @ast = Ast.new
       @position = 0

--- a/src/parsers/component.cr
+++ b/src/parsers/component.cr
@@ -14,6 +14,9 @@ module Mint
 
         name = type_id! ComponentExpectedName
 
+        # Clear refs here beacuse it's on the parser
+        refs.clear
+
         body = block(
           opening_bracket: ComponentExpectedOpeningBracket,
           closing_bracket: ComponentExpectedClosingBracket
@@ -78,6 +81,7 @@ module Mint
           name: name,
           uses: uses,
           gets: gets,
+          refs: refs
         )
       end
     end

--- a/src/parsers/html_component.cr
+++ b/src/parsers/html_component.cr
@@ -14,20 +14,32 @@ module Mint
 
         skip unless component
 
+        ref = start do
+          whitespace
+          skip unless keyword "as"
+          whitespace
+          variable! SyntaxError
+        end
+
         attributes, children, comments = html_body(
           expected_closing_bracket: HtmlComponentExpectedClosingBracket,
           expected_closing_tag: HtmlComponentExpectedClosingTag,
           with_dashes: false,
           tag: component)
 
-        Ast::HtmlComponent.new(
+        node = Ast::HtmlComponent.new(
           attributes: attributes,
           from: start_position,
           component: component,
           children: children,
           comments: comments,
           to: position,
-          input: data)
+          input: data,
+          ref: ref)
+
+        refs << {ref, node} if ref
+
+        node
       end
     end
   end

--- a/src/parsers/html_component.cr
+++ b/src/parsers/html_component.cr
@@ -2,6 +2,7 @@ module Mint
   class Parser
     syntax_error HtmlComponentExpectedClosingBracket
     syntax_error HtmlComponentExpectedClosingTag
+    syntax_error HtmlComponentExpectedReference
     syntax_error HtmlComponentExpectedType
 
     def html_component : Ast::HtmlComponent | Nil
@@ -18,7 +19,7 @@ module Mint
           whitespace
           skip unless keyword "as"
           whitespace
-          variable! SyntaxError
+          variable! HtmlComponentExpectedReference
         end
 
         attributes, children, comments = html_body(

--- a/src/parsers/html_element.cr
+++ b/src/parsers/html_element.cr
@@ -2,6 +2,7 @@ module Mint
   class Parser
     syntax_error HtmlElementExpectedClosingBracket
     syntax_error HtmlElementExpectedClosingTag
+    syntax_error HtmlElementExpectedReference
     syntax_error HtmlElementExpectedStyle
 
     def html_element : Ast::HtmlElement | Nil
@@ -22,7 +23,7 @@ module Mint
           whitespace
           skip unless keyword "as"
           whitespace
-          variable! SyntaxError
+          variable! HtmlElementExpectedReference
         end
 
         attributes, children, comments = html_body(

--- a/src/parsers/html_element.cr
+++ b/src/parsers/html_element.cr
@@ -18,13 +18,20 @@ module Mint
           style = variable_with_dashes! HtmlElementExpectedStyle
         end
 
+        ref = start do
+          whitespace
+          skip unless keyword "as"
+          whitespace
+          variable! SyntaxError
+        end
+
         attributes, children, comments = html_body(
           expected_closing_bracket: HtmlElementExpectedClosingBracket,
           expected_closing_tag: HtmlElementExpectedClosingTag,
           with_dashes: true,
           tag: tag)
 
-        Ast::HtmlElement.new(
+        node = Ast::HtmlElement.new(
           attributes: attributes,
           from: start_position,
           children: children,
@@ -32,7 +39,12 @@ module Mint
           style: style,
           to: position,
           input: data,
-          tag: tag)
+          tag: tag,
+          ref: ref)
+
+        refs << {ref, node} if ref
+
+        node
       end
     end
   end

--- a/src/type_checker.cr
+++ b/src/type_checker.cr
@@ -16,7 +16,6 @@ module Mint
     OBJECT_ERROR   = Type.new("Object.Error")
     ARRAY          = Type.new("Array", [Variable.new("a")] of Checkable)
     MAYBE          = Type.new("Maybe", [Variable.new("a")] of Checkable)
-    REF_FUNCTION   = Type.new("Function", [Type.new("Dom.Element"), VOID] of Checkable)
     EVENT_FUNCTION = Type.new("Function", [EVENT, Variable.new("a")] of Checkable)
     HTML_CHILDREN  = Type.new("Array", [HTML] of Checkable)
     TEXT_CHILDREN  = Type.new("Array", [STRING] of Checkable)

--- a/src/type_checkers/access.cr
+++ b/src/type_checkers/access.cr
@@ -32,7 +32,7 @@ module Mint
           end
         end
       when Nil
-        raise TypeError
+        resolve node.fields.first
       else
         check_record_access(node.fields.first, node, 1)
       end

--- a/src/type_checkers/access.cr
+++ b/src/type_checkers/access.cr
@@ -5,15 +5,49 @@ module Mint
     type_error AccessNotRecord
 
     def check(node : Ast::Access) : Checkable
-      target =
+      first =
+        lookup node.fields.first
+
+      case first
+      when Ast::Component
         resolve node.fields.first
+
+        scope first do
+          second =
+            lookup node.fields[1]
+
+          raise AccessFieldNotRecord, {
+            "field"  => node.fields[1].value,
+            "object" => second,
+            "node"   => node.fields[1],
+          } unless second
+
+          resolved =
+            resolve node.fields[1]
+
+          if resolved.is_a?(Record)
+            check_record_access(node.fields[1], node, 2)
+          else
+            resolved
+          end
+        end
+      when Nil
+        raise TypeError
+      else
+        check_record_access(node.fields.first, node, 1)
+      end
+    end
+
+    def check_record_access(first, node, from) : Checkable
+      target =
+        resolve first
 
       raise AccessNotRecord, {
         "object" => target,
         "node"   => node,
       } unless target.is_a?(Record)
 
-      node.fields[1..node.fields.size].each do |field|
+      node.fields[from..node.fields.size].each do |field|
         case target
         when Record
           new_target = target.fields[field.value]?

--- a/src/type_checkers/component.cr
+++ b/src/type_checkers/component.cr
@@ -1,5 +1,6 @@
 module Mint
   class TypeChecker
+    type_error ComponentReferenceNameConflict
     type_error ComponentFunctionTypeMismatch
     type_error ComponentExposedNameConflict
     type_error ComponentRenderTypeMismatch
@@ -35,6 +36,22 @@ module Mint
       check_names(node.functions, ComponentEntityNameConflict, checked)
       check_names(node.states, ComponentStateNameConflict, checked)
       check_names(node.gets, ComponentEntityNameConflict, checked)
+
+      # Checking for ref conflicts
+      node.refs.reduce({} of String => Ast::Node) do |memo, (variable, ref)|
+        name = variable.value
+
+        if other = memo[name]?
+          raise ComponentReferenceNameConflict, {
+            "other" => other,
+            "name"  => name,
+            "node"  => ref,
+          }
+        end
+
+        memo[name] = ref
+        memo
+      end
 
       # Checking for style name conflicts
       node.styles.reduce({} of String => Ast::Node) do |memo, style|

--- a/src/type_checkers/html_attribute.cr
+++ b/src/type_checkers/html_attribute.cr
@@ -7,6 +7,7 @@ module Mint
     type_error HtmlAttributeFragmentKeyTypeMismatch
     type_error HtmlElementClassNameForbidden
     type_error HtmlElementStyleForbidden
+    type_error HtmlElementRefForbidden
 
     def check(node : Ast::HtmlAttribute, element : Ast::HtmlFragment)
       got =
@@ -28,7 +29,9 @@ module Mint
       expected =
         case node.name.value.downcase
         when "ref"
-          [REF_FUNCTION]
+          raise HtmlElementRefForbidden, {
+            "node" => node,
+          }
         when .starts_with?("on")
           [EVENT_FUNCTION, VOID_FUNCTION]
         when "readonly", "disabled"

--- a/src/type_checkers/html_component.cr
+++ b/src/type_checkers/html_component.cr
@@ -1,5 +1,6 @@
 module Mint
   class TypeChecker
+    type_error HtmlComponentReferenceOutsideOfComponent
     type_error HtmlComponentNotFoundComponent
 
     def check(node : Ast::HtmlComponent) : Checkable
@@ -14,6 +15,12 @@ module Mint
       resolve component
 
       node.attributes.each { |attribute| resolve attribute, component }
+
+      node.ref.try do |ref|
+        raise HtmlComponentReferenceOutsideOfComponent, {
+          "node" => ref,
+        } unless component?
+      end
 
       check_html node.children
 

--- a/src/type_checkers/html_element.cr
+++ b/src/type_checkers/html_element.cr
@@ -1,5 +1,6 @@
 module Mint
   class TypeChecker
+    type_error HtmlElementReferenceOutsideOfComponent
     type_error HtmlElementStyleOutsideOfComponent
     type_error HtmlElementNotFoundStyle
 
@@ -23,6 +24,12 @@ module Mint
         resolve style_node
 
         html_elements[node] = component
+      end
+
+      node.ref.try do |ref|
+        raise HtmlElementReferenceOutsideOfComponent, {
+          "node" => ref,
+        } unless component?
       end
 
       node.attributes.each { |attribute| resolve attribute, node }

--- a/src/type_checkers/scope.cr
+++ b/src/type_checkers/scope.cr
@@ -140,6 +140,7 @@ module Mint
           node.gets.find(&.name.value.==(variable)) ||
           node.properties.find(&.name.value.==(variable)) ||
           node.states.find(&.name.value.==(variable)) ||
+          refs(component)[variable]? ||
           store_states(component)[variable]? ||
           store_functions(component)[variable]? ||
           store_gets(component)[variable]?
@@ -180,6 +181,19 @@ module Mint
         yield
       ensure
         nodes.each { |node| @levels.delete node }
+      end
+
+      private def refs(component)
+        component.refs.reduce({} of String => Ast::Component) do |memo, (variable, item)|
+          @ast
+            .components
+            .find(&.name.==(item.component))
+            .try do |entity|
+              memo[variable.value] = entity
+            end
+
+          memo
+        end
       end
 
       private def store_states(component)

--- a/src/type_checkers/scope.cr
+++ b/src/type_checkers/scope.cr
@@ -184,13 +184,18 @@ module Mint
       end
 
       private def refs(component)
-        component.refs.reduce({} of String => Ast::Component) do |memo, (variable, item)|
-          @ast
-            .components
-            .find(&.name.==(item.component))
-            .try do |entity|
-              memo[variable.value] = entity
-            end
+        component.refs.reduce({} of String => Ast::Node | Checkable) do |memo, (variable, item)|
+          case item
+          when Ast::HtmlComponent
+            @ast
+              .components
+              .find(&.name.==(item.component))
+              .try do |entity|
+                memo[variable.value] = entity
+              end
+          when Ast::HtmlElement
+            memo[variable.value] = item
+          end
 
           memo
         end

--- a/src/type_checkers/variable.cr
+++ b/src/type_checkers/variable.cr
@@ -23,7 +23,11 @@ module Mint
 
       variables[node] = item
 
-      resolve item[0]
+      if item[0].is_a?(Ast::HtmlElement) && item[1].is_a?(Ast::Component)
+        Type.new("Dom.Element")
+      else
+        resolve item[0]
+      end
     end
   end
 end


### PR DESCRIPTION
## TODO

- [x] implement `as` keyword
- [x] restrict using `as` only in component (like `style`)
- [x] check for naming conflicts of the referenced values

## Description
This PR adds the ability to reference HTML elements and child components of a component by name (using the `as` keyword).

In reality this allows for the two main use cases:

1. opening  a model with it's own state:
```
component Modal {
  state shown : Bool = false

  fun open : Promise(Never, Void) {
    next { shown = true }
  }

  fun render : Html {
    if (shown) {
      <div>
        <{ "Modal" }>
      </div>
    } else {
      <></>
    }
  }
}

component Main {
  fun handleClick : Promise(Never, Void) {
    modal.open()
  }

  fun render : Html {
    <div>
      <Modal as modal/>
      <button onClick={handleClick}>
        <{ "Open Modal" }>
      </button>
    </div>
  }
}
```

2. focusing an input:
```
component Main {
  fun handleClick : Promise(Never, Void) {
    Dom.focus(input)
  }

  fun render : Html {
    <div>
      <input as input/>
      <button onClick={handleClick}>
        <{ "Open Modal" }>
      </button>
    </div>
  }
}
```