### PR TITLE
For Expression

### DIFF
--- a/spec/compilers/for
+++ b/spec/compilers/for
@@ -1,0 +1,26 @@
+component Main {
+  fun render : Array(Html) {
+    for (item of ["A", "B"]) {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+--------------------------------------------------------------------------------
+class $Main extends Component {
+  render() {
+    return (() => {
+      const _0 = []
+      const _1 = [`A`, `B`]
+
+      for (let item of _1) {
+        _0.push(_createElement("div", {}, [item]))
+      }
+
+      return _0
+    })()
+  }
+}
+
+$Main.displayName = "Main"

--- a/spec/formatters/for
+++ b/spec/formatters/for
@@ -1,0 +1,15 @@
+component Main {
+  fun render : Array(String) {
+    for (item of ["B"]){item}when{item == "A"}
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun render : Array(String) {
+    for (item of ["B"]) {
+      item
+    } when {
+      item == "A"
+    }
+  }
+}

--- a/spec/parsers/for_spec.cr
+++ b/spec/parsers/for_spec.cr
@@ -7,20 +7,19 @@ describe "For Expression" do
   expect_ignore "::"
   expect_ignore "asd"
 
-  expect_error "for", Mint::Parser::ForExpectedOpeningParentheses
   expect_error "for ", Mint::Parser::ForExpectedOpeningParentheses
   expect_error "for (", Mint::Parser::ForExpectedOf
-  expect_error "for (a : A", Mint::Parser::ForExpectedOf
-  expect_error "for (a : A, b : B", Mint::Parser::ForExpectedOf
-  expect_error "for (a : A, b : B of", Mint::Parser::ForExpectedSubject
-  expect_error "for (a : A, b : B of a", Mint::Parser::ForExpectedClosingParentheses
-  expect_error "for (a : A, b : B of a)", Mint::Parser::ForExpectedOpeningBracket
-  expect_error "for (a : A, b : B of a) {", Mint::Parser::ForExpectedBody
-  expect_error "for (a : A, b : B of a) { x", Mint::Parser::ForExpectedClosingBracket
-  expect_error "for (a : A, b : B of a) { x } when", Mint::Parser::ForConditionExpectedOpeningBracket
-  expect_error "for (a : A, b : B of a) { x } when {", Mint::Parser::ForConditionExpectedBody
-  expect_error "for (a : A, b : B of a) { x } when { x", Mint::Parser::ForConditionExpectedClosingBracket
+  expect_error "for (a", Mint::Parser::ForExpectedOf
+  expect_error "for (a, b", Mint::Parser::ForExpectedOf
+  expect_error "for (a, b of", Mint::Parser::ForExpectedSubject
+  expect_error "for (a, b of a", Mint::Parser::ForExpectedClosingParentheses
+  expect_error "for (a, b of a)", Mint::Parser::ForExpectedOpeningBracket
+  expect_error "for (a, b of a) {", Mint::Parser::ForExpectedBody
+  expect_error "for (a, b of a) { x", Mint::Parser::ForExpectedClosingBracket
+  expect_error "for (a, b of a) { x } when", Mint::Parser::ForConditionExpectedOpeningBracket
+  expect_error "for (a, b of a) { x } when {", Mint::Parser::ForConditionExpectedBody
+  expect_error "for (a, b of a) { x } when { x", Mint::Parser::ForConditionExpectedClosingBracket
 
-  expect_ok "for (a : A, b : B of a) { x }"
-  expect_ok "for (a : A, b : B of a) { x } when { x }"
+  expect_ok "for (a, b of a) { x }"
+  expect_ok "for (a, b of a) { x } when { x }"
 end

--- a/spec/parsers/for_spec.cr
+++ b/spec/parsers/for_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+describe "For Expression" do
+  subject for_expression
+
+  expect_ignore "."
+  expect_ignore "::"
+  expect_ignore "asd"
+
+  expect_error "for", Mint::Parser::ForExpectedOpeningParentheses
+  expect_error "for ", Mint::Parser::ForExpectedOpeningParentheses
+  expect_error "for (", Mint::Parser::ForExpectedOf
+  expect_error "for (a : A", Mint::Parser::ForExpectedOf
+  expect_error "for (a : A, b : B", Mint::Parser::ForExpectedOf
+  expect_error "for (a : A, b : B of", Mint::Parser::ForExpectedSubject
+  expect_error "for (a : A, b : B of a", Mint::Parser::ForExpectedClosingParentheses
+  expect_error "for (a : A, b : B of a)", Mint::Parser::ForExpectedOpeningBracket
+  expect_error "for (a : A, b : B of a) {", Mint::Parser::ForExpectedBody
+  expect_error "for (a : A, b : B of a) { x", Mint::Parser::ForExpectedClosingBracket
+  expect_error "for (a : A, b : B of a) { x } when", Mint::Parser::ForConditionExpectedOpeningBracket
+  expect_error "for (a : A, b : B of a) { x } when {", Mint::Parser::ForConditionExpectedBody
+  expect_error "for (a : A, b : B of a) { x } when { x", Mint::Parser::ForConditionExpectedClosingBracket
+
+  expect_ok "for (a : A, b : B of a) { x }"
+  expect_ok "for (a : A, b : B of a) { x } when { x }"
+end

--- a/spec/type_checking/for
+++ b/spec/type_checking/for
@@ -1,0 +1,56 @@
+component Main {
+  fun render : Array(Html) {
+    for (item of ["A", "B"]) {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+-----------------------------------------------------------------ForTypeMismatch
+component Main {
+  fun render : Array(Html) {
+    for (item of "A") {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+
+--------------------------------------------------ForArrayOrSetArgumentsMismatch
+component Main {
+  fun render : Array(Html) {
+    for (item, item2 of ["A", "B"]) {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+---------------------------------------------------------ForMapArgumentsMismatch
+component Main {
+  get map : Map(String, String) {
+    ``
+  }
+
+  fun render : Array(Html) {
+    for (item of map) {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+--------------------------------------------------------ForConditionTypeMismatch
+component Main {
+  fun render : Array(Html) {
+    for (item of ["A", "B"]) {
+      <div>
+        <{ item }>
+      </div>
+    } when {
+      item
+    }
+  }
+}

--- a/src/ast/for.cr
+++ b/src/ast/for.cr
@@ -1,12 +1,12 @@
 module Mint
   class Ast
     class For < Node
-      getter head_comments, tail_comments, subject, body, items, condition
+      getter head_comments, tail_comments, subject, body, arguments, condition
 
       def initialize(@head_comments : Array(Comment),
                      @tail_comments : Array(Comment),
                      @condition : ForCondition | Nil,
-                     @items : Array(Argument),
+                     @arguments : Array(Variable),
                      @subject : Expression,
                      @body : Expression,
                      @input : Data,

--- a/src/ast/for.cr
+++ b/src/ast/for.cr
@@ -1,0 +1,18 @@
+module Mint
+  class Ast
+    class For < Node
+      getter head_comments, tail_comments, subject, body, items, condition
+
+      def initialize(@head_comments : Array(Comment),
+                     @tail_comments : Array(Comment),
+                     @condition : ForCondition | Nil,
+                     @items : Array(Argument),
+                     @subject : Expression,
+                     @body : Expression,
+                     @input : Data,
+                     @from : Int32,
+                     @to : Int32)
+      end
+    end
+  end
+end

--- a/src/ast/for_condition.cr
+++ b/src/ast/for_condition.cr
@@ -1,0 +1,15 @@
+module Mint
+  class Ast
+    class ForCondition < Node
+      getter condition, head_comments, tail_comments
+
+      def initialize(@head_comments : Array(Comment),
+                     @tail_comments : Array(Comment),
+                     @condition : Expression,
+                     @input : Data,
+                     @from : Int32,
+                     @to : Int32)
+      end
+    end
+  end
+end

--- a/src/compilers/for_expression.cr
+++ b/src/compilers/for_expression.cr
@@ -1,0 +1,46 @@
+module Mint
+  class Compiler
+    def _compile(node : Ast::For) : String
+      body =
+        compile node.body
+
+      subject =
+        compile node.subject
+
+      arguments =
+        if node.arguments.size == 1
+          node.arguments[0].value
+        else
+          "[" + node.arguments.map(&.value).join(",") + "]"
+        end
+
+      condition =
+        node.condition.try do |item|
+          <<-JS
+          const _2 = #{compile(item)}
+          if (_2) { continue }
+          JS
+        end
+
+      contents =
+        if condition
+          "#{condition}\n_0.push(#{body})"
+        else
+          "_0.push(#{body})"
+        end
+
+      <<-JS
+      (() => {
+        const _0 = []
+        const _1 = #{subject}
+
+        for (let #{arguments} of _1) {
+          #{contents}
+        }
+
+        return _0
+      })()
+      JS
+    end
+  end
+end

--- a/src/compilers/for_expression.cr
+++ b/src/compilers/for_expression.cr
@@ -17,8 +17,8 @@ module Mint
       condition =
         node.condition.try do |item|
           <<-JS
-          const _2 = #{compile(item)}
-          if (_2) { continue }
+          const _2 = #{compile(item.condition)}
+          if (!_2) { continue }
           JS
         end
 

--- a/src/formatters/for.cr
+++ b/src/formatters/for.cr
@@ -1,0 +1,26 @@
+module Mint
+  class Formatter
+    def format(node : Ast::ForCondition) : String
+      body =
+        list [node.condition] + node.head_comments + node.tail_comments
+
+      " when {\n#{indent(body)}\n}"
+    end
+
+    def format(node : Ast::For) : String
+      body =
+        list [node.body] + node.head_comments + node.tail_comments
+
+      subject =
+        format node.subject
+
+      arguments =
+        format node.arguments, ", "
+
+      condition =
+        format node.condition
+
+      "for (#{arguments} of #{subject}) {\n#{indent(body)}\n}#{condition}"
+    end
+  end
+end

--- a/src/formatters/html_expression.cr
+++ b/src/formatters/html_expression.cr
@@ -5,7 +5,7 @@ module Mint
         format node.expression
 
       case node.expression
-      when Ast::If, Ast::StringLiteral, Ast::With, Ast::Case, Ast::Try, Ast::ArrayLiteral
+      when Ast::If, Ast::For, Ast::StringLiteral, Ast::With, Ast::Case, Ast::Try, Ast::ArrayLiteral
         expression
       else
         if expression.includes?("\n")

--- a/src/messages/for_array_or_set_arguments_mismatch.cr
+++ b/src/messages/for_array_or_set_arguments_mismatch.cr
@@ -1,0 +1,10 @@
+message ForArrayOrSetArgumentsMismatch do
+  title "Type Error"
+
+  block do
+    text "If the iterable object of a for expression is a set or an array."
+    text "Then it needs to the have only one argument."
+  end
+
+  snippet node
+end

--- a/src/messages/for_condition_expected_body.cr
+++ b/src/messages/for_condition_expected_body.cr
@@ -1,0 +1,14 @@
+message ForConditionExpectedBody do
+  title "Syntax Error"
+
+  block do
+    text "A"
+    bold "when"
+    text "must have exactly"
+    bold "one expression."
+  end
+
+  was_looking_for "expression", got
+
+  snippet node
+end

--- a/src/messages/for_condition_expected_closing_bracket.cr
+++ b/src/messages/for_condition_expected_closing_bracket.cr
@@ -1,0 +1,7 @@
+message ForConditionExpectedClosingBracket do
+  title "Syntax Error"
+
+  closing_bracket "when", got
+
+  snippet node
+end

--- a/src/messages/for_condition_expected_opening_bracket.cr
+++ b/src/messages/for_condition_expected_opening_bracket.cr
@@ -1,0 +1,7 @@
+message ForConditionExpectedOpeningBracket do
+  title "Syntax Error"
+
+  opening_bracket "when", got
+
+  snippet node
+end

--- a/src/messages/for_condition_type_mismatch.cr
+++ b/src/messages/for_condition_type_mismatch.cr
@@ -1,0 +1,11 @@
+message ForConditionTypeMismatch do
+  title "Type Error"
+
+  block do
+    text "The condition of a for expression has an invalid type."
+  end
+
+  was_expecting_type expected, got
+
+  snippet node
+end

--- a/src/messages/for_expected_body.cr
+++ b/src/messages/for_expected_body.cr
@@ -1,0 +1,14 @@
+message ForExpectedBody do
+  title "Syntax Error"
+
+  block do
+    text "A"
+    bold "for expression"
+    text "must have exactly"
+    bold "one expression."
+  end
+
+  was_looking_for "expression", got
+
+  snippet node
+end

--- a/src/messages/for_expected_closing_bracket.cr
+++ b/src/messages/for_expected_closing_bracket.cr
@@ -1,0 +1,7 @@
+message ForExpectedClosingBracket do
+  title "Syntax Error"
+
+  closing_bracket "for expression", got
+
+  snippet node
+end

--- a/src/messages/for_expected_closing_parentheses.cr
+++ b/src/messages/for_expected_closing_parentheses.cr
@@ -1,0 +1,15 @@
+message ForExpectedClosingParentheses do
+  title "Syntax Error"
+
+  block do
+    text "The"
+    bold "condition"
+    text "of a"
+    bold "for expression"
+    text "must be enclosed by parenthesis."
+  end
+
+  was_looking_for "closing parenthesis", got, ")"
+
+  snippet node
+end

--- a/src/messages/for_expected_of.cr
+++ b/src/messages/for_expected_of.cr
@@ -1,0 +1,14 @@
+message ForExpectedOf do
+  title "Syntax Error"
+
+  block do
+    text "The arguments of a "
+    bold "for expression"
+    text "and it's subject must be separated with"
+    bold "of keyword."
+  end
+
+  was_looking_for "the of keyword", got
+
+  snippet node
+end

--- a/src/messages/for_expected_opening_bracket.cr
+++ b/src/messages/for_expected_opening_bracket.cr
@@ -1,0 +1,7 @@
+message ForExpectedOpeningBracket do
+  title "Syntax Error"
+
+  opening_bracket "for expression", got
+
+  snippet node
+end

--- a/src/messages/for_expected_opening_parentheses.cr
+++ b/src/messages/for_expected_opening_parentheses.cr
@@ -1,0 +1,16 @@
+message ForExpectedOpeningParentheses do
+  title "Syntax Error"
+
+  block do
+    text "I was looking for the "
+    bold "opening parenthesis "
+    code "("
+    text "of a"
+    bold "for expression "
+    text "but found "
+    code got
+    text " instead."
+  end
+
+  snippet node
+end

--- a/src/messages/for_expected_subject.cr
+++ b/src/messages/for_expected_subject.cr
@@ -1,0 +1,15 @@
+message ForExpectedSubject do
+  title "Syntax Error"
+
+  block do
+    text "I was looking for the"
+    bold "subject"
+    text "of a for expression"
+
+    text "but found"
+    code got
+    text "instead."
+  end
+
+  snippet node
+end

--- a/src/messages/for_map_arguments_mismatch.cr
+++ b/src/messages/for_map_arguments_mismatch.cr
@@ -1,0 +1,10 @@
+message ForMapArgumentsMismatch do
+  title "Type Error"
+
+  block do
+    text "If the iterable object of a for expression is a map."
+    text "Then it needs to the have two arguments."
+  end
+
+  snippet node
+end

--- a/src/messages/for_type_mismatch.cr
+++ b/src/messages/for_type_mismatch.cr
@@ -1,0 +1,17 @@
+message ForTypeMismatch do
+  title "Type Error"
+
+  block do
+    text "The iterable object of a for expression has an invalid type."
+  end
+
+  block do
+    text "I was expecting one of the following types:"
+  end
+
+  pre "Array(a), Set(a), Map(a, b)"
+
+  type_with_text got, "Instead it is:"
+
+  snippet node
+end

--- a/src/parsers/basic_expression.cr
+++ b/src/parsers/basic_expression.cr
@@ -18,6 +18,7 @@ module Mint
         decode ||
         encode ||
         if_expression ||
+        for_expression ||
         with_expression ||
         next_call ||
         sequence ||

--- a/src/parsers/for.cr
+++ b/src/parsers/for.cr
@@ -11,15 +11,15 @@ module Mint
     def for_expression : Ast::For | Nil
       start do |start_position|
         skip unless keyword "for"
+        whitespace! SkipError
 
-        whitespace
         char '(', ForExpectedOpeningParentheses
         whitespace
 
-        items = list(
+        arguments = list(
           terminator: ')',
           separator: ','
-        ) { argument }.compact
+        ) { variable }.compact
 
         whitespace
         keyword! "of", ForExpectedOf
@@ -46,9 +46,9 @@ module Mint
           head_comments: head_comments,
           tail_comments: tail_comments,
           condition: condition,
+          arguments: arguments,
           from: start_position,
           subject: subject,
-          items: items,
           to: position,
           input: data,
           body: body)

--- a/src/parsers/for.cr
+++ b/src/parsers/for.cr
@@ -1,0 +1,58 @@
+module Mint
+  class Parser
+    syntax_error ForExpectedOpeningParentheses
+    syntax_error ForExpectedClosingParentheses
+    syntax_error ForExpectedOpeningBracket
+    syntax_error ForExpectedClosingBracket
+    syntax_error ForExpectedSubject
+    syntax_error ForExpectedBody
+    syntax_error ForExpectedOf
+
+    def for_expression : Ast::For | Nil
+      start do |start_position|
+        skip unless keyword "for"
+
+        whitespace
+        char '(', ForExpectedOpeningParentheses
+        whitespace
+
+        items = list(
+          terminator: ')',
+          separator: ','
+        ) { argument }.compact
+
+        whitespace
+        keyword! "of", ForExpectedOf
+        whitespace
+
+        subject = expression! ForExpectedSubject
+
+        whitespace
+        char ')', ForExpectedClosingParentheses
+
+        head_comments, body, tail_comments =
+          block_with_comments(
+            opening_bracket: ForExpectedOpeningBracket,
+            closing_bracket: ForExpectedClosingBracket
+          ) do
+            expression! ForExpectedBody
+          end
+
+        whitespace
+        condition = for_condition
+        whitespace
+
+        Ast::For.new(
+          head_comments: head_comments,
+          tail_comments: tail_comments,
+          condition: condition,
+          from: start_position,
+          subject: subject,
+          items: items,
+          to: position,
+          input: data,
+          body: body)
+      end
+    end
+  end
+end

--- a/src/parsers/for_condition.cr
+++ b/src/parsers/for_condition.cr
@@ -1,0 +1,29 @@
+module Mint
+  class Parser
+    syntax_error ForConditionExpectedOpeningBracket
+    syntax_error ForConditionExpectedClosingBracket
+    syntax_error ForConditionExpectedBody
+
+    def for_condition : Ast::ForCondition | Nil
+      start do |start_position|
+        skip unless keyword "when"
+
+        head_comments, condition, tail_comments =
+          block_with_comments(
+            opening_bracket: ForConditionExpectedOpeningBracket,
+            closing_bracket: ForConditionExpectedClosingBracket
+          ) do
+            expression! ForConditionExpectedBody
+          end
+
+        Ast::ForCondition.new(
+          head_comments: head_comments,
+          tail_comments: tail_comments,
+          condition: condition,
+          from: start_position,
+          to: position,
+          input: data)
+      end
+    end
+  end
+end

--- a/src/parsers/html_body.cr
+++ b/src/parsers/html_body.cr
@@ -8,6 +8,7 @@ module Mint
         string_literal ||
         array ||
         if_expression ||
+        for_expression ||
         with_expression ||
         try_expression ||
         case_expression ||

--- a/src/type_checker.cr
+++ b/src/type_checker.cr
@@ -15,6 +15,8 @@ module Mint
     OBJECT         = Type.new("Object")
     OBJECT_ERROR   = Type.new("Object.Error")
     ARRAY          = Type.new("Array", [Variable.new("a")] of Checkable)
+    SET            = Type.new("Set", [Variable.new("a")] of Checkable)
+    MAP            = Type.new("Map", [Variable.new("a"), Variable.new("a")] of Checkable)
     MAYBE          = Type.new("Maybe", [Variable.new("a")] of Checkable)
     EVENT_FUNCTION = Type.new("Function", [EVENT, Variable.new("a")] of Checkable)
     HTML_CHILDREN  = Type.new("Array", [HTML] of Checkable)

--- a/src/type_checkers/for_expression.cr
+++ b/src/type_checkers/for_expression.cr
@@ -1,0 +1,59 @@
+module Mint
+  class TypeChecker
+    type_error ForArrayOrSetArgumentsMismatch
+    type_error ForConditionTypeMismatch
+    type_error ForMapArgumentsMismatch
+    type_error ForTypeMismatch
+
+    def check(node : Ast::For) : Checkable
+      subject =
+        resolve node.subject
+
+      is_array_or_set =
+        Comparer.compare(ARRAY, subject) || Comparer.compare(SET, subject)
+
+      is_map =
+        Comparer.compare(MAP, subject)
+
+      is_valid =
+        is_array_or_set || is_map
+
+      raise ForTypeMismatch, {
+        "node" => node,
+        "got"  => subject,
+      } unless is_valid
+
+      raise ForMapArgumentsMismatch, {
+        "node" => node,
+      } if is_map && node.arguments.size != 2
+
+      raise ForArrayOrSetArgumentsMismatch, {
+        "node" => node,
+      } if is_array_or_set && node.arguments.size != 1
+
+      arguments =
+        node
+          .arguments
+          .each_with_index
+          .reduce([] of Tuple(String, Checkable)) do |memo, (argument, index)|
+            memo << {argument.value, subject.parameters[index]}
+          end
+
+      type = scope(arguments) do
+        node.condition.try do |condition|
+          condition_type = resolve condition.condition
+
+          raise ForConditionTypeMismatch, {
+            "node"     => condition,
+            "got"      => condition_type,
+            "expected" => BOOL,
+          } unless Comparer.compare(BOOL, condition_type)
+        end
+
+        resolve node.body
+      end
+
+      Type.new("Array", [type])
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the **for expression** which allows iteration and filtering over `Array(a)` `Set(a)` and `Map(a, b)` types (for now).

The syntax looks like this: 
```
/* For arrays and sets */
for (item in array) {
  item
}

/* For maps */
for (key, value in map) {
  value
}

/* Filtering  using a condition */
for (item in array) {
  item
} when {
  item == "A"
}
```

The rationale behind this is that using `.map`, `.select` and functions like them is more verbose that it needs to be and also introduces multiple function calls.

So this:
```
["A", "B"]
|> Array.select((item : String) : Bool => { item == "A" }
|> Array.map((item : String) : String => { String.toLowerCase(item) }
```

Becomes this:
```
for (item in ["A", "B"]) {
  String.toLowerCase(item)
} when {
  item == "A"
}
```