### PR TITLE
Handle Format Command Exception If Pattern Not Valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 development:
 	crystal build src/mint.cr -o mint-dev -p --error-trace && \
-	mv mint-dev ~/.bin/mint-dev && mint-dev
+	mv mint-dev ~/.bin/mint-dev
 
 build:
-	crystal build src/mint.cr -o mint -p --error-trace && mv mint ~/.bin/mint && mint
+	crystal build src/mint.cr -o mint -p --error-trace --release && mv mint ~/.bin/mint && mint
 
 test:
 	crystal spec -p --error-trace && bin/ameba

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 development:
 	crystal build src/mint.cr -o mint-dev -p --error-trace && \
-	mv mint-dev ~/.bin/mint-dev
+	mv mint-dev ~/.bin/mint-dev && mint-dev
 
 build:
-	crystal build src/mint.cr -o mint -p --error-trace --release && mv mint ~/.bin/mint && mint
+	crystal build src/mint.cr -o mint -p --error-trace && mv mint ~/.bin/mint && mint
 
 test:
 	crystal spec -p --error-trace && bin/ameba

--- a/src/commands/format.cr
+++ b/src/commands/format.cr
@@ -10,33 +10,31 @@ module Mint
         default: "source/**/*.mint"
 
       def run
-        begin
-          execute "Formatting files" do
-            files = Dir.glob(arguments.pattern.to_s)
+        execute "Formatting files" do
+          files = Dir.glob(arguments.pattern.to_s)
 
-            if files.empty?
-              terminal.puts "Nothing to format!"
-            else
-              results =
-                files.map do |file|
-                  artifact =
-                    Parser.parse(file)
+          if files.empty?
+            terminal.puts "Nothing to format!"
+          else
+            results =
+              files.map do |file|
+                artifact =
+                  Parser.parse(file)
 
-                  formatted =
-                    Formatter.new(artifact, MintJson.parse_current.formatter_config).format
+                formatted =
+                  Formatter.new(artifact, MintJson.parse_current.formatter_config).format
 
-                  if formatted != File.read(file)
-                    File.write(file, formatted)
-                    terminal.puts "Formatted: #{file}"
-                    true
-                  end
-                end.compact
+                if formatted != File.read(file)
+                  File.write(file, formatted)
+                  terminal.puts "Formatted: #{file}"
+                  true
+                end
+              end.compact
 
-              terminal.puts "All files are formatted!" if results.empty?
-            end
+            terminal.puts "All files are formatted!" if results.empty?
           end
         rescue
-          print "I was looking for a valid pattern such \"source/**/*.mint\" \ngot \"#{arguments.pattern.to_s}\" instead.\n"
+          print "I was looking for a pattern that contains \".mint\" files, such \"source/**/*.mint\" \ngot \"#{arguments.pattern.to_s}\" instead.\n"
         end
       end
     end

--- a/src/commands/format.cr
+++ b/src/commands/format.cr
@@ -10,29 +10,33 @@ module Mint
         default: "source/**/*.mint"
 
       def run
-        execute "Formatting files" do
-          files = Dir.glob(arguments.pattern.to_s)
+        begin
+          execute "Formatting files" do
+            files = Dir.glob(arguments.pattern.to_s)
 
-          if files.empty?
-            terminal.puts "Nothing to format!"
-          else
-            results =
-              files.map do |file|
-                artifact =
-                  Parser.parse(file)
+            if files.empty?
+              terminal.puts "Nothing to format!"
+            else
+              results =
+                files.map do |file|
+                  artifact =
+                    Parser.parse(file)
 
-                formatted =
-                  Formatter.new(artifact, MintJson.parse_current.formatter_config).format
+                  formatted =
+                    Formatter.new(artifact, MintJson.parse_current.formatter_config).format
 
-                if formatted != File.read(file)
-                  File.write(file, formatted)
-                  terminal.puts "Formatted: #{file}"
-                  true
-                end
-              end.compact
+                  if formatted != File.read(file)
+                    File.write(file, formatted)
+                    terminal.puts "Formatted: #{file}"
+                    true
+                  end
+                end.compact
 
-            terminal.puts "All files are formatted!" if results.empty?
+              terminal.puts "All files are formatted!" if results.empty?
+            end
           end
+        rescue
+          print "I was looking for a valid pattern such \"source/**/*.mint\" \ngot \"#{arguments.pattern.to_s}\" instead.\n"
         end
       end
     end

--- a/src/commands/format.cr
+++ b/src/commands/format.cr
@@ -34,7 +34,8 @@ module Mint
             terminal.puts "All files are formatted!" if results.empty?
           end
         rescue
-          print "I was looking for a pattern that contains \".mint\" files, such \"source/**/*.mint\" \ngot \"#{arguments.pattern.to_s}\" instead.\n"
+          print "I was looking for a pattern that contains \".mint\" files,\n"
+          print "such as \"source/**/*.mint\". Got \"#{arguments.pattern}\" instead.\n"
         end
       end
     end

--- a/src/commands/format.cr
+++ b/src/commands/format.cr
@@ -34,8 +34,8 @@ module Mint
             terminal.puts "All files are formatted!" if results.empty?
           end
         rescue
-          print "I was looking for a pattern that contains \".mint\" files,\n"
-          print "such as \"source/**/*.mint\". Got \"#{arguments.pattern}\" instead.\n"
+          puts %(I was looking for a pattern that contains ".mint" files,)
+          puts %(such as "source/**/*.mint". Got "#{arguments.pattern}" instead.)
         end
       end
     end


### PR DESCRIPTION
```bash
$ mint format tests/
Mint - Formatting files
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Unhandled exception: Error reading file: Is a directory (Errno)
Failed to raise an exception: END_OF_STACK
[0x564504d061a6] ???
[0x56450497e42b] __crystal_raise +43
[0x56450497ecd5] ???
[0x56450498b1ad] ???
[0x56450498373c] ???
[0x564504983163] ???
[0x564504a0c1b5] ???
[0x56450499765a] ???
[0x564504980eb7] main +55
[0x7ff3b65461e3] __libc_start_main +243
[0x564504901cde] _start +46
[0x0] ???
```