### PR TITLE
Add Mint::VERSION constant

### DIFF
--- a/src/all.cr
+++ b/src/all.cr
@@ -12,6 +12,8 @@ require "json"
 
 MINT_ENV = {} of String => String
 
+require "./version"
+
 require "./ext/**"
 
 require "./errors/error"

--- a/src/commands/version.cr
+++ b/src/commands/version.cr
@@ -1,5 +1,3 @@
-require "yaml"
-
 module Mint
   class Cli < Admiral::Command
     class Version < Admiral::Command
@@ -7,16 +5,9 @@ module Mint
 
       define_help description: "Shows version"
 
-      macro read_file_at_compile_time(filename)
-        # Will work until Crystal supports Windows
-        {{ `cat #{filename}`.stringify }}
-      end
-
       def run
         execute "Showing version" do
-          shard_file = read_file_at_compile_time("shard.yml")
-          version = YAML.parse(shard_file)["version"]
-          terminal.puts "Mint #{version}"
+          terminal.puts "Mint #{Mint::VERSION}"
         end
       end
     end

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,0 +1,3 @@
+module Mint
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
+end


### PR DESCRIPTION
It shells out to `shards version` and removes the need for the `read_file_at_compile_time` macro.