### PR TITLE
add entries to Map

### DIFF
--- a/core/source/Map.mint
+++ b/core/source/Map.mint
@@ -314,4 +314,26 @@ module Map {
   fun size (map : Map(key, value)) : Number {
     `#{map}.size`
   }
+
+  /*
+  Returns the array of {key, value} Tuple.
+
+    (Map.empty()
+    |> Map.set("a", 1)
+    |> Map.set("b", 2)
+    |> Map.entries()) == [{"a", 1}, {"b", 2}]
+  */
+  fun entries (map : Map(a, b)) : Array(Tuple(a, b)) {
+    keys
+    |> Array.mapWithIndex(
+      (key : a, i : Number) : Tuple(a, b) {
+        {key, (Maybe.withDefault(Maybe.nothing(), values[i]))}
+      })
+  } where {
+    keys =
+      Map.keys(map)
+
+    values =
+      Map.values(map)
+  }
 }

--- a/core/tests/tests/Map.mint
+++ b/core/tests/tests/Map.mint
@@ -229,3 +229,17 @@ suite "Map.getWithDefault" {
     |> Map.getWithDefault("key", "fallback")) == "fallback"
   }
 }
+
+suite "Map.entries" {
+  test "returns an array of key-value tuple" {
+    (Map.empty()
+    |> Map.set("a", 100)
+    |> Map.set("b", 200)
+    |> Map.Extra.entries()) == [{"a", 100}, {"b", 200}]
+  }
+
+  test "returns an array of key-value tuple" {
+    (Map.empty()
+    |> Map.Extra.entries()) == []
+  }
+}

--- a/core/tests/tests/Map.mint
+++ b/core/tests/tests/Map.mint
@@ -235,11 +235,6 @@ suite "Map.entries" {
     (Map.empty()
     |> Map.set("a", 100)
     |> Map.set("b", 200)
-    |> Map.Extra.entries()) == [{"a", 100}, {"b", 200}]
-  }
-
-  test "returns an array of key-value tuple" {
-    (Map.empty()
-    |> Map.Extra.entries()) == []
+    |> Map.entries()) == [{"a", 100}, {"b", 200}]
   }
 }


### PR DESCRIPTION
Hi mint-lang 🍃.
Map has `keys` and `values` but no `entires` so I added.
It's very useful to iterate maps.