### PR TITLE
Use xcode12 On Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode12
+
 before_deploy:
   - mkdir build
   - |


### PR DESCRIPTION
Upgrading in order to bypass the OpenSSL [linking issue](https://github.com/crystal-lang/crystal/issues/9477) Crystal has with older OSX version as seen on this [CI build](https://travis-ci.org/github/mint-lang/mint/jobs/703775612)