### PR TITLE
#224 config option to turn off generation of icons

### DIFF
--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -14,9 +14,13 @@ module Mint
         description: "If specified the service worker functionality will be disabled",
         default: false
 
+      define_flag skip_icons : Bool,
+        description: "If specified the application icons will not be generated"  ,
+        default: false
+
       def run
         execute "Building for production" do
-          Builder.new(flags.relative, flags.skip_service_worker)
+          Builder.new(flags.relative, flags.skip_service_worker, flags.skip_icons)
         end
       end
     end

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -3,11 +3,11 @@ module Mint
   class IndexHtml
     getter json, env
 
-    def self.render(env, relative = false, no_service_worker = false)
-      new(env, relative, no_service_worker).to_s
+    def self.render(env, relative = false, no_service_worker = false, no_icons = false)
+      new(env, relative, no_service_worker, no_icons).to_s
     end
 
-    def initialize(@env : Environment, @relative : Bool, @no_service_worker : Bool)
+    def initialize(@env : Environment, @relative : Bool, @no_service_worker : Bool, @no_icons : Bool)
       @json = MintJson.parse_current
     end
 
@@ -41,7 +41,7 @@ module Mint
             # Insert the extra head content
             t.unsafe json.application.head
 
-            unless json.application.icon.empty?
+            if !json.application.icon.empty? || !@no_icons
               ICON_SIZES.each do |size|
                 t.link(
                   rel: "icon",


### PR DESCRIPTION
This PR adds:

 * a flag to the build command line `--skip-icons`
* when this flag is enabled no icon image files are generated in the build dist directory and no images are added to the manifest.json and no image links are added to the index.html

