### PR TITLE
Fix documentation typos

### DIFF
--- a/core/source/AnimationFrame.mint
+++ b/core/source/AnimationFrame.mint
@@ -1,7 +1,7 @@
 /* This module provides a wrapper over the Animation Frame Web API. */
 module AnimationFrame {
   /*
-  Schedules the function to run on the next frame, and returns it's ID.
+  Schedules the function to run on the next frame, and returns its ID.
 
     id = AnimationFrame.request(() { Debug.log("Hello") })
   */

--- a/core/source/Array.mint
+++ b/core/source/Array.mint
@@ -113,7 +113,7 @@ module Array {
   }
 
   /*
-  Returns all elements that matches the predicate function.
+  Returns all elements that match the predicate function.
 
     Array.select((number : Number) : Bool { number % 2 == 0 }, [1, 2, 3, 4]) == [2, 4]
   */
@@ -122,7 +122,7 @@ module Array {
   }
 
   /*
-  Returns all elements that does not matches the predicate function.
+  Returns all elements that do not matches the predicate function.
 
     Array.reject((number : Number) : Bool { number % 2 == 0 }, [1, 2, 3, 4]) == [1, 3]
   */
@@ -293,7 +293,7 @@ module Array {
   }
 
   /*
-  Returns an random element from the array.
+  Returns a random element from the array.
 
     Array.sample(["a"]) == Maybe.just("a")
     Array.sample() == Maybe.nothing()
@@ -323,7 +323,7 @@ module Array {
   }
 
   /*
-  Put two lists together:
+  Puts two lists together:
 
     Array.append([1,1,2] [3,5,8]) == [1,1,2,3,5,8]
   */
@@ -482,7 +482,7 @@ module Array {
 
   /*
   Flattens an `Array(Maybe(a))` into an `Array(a)`, by unwrapping the items
-  and skipping nothings.
+  and skipping all elements of type `Nothing`.
 
     Array.compact([Maybe.just("A"), Maybe.nothing()]) == ["A"]
   */
@@ -565,8 +565,8 @@ module Array {
   }
 
   /*
-  Spaws the items at the given indexes of the given array. It returns the array
-  unchanged if there is no item at any of the given indexs.
+  Swaps the items at the given indexes of the given array. It returns the array
+  unchanged if there is no item at any of the given indexes.
 
     Array.swap(0, 1, ["a","b"]) == ["b", "a"]
   */

--- a/core/source/Debug.mint
+++ b/core/source/Debug.mint
@@ -1,6 +1,6 @@
-/* Functions for debugging purpuses */
+/* Functions for debugging purposes */
 module Debug {
-  /* Logs an arbritaty value to the windows console. */
+  /* Logs an arbitrary value to the windows console. */
   fun log (value : a) : a {
     `
     (() => {

--- a/core/source/Dom.mint
+++ b/core/source/Dom.mint
@@ -110,7 +110,7 @@ module Dom {
   /*
   Sets the value property of a `Dom.Element`.
 
-  It is used to set the value of `input` fields programatically.
+  It is used to set the value of `input` fields programmatically.
   */
   fun setValue (value : String, dom : Dom.Element) : Dom.Element {
     `(#{dom}.value = #{value}) && #{dom}`

--- a/core/source/File.mint
+++ b/core/source/File.mint
@@ -84,7 +84,7 @@ module File {
   Opens the browsers file dialog for selecting a single file.
 
   * The mime type can be restricted to the given one.
-  * It might not esolve if the user cancels the dialog.
+  * It might not resolve if the user cancels the dialog.
 
     sequence {
       file =

--- a/core/source/Html.Event.mint
+++ b/core/source/Html.Event.mint
@@ -41,7 +41,7 @@ record Html.Event {
   event : Html.NativeEvent
 }
 
-/* Utilit functions for `Html.Event` */
+/* Utility functions for `Html.Event` */
 module Html.Event {
   fun fromEvent (event : Html.NativeEvent) : Html.Event {
     {

--- a/core/source/Html.Portals.Body.mint
+++ b/core/source/Html.Portals.Body.mint
@@ -3,7 +3,7 @@ component Html.Portals.Body {
   /* The children to render into the portal */
   property children : Array(Html) = []
 
-  /* Renders the children into the documents body. */
+  /* Renders the children into the document's body. */
   fun render : Html {
     `_createPortal(#{children}, document.body)`
   }

--- a/core/source/Html.mint
+++ b/core/source/Html.mint
@@ -1,6 +1,6 @@
 module Html {
   /*
-  Returns an empty Html node. It is useful for example if you dont to
+  Returns an empty Html node. It is useful for example if you don't to
   render something conditionally.
 
     if (Array.isEmpty(items)) {

--- a/core/source/Http.mint
+++ b/core/source/Http.mint
@@ -53,7 +53,7 @@ sequence {
 */
 module Http {
   /*
-  Creates an empty request record. It is useful if you want to use a non
+  Creates an empty request record. It is useful if you want to use a non-
   standard HTTP method.
 
     Http.empty() ==
@@ -230,13 +230,13 @@ module Http {
     `
   }
 
-  /* Returns all running requuests. */
+  /* Returns all running requests. */
   fun requests : Map(String, Http.NativeRequest) {
     `this._requests`
   }
 
   /*
-  Sends the request with a generated unique id.
+  Sends the request with a generated unique ID.
 
     "https://httpbin.org/get"
     |> Http.get()

--- a/core/source/Json.mint
+++ b/core/source/Json.mint
@@ -1,4 +1,4 @@
-/* A module for parsing and stringifing JSON format. */
+/* A module for parsing and stringifying JSON format. */
 module Json {
   /*
   Parses a string into an `Object`, returns `Maybe.nothing()`
@@ -20,7 +20,7 @@ module Json {
   }
 
   /*
-  Stringifies am `Object` into JSON string.
+  Stringifies an `Object` into JSON string.
 
     Json.stringify(`{ a: "Hello" }`) == "{ \"a\": \"Hello\" }"
   */

--- a/core/source/Map.mint
+++ b/core/source/Map.mint
@@ -6,7 +6,7 @@ module Map {
   }
 
   /*
-  Sets the given value to the kiven key in the map.
+  Sets the given value to the given key in the map.
 
     Map.empty()
     |> Map.set("key", "value")

--- a/core/source/Math.mint
+++ b/core/source/Math.mint
@@ -20,7 +20,7 @@ module Math {
   }
 
   /*
-  Returns the smallest integer greater than or equal to a given number.
+  Returns the smallest integer greater than or equal to the given number.
 
     Math.ceil(0.3) == 1
   */
@@ -29,7 +29,7 @@ module Math {
   }
 
   /*
-  Returns the largest integer less than or equal to a given number.
+  Returns the largest integer less than or equal to the given number.
 
     Math.floor(0.8) == 0
   */
@@ -103,7 +103,7 @@ module Math {
   }
 
   /*
-  Truncates the given number to the giver amount.
+  Truncates the given number to the given amount.
 
     Math.truncate(0.123456) == 0.12
   */

--- a/core/source/Number.mint
+++ b/core/source/Number.mint
@@ -1,6 +1,6 @@
 module Number {
   /*
-  Returns true if number is odd.
+  Returns true if given number is odd.
 
     Number.isOdd(1) == false
     Number.isOdd(2) == true
@@ -10,7 +10,7 @@ module Number {
   }
 
   /*
-  Returns true if number is even.
+  Returns true if given number is even.
 
     Number.isEven(1) == true
     Number.isEven(2) == false
@@ -20,7 +20,7 @@ module Number {
   }
 
   /*
-  Returns true if a number is a `NaN`.
+  Returns true if given number is `NaN`.
 
     Number.isNaN(`NaN`) == true
     Number.isNaN(0) == false
@@ -41,7 +41,7 @@ module Number {
   /*
   Formats a number using fixed-point notation.
 
-  The first arguments speficies the number of digits to appear after the decimal
+  The first arguments specifies the number of digits to appear after the decimal
   point, it can be between 0 and 20.
 
     Number.toFixed(2, 0.1234567) == "0.12"
@@ -71,7 +71,7 @@ module Number {
   }
 
   /*
-  Formats the given number using the griven prefix and separating the digits
+  Formats the given number using the given prefix and separating the digits
   by 3 with a comma.
 
     Number.format("$ ", 1034150) == "$ 1,034,150"

--- a/core/source/Object/Decode.mint
+++ b/core/source/Object/Decode.mint
@@ -1,6 +1,6 @@
 /* Functions for decoding specific types from an `Object`. */
 module Object.Decode {
-  /* Decodes an field from an object using the given decoder. */
+  /* Decodes a field from an object using the given decoder. */
   fun field (
     key : String,
     decoder : Function(Object, Result(Object.Error, a)),
@@ -29,7 +29,7 @@ module Object.Decode {
     `Decoder.boolean(#{input})`
   }
 
-  /* Decodes the object as a `Array` using the given decoder. */
+  /* Decodes the object as an `Array` using the given decoder. */
   fun array (
     decoder : Function(Object, Result(Object.Error, a)),
     input : Object

--- a/core/source/Provider/Shortcuts.mint
+++ b/core/source/Provider/Shortcuts.mint
@@ -34,7 +34,7 @@ provider Provider.Shortcuts : Provider.Shortcuts.Subscription {
 
       shift =
         if (event.shiftKey && event.keyCode != 16) {
-          Maybe::Just(17)
+          Maybe::Just(16)
         } else {
           Maybe::Nothing
         }

--- a/core/source/Provider/Tick.mint
+++ b/core/source/Provider/Tick.mint
@@ -3,7 +3,7 @@ record Provider.Tick.Subscription {
   ticks : Function(Promise(Never, Void))
 }
 
-/* A provider for periodic updated (every 1 seconds). */
+/* A provider for periodic updates (every 1 seconds). */
 provider Provider.Tick : Provider.Tick.Subscription {
   state id : Number = -1
 

--- a/core/source/Provider/Websocket.mint
+++ b/core/source/Provider/Websocket.mint
@@ -1,4 +1,4 @@
-/* Provider to handle webscoket connections. */
+/* Provider to handle websocket connections. */
 provider Provider.WebSocket : WebSocket.Config {
   state connections : Map(String, WebSocket) = Map.empty()
 

--- a/core/source/Storage/Common.mint
+++ b/core/source/Storage/Common.mint
@@ -3,17 +3,17 @@ enum Storage.Error {
   /* The storage API is disabled. */
   SecurityError
 
-  /* The storage is full (over the qouta, usually 5MB). */
+  /* The storage is full (over the quota, usually 5MB). */
   QuotaExceeded
 
-  /* The key in the storage does not exists. */
+  /* The key in the storage does not exist. */
   NotFound
 
-  /* The reason for the faliure is unknown. */
+  /* The reason for the failure is unknown. */
   Unknown
 }
 
-/* Common implementation of the storage api. */
+/* Common implementation of the storage API. */
 module Storage.Common {
   /* Sets the given key to the given value in the given storage. */
   fun set (storage : Storage, key : String, value : String) : Result(Storage.Error, Void) {

--- a/core/source/String.mint
+++ b/core/source/String.mint
@@ -105,10 +105,10 @@ module String {
   /*
   Returns if the given string is an anagram of the other string.
 
-    String.isAnagarm("asd", "blah") == false
-    String.isAnagarm("rail safety", "fairy tales") == true
+    String.isAnagram("asd", "blah") == false
+    String.isAnagram("rail safety", "fairy tales") == true
   */
-  fun isAnagarm (string1 : String, string2 : String) : Bool {
+  fun isAnagram (string1 : String, string2 : String) : Bool {
     `
     (() => {
       const normalize = string =>

--- a/core/source/Test/Html.mint
+++ b/core/source/Test/Html.mint
@@ -231,7 +231,7 @@ module Test.Html {
     `
   }
 
-  /* Asserts the value of a css property on the element that matches the given selector. */
+  /* Asserts the value of a CSS property on the element that matches the given selector. */
   fun assertCSSOf (
     selector : String,
     property : String,

--- a/core/source/WebSocket.mint
+++ b/core/source/WebSocket.mint
@@ -78,7 +78,7 @@ module WebSocket {
   }
 
   /*
-  Closes the given given websocket connection.
+  Closes the given websocket connection.
 
     WebSocket.close(websocket)
 
@@ -90,7 +90,7 @@ module WebSocket {
   }
 
   /*
-  Closes the given given websocket connection without reconnecting, even if the
+  Closes the given websocket connection without reconnecting, even if the
   `reconnectOnClose` flag was set.
 
     WebSocket.closeWithoutReconnecting(websocket)

--- a/core/source/Window.mint
+++ b/core/source/Window.mint
@@ -147,7 +147,7 @@ module Window {
   }
 
   /*
-  Gets the with of the scrollbar.
+  Gets the width of the scrollbar.
 
     Window.getScrollbarWidth() == 10
   */

--- a/core/tests/tests/String.mint
+++ b/core/tests/tests/String.mint
@@ -106,11 +106,11 @@ suite "String.capitalize" {
 
 suite "String.isAnagram" {
   test "returns false for non anagrams" {
-    String.isAnagarm("asd", "blah") == false
+    String.isAnagram("asd", "blah") == false
   }
 
   test "returns true for anagrams" {
-    String.isAnagarm("rail safety", "fairy tales") == true
+    String.isAnagram("rail safety", "fairy tales") == true
   }
 }
 


### PR DESCRIPTION
There's one commit spread across 19 files or so because I didn't feel it would be a great idea to make individual commits for a few single-letter fixes per file. Array.mint had quite a few typos so it got a commit of its own.

**Breaking changes**

* String.isAnagarm is now renamed to String.isAnagram
* Provider.Shortcuts now returns the correct keycode for pressing shift