### PR TITLE
Ignore .dwarf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 mint
 docs
 bin
+*.dwarf

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	crystal spec -p --error-trace && bin/ameba
 
 test-core:
-	crystal build src/mint.cr -o mint -p --error-trace && cd core/tests && ../../mint test && cd ../../ && rm mint
+	crystal build src/mint.cr -o mint -p --error-trace && cd core/tests && ../../mint test && cd ../../ && rm -f mint mint.dwarf
 
 documentation:
 	rm -rf docs && crystal docs


### PR DESCRIPTION
Whenever I run `make test-core` it generates a `mint.dwarf` files that I have to manually remove. I assume it's an artifact from building `mint` to run the core tests.

I guess we could also manually remove it as an extra step in the `Makefile`. Thoughts?