### PR TITLE
fix crash with remainder (%) operator

### DIFF
--- a/src/type_checkers/operation.cr
+++ b/src/type_checkers/operation.cr
@@ -42,7 +42,7 @@ module Mint
         } unless Comparer.compare(left, right)
 
         left
-      when "-", "*", "/"
+      when "-", "*", "/", "%"
         right = resolve node.right
         left = resolve node.left
 


### PR DESCRIPTION
Currently using the % operator triggers a TypeError in `type_checkers/operation.cr`