### PR TITLE
Make hostname:port configurable for test server.

### DIFF
--- a/src/commands/test.cr
+++ b/src/commands/test.cr
@@ -9,7 +9,7 @@ module Mint
         short: "m"
 
       define_flag browser : String,
-        description: "Which browser to run the tests in",
+        description: "Which browser to run the tests in (chrome, firefox)",
         default: "chrome",
         short: "b"
 
@@ -17,6 +17,30 @@ module Mint
         description: "Which reporter to use (dot, documentation)",
         default: "dot",
         short: "r"
+
+      define_flag host : String,
+        description: "Host to serve the tests on. (Default: 127.0.0.1)",
+        default: ENV["HOST"]? || "127.0.0.1",
+        required: false,
+        short: "h"
+
+      define_flag port : Int32,
+        description: "Port to serve the tests on. (Default: 3001)",
+        default: (ENV["PORT"]? || "3001").to_i,
+        required: false,
+        short: "p"
+
+      define_flag browser_host : String,
+        description: "Target host, useful when hosted on another machine. (Default: 127.0.0.1)",
+        default: ENV["BROWSER_HOST"]? || "127.0.0.1",
+        required: false,
+        short: "x"
+
+      define_flag browser_port : Int32,
+        description: "Target port, useful when hosted on another machine. (Default: 3001)",
+        default: (ENV["BROWSER_PORT"]? || "3001").to_i,
+        required: false,
+        short: "c"
 
       define_argument test : String
 

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -54,7 +54,7 @@ module Mint
       watch_for_changes
       setup_kemal
 
-      Server.run "Development", @host, @port
+      Server.run "Development", @host, @port, @host, @port
     end
 
     def compile_script

--- a/src/utils/server.cr
+++ b/src/utils/server.cr
@@ -21,14 +21,14 @@ module Mint
       true
     end
 
-    def run(name : String, host : String = "127.0.0.1", port : Int32 = 3000)
+    def run(name, host = "127.0.0.1", port = 3000, browser_host = "127.0.0.1", browser_port = 3000)
       config = Kemal.config
       config.logger = Logger.new
       config.setup
 
       if port_open?(host, port)
         server = HTTP::Server.new(config.handlers)
-        terminal.print "#{COG} #{name} server started on http://#{host}:#{port}/\n"
+        terminal.print "#{COG} #{name} server started on http://#{browser_host}:#{browser_port}/\n"
       elsif STDIN.tty?
         new_port = config.port + 1
         until port_open?(host, new_port)


### PR DESCRIPTION
Solves #205 

## What?

There are 4 new options for `mint test`:
- host
- port
- browser_host
- browser_port

## Running test using Docker:

`mint test --manual  --host 0.0.0.0`

This launches test server on host `0.0.0.0` which is available outside of the Docker container but also sets `--browser-host` to `127.0.0.1` by default which is a connection address for websocket outside the container. Same with `port`/`browser_port` pair.

Full instruction will be at https://github.com/mint-lang/mint-docker/issues/1