### PR TITLE
Fix #252

### DIFF
--- a/src/messages/component_main_property.cr
+++ b/src/messages/component_main_property.cr
@@ -7,6 +7,6 @@ message ComponentMainProperty do
     text "component cannot have properties."
   end
 
-  snippet property_name, "A property is defined here:"
+  snippet property_node, "A property is defined here:"
   snippet node, "The component is here:"
 end

--- a/src/messages/component_main_property.cr
+++ b/src/messages/component_main_property.cr
@@ -7,6 +7,6 @@ message ComponentMainProperty do
     text "component cannot have properties."
   end
 
-  snippet property, "A property is defined here:"
+  snippet property_name, "A property is defined here:"
   snippet node, "The component is here:"
 end

--- a/src/messages/html_component_attribute_required.cr
+++ b/src/messages/html_component_attribute_required.cr
@@ -5,6 +5,6 @@ message HtmlComponentAttributeRequired do
     text "One of the required properties were not specified for a component."
   end
 
-  snippet property, "The property in question is:"
+  snippet property_node, "The property in question is:"
   snippet node, "The component was referenced here:"
 end

--- a/src/messages/html_component_attribute_required.cr
+++ b/src/messages/html_component_attribute_required.cr
@@ -5,6 +5,6 @@ message HtmlComponentAttributeRequired do
     text "One of the required properties were not specified for a component."
   end
 
-  snippet "The property in question is:", property
-  snippet "The component was refereced here:", node
+  snippet property, "The property in question is:"
+  snippet node, "The component was referenced here:"
 end

--- a/src/type_checkers/component.cr
+++ b/src/type_checkers/component.cr
@@ -64,8 +64,8 @@ module Mint
 
       if node.name == "Main" && (property = node.properties.first?)
         raise ComponentMainProperty, {
-          "property" => property,
-          "node"     => node,
+          "property_name" => property,
+          "node"          => node,
         }
       end
 

--- a/src/type_checkers/component.cr
+++ b/src/type_checkers/component.cr
@@ -64,7 +64,7 @@ module Mint
 
       if node.name == "Main" && (property = node.properties.first?)
         raise ComponentMainProperty, {
-          "property_name" => property,
+          "property_node" => property,
           "node"          => node,
         }
       end

--- a/src/type_checkers/html_component.cr
+++ b/src/type_checkers/html_component.cr
@@ -33,8 +33,8 @@ module Mint
         next if property.default
 
         raise HtmlComponentAttributeRequired, {
-          "property" => property,
-          "node"     => node,
+          "property_node" => property,
+          "node"          => node,
         } unless attributes.includes?(property.name.value)
       end
 


### PR DESCRIPTION
In the [`ComponentMainProperty`](https://github.com/mint-lang/mint/blob/master/src/messages/component_main_property.cr) and [`HtmlComponentAttributeRequired`](https://github.com/mint-lang/mint/blob/master/src/messages/html_component_attribute_required.cr) the `property` in the error message does not show, not sure why.