### PR TITLE
Various fixes

### DIFF
--- a/core/source/FormData.mint
+++ b/core/source/FormData.mint
@@ -15,7 +15,7 @@ module FormData {
   }
 
   /*
-  Returns the keys of a FromData object.
+  Returns the keys of a FormData object.
 
     FormData.empty()
     |> FormData.addString("key", "value")

--- a/core/source/Html.mint
+++ b/core/source/Html.mint
@@ -1,6 +1,6 @@
 module Html {
   /*
-  Returns an empty Html node. It is useful for example if you don't to
+  Returns an empty Html node. It is useful for example if you don't want to
   render something conditionally.
 
     if (Array.isEmpty(items)) {

--- a/core/source/Http.mint
+++ b/core/source/Http.mint
@@ -243,7 +243,7 @@ module Http {
     |> Http.send()
   */
   fun send (request : Http.Request) : Promise(Http.ErrorResponse, Http.Response) {
-    sendWithID(Uid.generate(), request)
+    sendWithId(Uid.generate(), request)
   }
 
   /*
@@ -251,9 +251,9 @@ module Http {
 
     "https://httpbin.org/get"
     |> Http.get()
-    |> Http.sendWithID("my-request")
+    |> Http.sendWithId("my-request")
   */
-  fun sendWithID (uid : String, request : Http.Request) : Promise(Http.ErrorResponse, Http.Response) {
+  fun sendWithId (uid : String, request : Http.Request) : Promise(Http.ErrorResponse, Http.Response) {
     `
     new Promise((resolve, reject) => {
       if (!this._requests) { this._requests = {} }

--- a/core/source/Result.mint
+++ b/core/source/Result.mint
@@ -45,10 +45,10 @@ module Result {
   Returns the error of the given result or the default value if it's an ok.
 
     (Result.error("error")
-    |> Result.withDefault("a")) == "error"
+    |> Result.withError("a")) == "error"
 
     (Result.ok("ok")
-    |> Result.withDefault("a")) == "a"
+    |> Result.withError("a")) == "a"
   */
   fun withError (defaultError : a, input : Result(a, b)) : a {
     case (input) {

--- a/core/source/Test/Html.mint
+++ b/core/source/Test/Html.mint
@@ -232,7 +232,7 @@ module Test.Html {
   }
 
   /* Asserts the value of a CSS property on the element that matches the given selector. */
-  fun assertCSSOf (
+  fun assertCssOf (
     selector : String,
     property : String,
     value : String,

--- a/core/tests/tests/Dom.mint
+++ b/core/tests/tests/Dom.mint
@@ -153,7 +153,7 @@ suite "Dom.focusWhenVisible" {
         |> triggerClick("#focus")
         |> triggerClick("#show")
         |> timeout(200)
-        |> assertCSSOf("#input", "display", "inline-block")
+        |> assertCssOf("#input", "display", "inline-block")
         |> assertActiveElement("#input")
       }
     }

--- a/core/tests/tests/Http.mint
+++ b/core/tests/tests/Http.mint
@@ -136,12 +136,12 @@ suite "Http.header" {
   }
 }
 
-suite "Http.sendWithID" {
+suite "Http.sendWithId" {
   test "sends the request with the given ID" {
     try {
       response =
         Http.get("/blah")
-        |> Http.sendWithID("A")
+        |> Http.sendWithId("A")
 
       `#{Http.requests()}["A"] != undefined`
     }
@@ -172,7 +172,7 @@ component Test.Http {
         Http.empty()
         |> Http.url(url)
         |> Http.method(method)
-        |> Http.sendWithID("test")
+        |> Http.sendWithId("test")
         |> wrap(
           `
           (async (promise) => {


### PR DESCRIPTION
Fixes a few small typos in the documentation and renames some functions to be consistent with acronyms in other functions.

**Breaking changes**

`Http.sendWithID` renamed to `Http.sendWithId`
`Test.Html.assertCSSOf` renamed to `Test.Html.assertCssOf`