### PR TITLE
Compile external assets into their own files.

### DIFF
--- a/src/builder.cr
+++ b/src/builder.cr
@@ -22,21 +22,15 @@ module Mint
       terminal.print "#{COG} Compiling your application:\n"
       File.write Path[DIST_DIR, "index.js"], index
 
-      javascripts =
-        SourceFiles.external_javascripts
-
-      unless javascripts.empty?
+      if SourceFiles.external_javascripts?
         terminal.measure "#{COG} Writing external javascripts..." do
-          File.write Path[DIST_DIR, "external-javascripts.js"], javascripts
+          File.write Path[DIST_DIR, "external-javascripts.js"], SourceFiles.external_javascripts
         end
       end
 
-      stylesheets =
-        SourceFiles.external_stylesheets
-
-      unless stylesheets.empty?
+      if SourceFiles.external_stylesheets?
         terminal.measure "#{COG} Writing external stylesheets..." do
-          File.write Path[DIST_DIR, "external-stylesheets.css"], stylesheets
+          File.write Path[DIST_DIR, "external-stylesheets.css"], SourceFiles.external_stylesheets
         end
       end
 

--- a/src/builder.cr
+++ b/src/builder.cr
@@ -22,6 +22,24 @@ module Mint
       terminal.print "#{COG} Compiling your application:\n"
       File.write Path[DIST_DIR, "index.js"], index
 
+      javascripts =
+        SourceFiles.external_javascripts
+
+      unless javascripts.empty?
+        terminal.measure "#{COG} Writing external javascripts..." do
+          File.write Path[DIST_DIR, "external-javascripts.js"], javascripts
+        end
+      end
+
+      stylesheets =
+        SourceFiles.external_stylesheets
+
+      unless stylesheets.empty?
+        terminal.measure "#{COG} Writing external stylesheets..." do
+          File.write Path[DIST_DIR, "external-stylesheets.css"], stylesheets
+        end
+      end
+
       terminal.measure "#{COG} Writing index.html... " do
         File.write Path[DIST_DIR, "index.html"], IndexHtml.render(Environment::BUILD, relative, skip_service_worker)
       end

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -178,12 +178,6 @@ module Mint
 
     # Wraps the application with the runtime
     def wrap_runtime(body, main = "")
-      javascripts =
-        SourceFiles
-          .external_files("javascripts")
-          .map { |file| File.read(file) }
-          .join("\n\n")
-
       html_event_module =
         ast.modules.find(&.name.==("Html.Event")).not_nil!
 
@@ -194,8 +188,6 @@ module Mint
         js.class_of(html_event_module) + "." + js.variable_of(from_event)
 
       <<-RESULT
