### PR TITLE
Do not override `Object#to_s`

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,4 +1,2 @@
 Metrics/CyclomaticComplexity:
   Enabled: false
-Lint/RedundantStringCoercion:
-  Enabled: false

--- a/src/ast/data.cr
+++ b/src/ast/data.cr
@@ -6,13 +6,8 @@ module Mint
       def initialize(@input : String, @file : String)
       end
 
-      def to_s
-        "<#{file} #{@input[0, 10]}...>"
-      end
-
       def to_s(io)
-        io << to_s
-        io
+        io << "<#{file} #{@input[0, 10]}...>"
       end
     end
   end

--- a/src/debugger.cr
+++ b/src/debugger.cr
@@ -14,11 +14,11 @@ module Mint
     end
 
     def debug(node : Tuple(String, TypeChecker::Checkable, Ast::Node))
-      "#{node[0]} => #{node[1].to_s}"
+      "#{node[0]} => #{node[1]}"
     end
 
     def debug(node : Tuple(String, TypeChecker::Checkable))
-      "#{node[0]} => #{node[1].to_s}"
+      "#{node[0]} => #{node[1]}"
     end
 
     def debug(node : Ast::InlineFunction)

--- a/src/installer/fixed_constraint.cr
+++ b/src/installer/fixed_constraint.cr
@@ -10,13 +10,8 @@ module Mint
         @lower = version
       end
 
-      def to_s
-        "#{target} as #{version}"
-      end
-
       def to_s(io)
-        io << to_s
-        io
+        io << "#{target} as #{version}"
       end
 
       def ==(other)

--- a/src/installer/semver.cr
+++ b/src/installer/semver.cr
@@ -19,13 +19,8 @@ module Mint
       def initialize(@major = 0, @minor = 0, @patch = 0)
       end
 
-      def to_s
-        "#{major}.#{minor}.#{patch}"
-      end
-
       def to_s(io)
-        io << to_s
-        io
+        io << "#{major}.#{minor}.#{patch}"
       end
 
       def next_patch

--- a/src/installer/simple_constraint.cr
+++ b/src/installer/simple_constraint.cr
@@ -6,13 +6,8 @@ module Mint
       def initialize(@lower : Semver, @upper : Semver)
       end
 
-      def to_s
-        "#{@lower} <= v < #{@upper}"
-      end
-
       def to_s(io)
-        io << to_s
-        io
+        io << "#{@lower} <= v < #{@upper}"
       end
 
       def ==(other)

--- a/src/style_builder.cr
+++ b/src/style_builder.cr
@@ -21,8 +21,8 @@ module Mint
     property default : String | Nil
     property variable : String | Nil
 
-    def to_s
-      if variable && default
+    def to_s(io)
+      io << if variable && default
         "var(#{variable}, #{default})"
       elsif variable
         "var(#{variable})"
@@ -155,7 +155,7 @@ module Mint
         .each do |(medias, rules), properties|
           body =
             properties
-              .map { |key, value| "#{key}: #{value.to_s};" }
+              .map { |key, value| "#{key}: #{value};" }
               .join("\n")
 
           rules.each do |rule|

--- a/src/type_checkers/types.cr
+++ b/src/type_checkers/types.cr
@@ -18,8 +18,8 @@ module Mint
         to_s
       end
 
-      def to_s
-        @instance.try(&.to_s) || name
+      def to_s(io)
+        io << (@instance.try(&.to_s) || name)
       end
 
       def to_pretty
@@ -61,8 +61,8 @@ module Mint
         parameters.any?(&.have_holes?)
       end
 
-      def to_s
-        if parameters.empty?
+      def to_s(io)
+        io << if parameters.empty?
           name
         else
           formatted =
@@ -107,11 +107,11 @@ module Mint
         name
       end
 
-      def to_s
-        if fields.empty?
+      def to_s(io)
+        io << if fields.empty?
           name
         else
-          defs = fields.map { |key, value| "#{key}: #{value.to_s}" }.join(", ")
+          defs = fields.map { |key, value| "#{key}: #{value}" }.join(", ")
           "#{name}(#{defs})"
         end
       end
@@ -135,11 +135,11 @@ module Mint
     end
 
     class PartialRecord < Record
-      def to_s
-        if fields.empty?
+      def to_s(io)
+        io << if fields.empty?
           "(...)"
         else
-          defs = fields.map { |key, value| "#{key}: #{value.to_s}" }.join(", ")
+          defs = fields.map { |key, value| "#{key}: #{value}" }.join(", ")
           "(#{defs}, ...)"
         end
       end
@@ -234,7 +234,7 @@ module Mint
           node1
         elsif node1.is_a?(Type) && node2.is_a?(Type)
           if node1.name != node2.name || node1.parameters.size != node2.parameters.size
-            raise "Type error: #{node1.to_s} is not #{node2.to_s}!"
+            raise "Type error: #{node1} is not #{node2}!"
           else
             node1.parameters.each_with_index do |item, index|
               unify(item, node2.parameters[index])

--- a/src/utils/decoder.cr
+++ b/src/utils/decoder.cr
@@ -68,7 +68,7 @@ module Mint
         "Decoder.map(#{decoder})"
       else
         # This should never happen because of the typechecker!
-        raise "Cannot generate a decoder for #{node.to_s}!"
+        raise "Cannot generate a decoder for #{node}!"
       end
     end
   end


### PR DESCRIPTION
Following up the convo here https://github.com/mint-lang/mint/commit/364af52f3d7bf139f008592db3ffd49859ec0480#r38111871

The problem is `Object#to_s` is overridden which is not desired in most cases. In this PR we change it to`Object#to_s(io)` instead, which is used by `Object#to_s` internally. 

<hr>

Check out the warning here:
 https://github.com/crystal-lang/crystal/blob/612825a53c831ce7d17368c8211342b199ca02ff/src/object.cr#L89-L93

Check out the `Array#to_s(io)` sample:
https://github.com/crystal-lang/crystal/blob/612825a53c831ce7d17368c8211342b199ca02ff/src/array.cr#L1825

