### PR TITLE
Caching component virtual doms 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ deploy:
       tags: true
 
 addons:
-  firefox: latest
+  chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ install:
 script:
   - crystal spec
   - bin/ameba
-  - make test-core
+  - if [ $TRAVIS_OS_NAME == "osx" ]; then
+    echo "Not testing core on osx!";
+    else
+    make test-core;
+    fi
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	crystal spec -p --error-trace && bin/ameba
 
 test-core:
-	crystal build src/mint.cr -o mint -p --error-trace && cd core && ../mint test -b firefox && cd .. && rm mint
+	crystal build src/mint.cr -o mint -p --error-trace && cd core && ../mint test && cd .. && rm mint
 
 documentation:
 	rm -rf docs && crystal docs

--- a/spec/compilers/component_namespaced
+++ b/spec/compilers/component_namespaced
@@ -20,8 +20,10 @@ A.displayName = "Ui.Dropdown";
 
 class B extends _C {
   render() {
-    return _h(A, {});
+    return $a();
   }
 };
 
 B.displayName = "Main";
+
+const $a = _m(() => _h(A, {}));

--- a/spec/compilers/html_component
+++ b/spec/compilers/html_component
@@ -20,8 +20,10 @@ A.displayName = "Test";
 
 class B extends _C {
   render() {
-    return _h(A, {});
+    return $a();
   }
 };
 
 B.displayName = "Main";
+
+const $a = _m(() => _h(A, {}));

--- a/spec/compilers/static_component
+++ b/spec/compilers/static_component
@@ -57,6 +57,31 @@ class A extends _C {
 A.displayName = "Test";
 
 class B extends _C {
+  constructor(props) {
+    super(props);
+
+    this._d({
+      c: [
+        "children",
+        []
+      ],
+      b: [
+        null,
+        ``
+      ]
+    });
+  }
+
+  render() {
+    return _h("div", {}, [
+      this.b
+    ]);
+  }
+};
+
+B.displayName = "TestWithChildren";
+
+class C extends _C {
   render() {
     return _h(React.Fragment, {}, [
       $a(),
@@ -64,12 +89,12 @@ class B extends _C {
       $b(),
       $b(),
       $c(),
-      $c(),
+      $c()
     ]);
   }
 };
 
-B.displayName = "Main";
+C.displayName = "Main";
 
 const $a = _m(() => _h(A, {}));
 

--- a/spec/compilers/static_component
+++ b/spec/compilers/static_component
@@ -1,14 +1,19 @@
 component Test {
-  property readonly : Bool = false
+  property text : String = ""
 
   fun render : Html {
-    <div></div>
+    <div><{ text }></div>
   }
 }
 
 component Main {
   fun render : Html {
-    <Test readonly={true}/>
+    <>
+      <Test/>
+      <Test/>
+      <Test text="Hello"/>
+      <Test text="Hello"/>
+    </>
   }
 }
 --------------------------------------------------------------------------------
@@ -19,13 +24,15 @@ class A extends _C {
     this._d({
       a: [
         null,
-        false
+        ``
       ]
     });
   }
 
   render() {
-    return _h("div", {});
+    return _h("div", {}, [
+      this.a
+    ]);
   }
 };
 
@@ -33,12 +40,19 @@ A.displayName = "Test";
 
 class B extends _C {
   render() {
-    return $a();
+    return _h(React.Fragment, {}, [
+      $a(),
+      $a(),
+      $b(),
+      $b()
+    ]);
   }
 };
 
 B.displayName = "Main";
 
-const $a = _m(() => _h(A, {
-  a: true
+const $a = _m(() => _h(A, {}));
+
+const $b = _m(() => _h(A, {
+  a: `Hello`
 }));

--- a/spec/compilers/static_component
+++ b/spec/compilers/static_component
@@ -6,13 +6,31 @@ component Test {
   }
 }
 
+component TestWithChildren {
+  property children : Array(Html) = []
+  property text : String = ""
+
+  fun render : Html {
+    <div><{ text }></div>
+  }
+}
+
 component Main {
   fun render : Html {
     <>
       <Test/>
       <Test/>
+
       <Test text="Hello"/>
       <Test text="Hello"/>
+
+      <TestWithChildren>
+        <span>"Hello"</span>
+      </TestWithChildren>
+
+      <TestWithChildren>
+        <span>"Hello"</span>
+      </TestWithChildren>
     </>
   }
 }
@@ -44,7 +62,9 @@ class B extends _C {
       $a(),
       $a(),
       $b(),
-      $b()
+      $b(),
+      $c(),
+      $c(),
     ]);
   }
 };
@@ -56,3 +76,7 @@ const $a = _m(() => _h(A, {}));
 const $b = _m(() => _h(A, {
   a: `Hello`
 }));
+
+const $c = _m(() => _h(B, {}, _array(_h("span", {}, [
+  `Hello`
+]))));

