### PR TITLE
Template 'left' and 'top' in `Dom.getElementFromPoint`

### DIFF
--- a/core/source/Dom.mint
+++ b/core/source/Dom.mint
@@ -260,7 +260,7 @@ module Dom {
   fun getElementFromPoint (left : Number, top : Number) : Maybe(Dom.Element) {
     `
     (() => {
-      const element = document.elementFromPoint(left, top)
+      const element = document.elementFromPoint(#{left}, #{top})
 
       if (element) {
         return new Just(element)


### PR DESCRIPTION
This fixes a bug where using the `getElementFromPoint` would give a 'left is not defined' error in JS as the variable was hard coded rather than templated.