-      #{javascripts}
-
       (() => {
         const _enums = {}
         const mint = Mint(_enums)

--- a/src/messages/mint_json_external_javascript_not_exists.cr
+++ b/src/messages/mint_json_external_javascript_not_exists.cr
@@ -7,10 +7,5 @@ message MintJsonExternalJavascriptNotExists do
     text "does not exist."
   end
 
-  block do
-    text "Any external files should be"
-    text "placed inside the \"public\" directory."
-  end
-
   snippet node
 end

--- a/src/messages/mint_json_external_stylesheet_not_exists.cr
+++ b/src/messages/mint_json_external_stylesheet_not_exists.cr
@@ -7,10 +7,5 @@ message MintJsonExternalStylesheetNotExists do
     text "does not exist."
   end
 
-  block do
-    text "Any external files should be"
-    text "placed inside the \"public\" directory."
-  end
-
   snippet node
 end

--- a/src/mint_json.cr
+++ b/src/mint_json.cr
@@ -248,7 +248,7 @@ module Mint
         @parser.read_string
 
       path =
-        File.join(@root, PUBLIC_DIR, file)
+        File.join(@root, file)
 
       raise MintJsonExternalJavascriptNotExists, {
         "node" => node(location),
@@ -283,7 +283,7 @@ module Mint
         @parser.read_string
 
       path =
-        File.join(@root, PUBLIC_DIR, file)
+        File.join(@root, file)
 
       raise MintJsonExternalStylesheetNotExists, {
         "node" => node(location),

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -104,13 +104,13 @@ module Mint
       get "/external-javascripts.js" do |env|
         env.response.content_type = "application/javascript"
 
-        SourceFiles.external_javascripts
+        @watcher.external_javascripts.to_s
       end
 
       get "/external-stylesheets.css" do |env|
         env.response.content_type = "text/css"
 
-        SourceFiles.external_stylesheets
+        @watcher.external_stylesheets.to_s
       end
 
       get "/:name" do |env|

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -101,6 +101,18 @@ module Mint
         script
       end
 
+      get "/external-javascripts.js" do |env|
+        env.response.content_type = "application/javascript"
+
+        SourceFiles.external_javascripts
+      end
+
+      get "/external-stylesheets.css" do |env|
+        env.response.content_type = "text/css"
+
+        SourceFiles.external_stylesheets
+      end
+
       get "/:name" do |env|
         # Set cache to expire in 30 days.
         env.response.headers["Cache-Control"] = "max-age=2592000"

--- a/src/utils/ast_watcher.cr
+++ b/src/utils/ast_watcher.cr
@@ -7,6 +7,8 @@ module Mint
     @pattern = [] of String
     @progress = false
     @include_core = true
+    @external_javascripts : String | Nil = nil
+    @external_stylesheets : String | Nil = nil
 
     getter include_core
 
@@ -28,6 +30,14 @@ module Mint
         @channel.receive
         yield compile
       end
+    end
+
+    def external_javascripts
+      @external_javascripts ||= SourceFiles.external_javascripts
+    end
+
+    def external_stylesheets
+      @external_stylesheets ||= SourceFiles.external_stylesheets
     end
 
     def terminal
@@ -111,6 +121,9 @@ module Mint
 
       spawn do
         static_watcher.watch do
+          @external_javascripts = nil
+          @external_stylesheets = nil
+
           @channel.send(nil)
         end
       end

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -57,9 +57,11 @@ module Mint
               end
             end
 
-            t.link(
-              rel: "stylesheet",
-              href: "/external-stylesheets.css")
+            if SourceFiles.external_stylesheets?
+              t.link(
+                rel: "stylesheet",
+                href: "/external-stylesheets.css")
+            end
           end
 
           t.body do
@@ -82,7 +84,10 @@ module Mint
               end
             end
 
-            t.script(src: path_for("external-javascripts.js")) { }
+            if SourceFiles.external_javascripts?
+              t.script(src: path_for("external-javascripts.js")) { }
+            end
+
             t.script(src: path_for("index.js")) { }
 
             t.noscript do

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -57,20 +57,9 @@ module Mint
               end
             end
 
-            unless json.external_files["stylesheets"].empty?
-              json.external_files["stylesheets"].each do |stylesheet|
-                if env.development?
-                  file_path = File.basename(stylesheet)
-                else
-                  file_path = File.join(@relative ? "css" : CSS_DIR, File.basename(stylesheet))
-                end
-
-                t.link(
-                  rel: "stylesheet",
-                  href: path_for(file_path)
-                )
-              end
-            end
+            t.link(
+              rel: "stylesheet",
+              href: "/external-stylesheets.css")
           end
 
           t.body do
@@ -93,6 +82,7 @@ module Mint
               end
             end
 
+            t.script(src: path_for("external-javascripts.js")) { }
             t.script(src: path_for("index.js")) { }
 
             t.noscript do

--- a/src/utils/source_files.cr
+++ b/src/utils/source_files.cr
@@ -28,6 +28,14 @@ module Mint
         .join("\n\n")
     end
 
+    def external_stylesheets?
+      external_files("stylesheets").any?
+    end
+
+    def external_javascripts?
+      external_files("javascripts").any?
+    end
+
     def external_files(files_type : String = "")
       if files_type.empty?
         [external_files("javascripts"), external_files("stylesheets")].flatten

--- a/src/utils/source_files.cr
+++ b/src/utils/source_files.cr
@@ -16,6 +16,18 @@ module Mint
         .map { |dir| "#{dir}/**/*.mint" }
     end
 
+    def external_javascripts
+      external_files("javascripts")
+        .map { |file| File.read(file) }
+        .join(";\n")
+    end
+
+    def external_stylesheets
+      external_files("stylesheets")
+        .map { |file| File.read(file) }
+        .join("\n\n")
+    end
+
     def external_files(files_type : String = "")
       if files_type.empty?
         [external_files("javascripts"), external_files("stylesheets")].flatten


### PR DESCRIPTION
This PR resolves issues with packages having external files:
- external javascripts are now compiled into a single file `external-javascripts.js` (in development and build)
- external stylesheets are now compiled into a single file `external-stylesheets.css` (in development and build)
- external files are no longer being restricted to the `public` directory

With the change of #155 the following issues cropped up:
- packages could not serve their external stylesheets in development because we relied on them being in the `public` directory
- having restrict external files into the public directory made it impossible to reference files outside of the project. To give this more context: I'm working on `mint-ui` and `mint-ui-showcase`, I needed to access a JavaScript file which is `mint-ui` from `mint-ui-showcase` as (`../mint-ui/assets/scroll_into_view.js`) and this was not possible
