### PR TITLE
Followup to #255

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_deploy:
 
 deploy:
   - provider: s3
+    skip_cleanup: true
     access_key_id: AKIAJIQ3HKG3DMFSDRFA
     secret_access_key:
       secure: clxV2kBzgqKUIgkNjnm/y5Tc3SWqW8VgX/cP97TFCtRMsVJKWwReTi9LkbcB2RHmOoj7OMbJ4XEI9vdK/yE19p/9p+9s27qc9gMyDPtWy3cC1xKHukjjC8FQWNdhb5DEuZKf1KtQW/8Lr1M8PwynF54qiJ2tKiwpU7v6QCWggR+YC7UwF2pIZZhGCv2eeTl4Szw9LqMFwLL213coTVOz6cUSrdgILaH3bAv72QsPHWUT1B9keE51RFjjGINCX0x/Ui9DnR/ILlXFDnq2khmCiQ8d2CUvNH/NgBlc0DUsuxsBl3SiZnkMc4ElMYmhEcBm78XQ5zMqxZbcio/Zni7QEqqmkxhjXIbe0ycuLHv4UCS/9Io5KqP2G1zorQa3R5CMej/F55D4c/SYEWikialZeDPrySqzzROVJN4lAgBHgI3iiqgVKvwPJvDuZLGRhAU78lFdCqlcJh7LyOsbmAIF9+yOpRsDXnPpyZlFGH/MKAQWoZSFt7WUYAF6Thk6taCChg+ju934QAM7kcprBAR6LWG19AHpQTn/T4CUXMatz5Jjjlj98uRWBS4VX/xgrCHGXmTz08KWOwDbe0dTxDhBXy430MXQd+9nrPfJFJ6iGNfbvPNveqRsdNJP3NdzxodPCTwxjgVU7Wunm/qkhxNt0zwJH4wiyy3SlVscWK2+OTw=
@@ -45,6 +46,7 @@ deploy:
     local_dir: build
 
   - provider: releases
+    skip_cleanup: true
     token:
       secure: j24NX9YWlWigJ1L5csx+GpbcLBY0RUzD029uFBNGEN9C1nXGIdtXVaxUrd+vCqJf3I40qykKZdajwW8bkt/79KDGDehytDPczP6FKk1NBMR+6usNzgzTMQLg0e7AGn7tVrBRS2cZUaiB6V23K7TNt6O67/jf55CgMsCUXAqycs8TowcXQ7KQvLrN1c2L1X5ypzGgF6Lc484ry9NVsXmr0fcKMJfCaOlJxMhg479GNPwS3EwGs9GrT5STLO+XcssfdFE8ij6eTE7SDtEQgm2MNlysQ6pPbs24k77coC6bVm/KIJMHyResBmOuKRLiY07fEt6LemdxOcfwK59LZCh4ccdawUhI/EhGg6K8QLXeStmRw835pD2juNqfg9Icje1eCkLQJ+6I+FD9QhwRr2ix+yCzVYX3Vfe6wCKqNfnc/kEz/z2UubXrcZeADsOTWIbJXOx0pLue9SnPFXVc/kjp1tUtgQMaZeC8dAhO0Il6miRP5uSEO6Fd/LRFs0LxHoSpbrPLbXggVQd9qm1RKIHaksn8Ajy35DO+vmA0XfXeuAtSlSECsyKXmueGnF+yTXAy/8+S/eKQQbfIAMRUx0SIPKdS86Z5ziWU/afcZNaWWtgI73So88DUG3rPlPwLayV6BpwVxMKbbyDMBOUxWIcZ17orr3KhXVJgpklrFVrdUuU=
     file_glob: true

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,8 @@ build:
 test-core: build
 	cd core/tests && ../../bin/mint test
 
+development: build
+	cp bin/mint ~/.bin/mint-dev
+
 documentation:
 	rm -rf docs && crystal docs


### PR DESCRIPTION
Adds back `skip_cleanup: true` flag to deploy steps on Travis CI, since apparently we’re still using deployments v1, in contrast to the _hint_ displayed within the Travis' web ui.

Followup to #255