### PR TITLE
Serve Documentation Assets With Proper Content Type

### DIFF
--- a/src/documentation_server.cr
+++ b/src/documentation_server.cr
@@ -70,6 +70,9 @@ module Mint
 
         # If there is a baked file serve that.
         begin
+          env.response.content_type =
+            MIME.from_filename?(env.params.url["name"]).to_s
+
           Assets.read("docs-viewer/" + env.params.url["name"])
         rescue BakedFileSystem::NoSuchFileError
           index


### PR DESCRIPTION
Fixes Error:
```bash
Failed to register/update a ServiceWorker for scope ‘http://127.0.0.1:3002/’: Bad Content-Type of ‘text/html’ received for script ‘http://127.0.0.1:3002/service-worker.js’.  Must be a JavaScript MIME type.
SecurityError: The operation is insecure.
```