### PR TITLE
String Interpolation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 development:
-	crystal build src/mint.cr -o mint-dev -p && \
+	crystal build src/mint.cr -o mint-dev -p --error-trace && \
 	mv mint-dev ~/.bin/mint-dev && mint-dev
 
 build:
-	crystal build src/mint.cr -o mint -p && mv mint ~/.bin/mint && mint
+	crystal build src/mint.cr -o mint -p --error-trace && mv mint ~/.bin/mint && mint
 
 test:
 	crystal spec -p --error-trace && bin/ameba
 
 test-core:
-	crystal build src/mint.cr -o mint -p && cd core && ../mint test -b firefox && cd .. && rm mint
+	crystal build src/mint.cr -o mint -p --error-trace && cd core && ../mint test -b firefox && cd .. && rm mint
 
 documentation:
 	rm -rf docs && crystal docs

--- a/spec/compilers/string_literal_with_interpolation
+++ b/spec/compilers/string_literal_with_interpolation
@@ -1,0 +1,13 @@
+component Main {
+  fun render : String {
+    "Hello There #{"Hello"}"
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return `Hello There ${`Hello`}`;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/string_literal_with_interpolation_and_js_iterpolation
+++ b/spec/compilers/string_literal_with_interpolation_and_js_iterpolation
@@ -1,0 +1,13 @@
+component Main {
+  fun render : String {
+    "Hello There #{"Hello"}"
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return `Hello There ${`Hello`}`;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/string_literal_with_interpolation_of_number
+++ b/spec/compilers/string_literal_with_interpolation_of_number
@@ -1,0 +1,13 @@
+component Main {
+  fun render : String {
+    "Hello There #{0}"
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return `Hello There ${0}`;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/string_literal_with_js_iterpolation
+++ b/spec/compilers/string_literal_with_js_iterpolation
@@ -1,0 +1,13 @@
+component Main {
+  fun render : String {
+    "Hello There ${a}"
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return `Hello There \${a}`;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/formatters/string_literal_splitted_with_interpolation
+++ b/spec/formatters/string_literal_splitted_with_interpolation
@@ -1,0 +1,19 @@
+module A {
+  fun test : String {
+    "Lorem ipsum dolor sit amet, consectetur adipiscing #{"WHAAT"} elit." \ " Donec pulvinar bibendum convallis. Sed malesuada commodo felis quis accumsan. Pellentesque lacinia sagittis vestibulum. Mauris aliquam a ante vel fermentum. Quisque sed consectetur elit. Donec sagittis, leo id tempus feugiat, leo ligula sollicitudin nisl, quis facilisis lorem tellus sit amet mi. Nullam vel nulla eu felis iaculis tincidunt. Nulla volutpat lorem sollicitudin finibus auctor."
+  }
+}
+--------------------------------------------------------------------------------
+module A {
+  fun test : String {
+    "Lorem ipsum dolor sit amet, consectetur adipiscing #{"WHAAT"}" \
+    " elit. Donec pulvinar bibendum convallis. Sed malesuada " \
+    "commodo felis quis accumsan. Pellentesque lacinia sagitt" \
+    "is vestibulum. Mauris aliquam a ante vel fermentum. Quis" \
+    "que sed consectetur elit. Donec sagittis, leo id tempus " \
+    "feugiat, leo ligula sollicitudin nisl, quis facilisis lo" \
+    "rem tellus sit amet mi. Nullam vel nulla eu felis iaculi" \
+    "s tincidunt. Nulla volutpat lorem sollicitudin finibus a" \
+    "uctor."
+  }
+}

--- a/spec/formatters/string_literal_with_interpolation
+++ b/spec/formatters/string_literal_with_interpolation
@@ -1,0 +1,11 @@
+module A {
+  fun test : String {
+    "Hello there #{"Joe"}"
+  }
+}
+--------------------------------------------------------------------------------
+module A {
+  fun test : String {
+    "Hello there #{"Joe"}"
+  }
+}

--- a/spec/type_checking/string_literal
+++ b/spec/type_checking/string_literal
@@ -3,3 +3,23 @@ component Main {
     "Hello There"
   }
 }
+--------------------------------------------------------------------------------
+component Main {
+  fun render : String {
+    try {
+      name = 0
+
+      "Hello There #{name}!"
+    }
+  }
+}
+------------------------------------------StringLiteralInterpolationTypeMismatch
+component Main {
+  fun render : String {
+    try {
+      name = {}
+
+      "Hello There #{name}!"
+    }
+  }
+}

--- a/src/ast/string_literal.cr
+++ b/src/ast/string_literal.cr
@@ -9,6 +9,13 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def string_value
+        value
+          .select(&.is_a?(String))
+          .map(&.as(String))
+          .join("")
+      end
     end
   end
 end

--- a/src/ast/string_literal.cr
+++ b/src/ast/string_literal.cr
@@ -3,7 +3,7 @@ module Mint
     class StringLiteral < Node
       getter value, broken
 
-      def initialize(@value : String,
+      def initialize(@value : Array(String | Expression),
                      @broken : Bool,
                      @input : Data,
                      @from : Int32,

--- a/src/compilers/string_literal.cr
+++ b/src/compilers/string_literal.cr
@@ -2,7 +2,21 @@ module Mint
   class Compiler
     def _compile(node : Ast::StringLiteral) : String
       value =
-        node.value.gsub('`', "\\`")
+        node
+          .value
+          .map do |item|
+            case item
+            when Ast::Node
+              "${#{compile(item)}}"
+            when String
+              item
+                .gsub('`', "\\`")
+                .gsub("${", "\\${")
+            else
+              ""
+            end
+          end
+          .join("")
 
       "`#{value}`"
     end

--- a/src/documentation_server/record_definition_field.cr
+++ b/src/documentation_server/record_definition_field.cr
@@ -4,7 +4,7 @@ module Mint
       json.object do
         json.field "key", node.key.value
         json.field "type", stringify(node.type)
-        json.field "mapping", node.mapping.try(&.value)
+        json.field "mapping", node.mapping.try(&.string_value)
       end
     end
   end

--- a/src/messages/string_literal_interpolation_type_mismatch.cr
+++ b/src/messages/string_literal_interpolation_type_mismatch.cr
@@ -1,0 +1,12 @@
+message StringLiteralInterpolationTypeMismatch do
+  title "Type Error"
+
+  block do
+    text "An interpolation in string is causing a mismatch."
+  end
+
+  type_with_text expected, "The expected type is:"
+  type_with_text got, "Instead it got:"
+
+  snippet node, "It is here:"
+end

--- a/src/parsers/record_definition_field.cr
+++ b/src/parsers/record_definition_field.cr
@@ -21,7 +21,8 @@ module Mint
             whitespace
             skip unless keyword "using"
             whitespace
-            string_literal! RecordDefinitionFieldExpectedMapping
+            string_literal! RecordDefinitionFieldExpectedMapping,
+              with_interpolation: false
           end
 
         Ast::RecordDefinitionField.new(

--- a/src/parsers/suite.cr
+++ b/src/parsers/suite.cr
@@ -10,7 +10,10 @@ module Mint
         skip unless keyword "suite"
 
         whitespace
-        name = string_literal! SuiteExpectedName
+
+        name = string_literal! SuiteExpectedName,
+          with_interpolation: false
+
         whitespace
 
         body = block(

--- a/src/parsers/test.cr
+++ b/src/parsers/test.cr
@@ -10,7 +10,10 @@ module Mint
         skip unless keyword "test"
 
         whitespace
-        name = string_literal! TestExpectedName
+
+        name = string_literal! TestExpectedName,
+          with_interpolation: false
+
         whitespace
 
         head_comments, expression, tail_comments = block_with_comments(

--- a/src/type_checkers/css_definition.cr
+++ b/src/type_checkers/css_definition.cr
@@ -29,8 +29,7 @@ module Mint
           "name" => node.name,
           "node" => node,
           "got"  => type,
-        } unless Comparer.compare(type, STRING) ||
-                 Comparer.compare(type, NUMBER)
+        } unless Comparer.matches_any?(type, [STRING, NUMBER])
       end
 
       NEVER

--- a/src/type_checkers/record_definition.cr
+++ b/src/type_checkers/record_definition.cr
@@ -12,18 +12,7 @@ module Mint
       mappings =
         node
           .fields
-          .map do |field|
-            value =
-              field.mapping.try do |string_literal|
-                string_literal
-                  .value
-                  .select(&.is_a?(String))
-                  .map(&.as(String))
-                  .join("")
-              end
-
-            {field.key.value, value}
-          end
+          .map { |field| {field.key.value, field.mapping.try(&.string_value)} }
           .to_h
 
       type = Record.new(node.name, fields, mappings)

--- a/src/type_checkers/record_definition.cr
+++ b/src/type_checkers/record_definition.cr
@@ -12,7 +12,18 @@ module Mint
       mappings =
         node
           .fields
-          .map { |field| {field.key.value, field.mapping.try(&.value)} }
+          .map do |field|
+            value =
+              field.mapping.try do |string_literal|
+                string_literal
+                  .value
+                  .select(&.is_a?(String))
+                  .map(&.as(String))
+                  .join("")
+              end
+
+            {field.key.value, value}
+          end
           .to_h
 
       type = Record.new(node.name, fields, mappings)

--- a/src/type_checkers/string_literal.cr
+++ b/src/type_checkers/string_literal.cr
@@ -1,6 +1,22 @@
 module Mint
   class TypeChecker
+    type_error StringLiteralInterpolationTypeMismatch
+
     def check(node : Ast::StringLiteral) : Checkable
+      node.value.each do |item|
+        case item
+        when Ast::Node
+          item_type =
+            resolve item
+
+          raise StringLiteralInterpolationTypeMismatch, {
+            "expected" => STRING,
+            "got"      => item_type,
+            "node"     => item,
+          } unless Comparer.matches_any?(item_type, [STRING, NUMBER])
+        end
+      end
+
       STRING
     end
   end


### PR DESCRIPTION
This PR adds string interpolation to the language.

It uses the same syntax as JavaScript interpolation and CSS interpolation: "#{...}"  the expressions must evaluate to either `String` or `Number` types.

Example:

```
"Hello #{name} #{0}!"
```