--- a/src/ast/array_literal.cr
+++ b/src/ast/array_literal.cr
@@ -8,6 +8,17 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def static?
+        items.all?(static?)
+      end
+
+      def static_value
+        values =
+          items.map(&.static_value).join(",")
+
+        "[#{values}]"
+      end
     end
   end
 end

--- a/src/ast/array_literal.cr
+++ b/src/ast/array_literal.cr
@@ -10,12 +10,12 @@ module Mint
       end
 
       def static?
-        items.all?(static?)
+        items.all?(&.static?)
       end
 
       def static_value
         values =
-          items.map(&.static_value).join(",")
+          items.map(&.static_value).join(',')
 
         "[#{values}]"
       end

--- a/src/ast/bool_literal.cr
+++ b/src/ast/bool_literal.cr
@@ -8,6 +8,14 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def static?
+        true
+      end
+
+      def static_value
+        value.to_s
+      end
     end
   end
 end

--- a/src/ast/html_attribute.cr
+++ b/src/ast/html_attribute.cr
@@ -3,6 +3,8 @@ module Mint
     class HtmlAttribute < Node
       getter value, name
 
+      delegate static?, static_value, to: @value
+
       def initialize(@value : Expression,
                      @name : Variable,
                      @input : Data,

--- a/src/ast/html_attribute.cr
+++ b/src/ast/html_attribute.cr
@@ -3,13 +3,17 @@ module Mint
     class HtmlAttribute < Node
       getter value, name
 
-      delegate static?, static_value, to: @value
+      delegate static?, to: @value
 
       def initialize(@value : Expression,
                      @name : Variable,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)
+      end
+
+      def static_value : String
+        "#{name.value}=#{value.static_value}"
       end
     end
   end

--- a/src/ast/html_component.cr
+++ b/src/ast/html_component.cr
@@ -19,8 +19,8 @@ module Mint
 
       def static_hash
         component +
-          attributes.map(&.static_value).join("") +
-          children.map(&.static_value).join("")
+          attributes.map(&.static_value).join +
+          children.map(&.static_value).join
       end
     end
   end

--- a/src/ast/html_component.cr
+++ b/src/ast/html_component.cr
@@ -12,6 +12,14 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def static?
+        children.empty? && ref.nil? && attributes.all?(&.static?)
+      end
+
+      def static_hash
+        component + attributes.map(&.static_value).join("")
+      end
     end
   end
 end

--- a/src/ast/html_component.cr
+++ b/src/ast/html_component.cr
@@ -14,11 +14,13 @@ module Mint
       end
 
       def static?
-        children.empty? && ref.nil? && attributes.all?(&.static?)
+        children.all?(&.static?) && ref.nil? && attributes.all?(&.static?)
       end
 
       def static_hash
-        component + attributes.map(&.static_value).join("")
+        component +
+          attributes.map(&.static_value).join("") +
+          children.map(&.static_value).join("")
       end
     end
   end

--- a/src/ast/html_element.cr
+++ b/src/ast/html_element.cr
@@ -13,6 +13,19 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def static?
+        children.all?(&.static?) &&
+          ref.nil? &&
+          attributes.all?(&.static?) &&
+          styles.empty?
+      end
+
+      def static_hash
+        component +
+          attributes.map(&.static_value).join("") +
+          children.map(&.static_value).join("")
+      end
     end
   end
 end

--- a/src/ast/html_element.cr
+++ b/src/ast/html_element.cr
@@ -21,8 +21,8 @@ module Mint
           styles.empty?
       end
 
-      def static_hash
-        component +
+      def static_value
+        tag.value +
           attributes.map(&.static_value).join +
           children.map(&.static_value).join
       end

--- a/src/ast/html_element.cr
+++ b/src/ast/html_element.cr
@@ -23,8 +23,8 @@ module Mint
 
       def static_hash
         component +
-          attributes.map(&.static_value).join("") +
-          children.map(&.static_value).join("")
+          attributes.map(&.static_value).join +
+          children.map(&.static_value).join
       end
     end
   end

--- a/src/ast/html_expression.cr
+++ b/src/ast/html_expression.cr
@@ -3,6 +3,8 @@ module Mint
     class HtmlExpression < Node
       getter expression
 
+      delegate static?, static_value, to: @expression
+
       def initialize(@expression : Expression,
                      @input : Data,
                      @from : Int32,

--- a/src/ast/node.cr
+++ b/src/ast/node.cr
@@ -11,6 +11,14 @@ module Mint
       def to_tuple
         {input: input, from: from, to: to}
       end
+
+      def static?
+        false
+      end
+
+      def static_value
+        ""
+      end
     end
   end
 end

--- a/src/ast/number_literal.cr
+++ b/src/ast/number_literal.cr
@@ -9,6 +9,18 @@ module Mint
                      @from : Int32,
                      @to : Int32)
       end
+
+      def static?
+        true
+      end
+
+      def static_value
+        if float
+          value.to_s
+        else
+          value.to_i64.to_s
+        end
+      end
     end
   end
 end

--- a/src/ast/number_literal.cr
+++ b/src/ast/number_literal.cr
@@ -16,10 +16,10 @@ module Mint
 
       def static_value
         if float
-          value.to_s
+          value
         else
-          value.to_i64.to_s
-        end
+          value.to_i64
+        end.to_s
       end
     end
   end

--- a/src/ast/string_literal.cr
+++ b/src/ast/string_literal.cr
@@ -12,9 +12,16 @@ module Mint
 
       def string_value
         value
-          .select(&.is_a?(String))
-          .map(&.as(String))
+          .select(String)
           .join("")
+      end
+
+      def static?
+        value.all?(String)
+      end
+
+      def static_value
+        string_value
       end
     end
   end

--- a/src/compiler.cr
+++ b/src/compiler.cr
@@ -4,7 +4,10 @@ module Mint
     delegate ast, types, variables, to: @artifacts
     delegate record_field_lookup, to: @artifacts
 
-    getter js, style_builder
+    getter js, style_builder, static_components, static_components_pool
+
+    @static_components = {} of String => String
+    @static_components_pool = NamePool(String, Nil).new
 
     def initialize(@artifacts : TypeChecker::Artifacts, @optimize = false)
       @style_builder = StyleBuilder.new

--- a/src/compilers/html_component.cr
+++ b/src/compilers/html_component.cr
@@ -1,6 +1,19 @@
 module Mint
   class Compiler
     def _compile(node : Ast::HtmlComponent) : String
+      if node.static?
+        name =
+          static_components_pool.of(node.static_hash, nil)
+
+        static_components[name] ||= compile_html_component(node)
+
+        "$" + name + "()"
+      else
+        compile_html_component(node)
+      end
+    end
+
+    def compile_html_component(node : Ast::HtmlComponent) : String
       name =
         js.class_of(lookups[node])
 

--- a/src/compilers/number_literal.cr
+++ b/src/compilers/number_literal.cr
@@ -1,11 +1,7 @@
 module Mint
   class Compiler
     def _compile(node : Ast::NumberLiteral) : String
-      if node.float
-        node.value.to_s
-      else
-        node.value.to_i64.to_s
-      end
+      node.static_value
     end
   end
 end

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -79,8 +79,13 @@ module Mint
           "_insertStyles(`\n#{all_css}\n`)"
         end
 
+      static =
+        static_components.map do |name, compiled|
+          js.const("$#{name}", "_m(() => #{compiled})")
+        end
+
       elements =
-        enums + records + providers + routes + modules + components + stores + [footer]
+        enums + records + providers + routes + modules + components + static + stores + [footer]
           .reject(&.empty?)
 
       js.statements(elements)
@@ -182,6 +187,15 @@ module Mint
         const _M = mint.Module;
         const _S = mint.Store;
         const _E = mint.Enum;
+
+        const _m = (function) => {
+          let value;
+          return () => {
+            if (value) { return value }
+            value = function()
+            return value
+          }
+        }
 
         const _s = (item, callback) => {
           if (item instanceof #{nothing}) {

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -78,7 +78,7 @@ module Mint
         end
 
       elements =
-        enums + records + providers + routes + modules + components + static + stores + [footer] + suites
+        (enums + records + providers + routes + modules + components + static + stores + [footer] + suites)
           .reject(&.empty?)
 
       js.statements(elements)

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -188,11 +188,11 @@ module Mint
         const _S = mint.Store;
         const _E = mint.Enum;
 
-        const _m = (function) => {
+        const _m = (method) => {
           let value;
           return () => {
             if (value) { return value }
-            value = function()
+            value = method()
             return value
           }
         }


### PR DESCRIPTION
This PR implements caching for components that are considered static.

Rendered virtual DOM nodes of components with static properties can be cached to increase performance and reduce compiled file size.

For example if we have an icon using SVG:
```
component Icons.Projects {
  property size : Number = 26

  fun render : Html {
    <Icon size={size}>
      <path
        d={
          "M96,176h80V96H96V176z M216,416h80v-80h-80V416z M96,416h8" \
          "0v-80H96V416z M96,296h80v-80H96V296z M216,296h80v-80h-80" \
          "V296z M336,96v80h80V96H336z M216,176h80V96h-80V176z M336" \
          ",296h80v-80h-80V296z M336,416h80v-80h-80V416z"
        }/>
    </Icon>
  }
}
```
And we use it in many places like this: `<Icons.Projects/>` it would re-render the virtual DOM every time but it's basically static content.

With this PR components uses that match the following criteria are cached:
* have no children
* does not have a reference attached to it
* all of it's attributes are considered static (number, bool, string literals or array containing those)

If you take the example above all of these uses will be cached:
*  `<Icons.Projects/>`
*  `<Icons.Projects size={30}/>`
*  `<Icons.Projects size={45}/>`