### PR TITLE
Fix incorrect function name in docs

### DIFF
--- a/core/source/Dom.mint
+++ b/core/source/Dom.mint
@@ -31,7 +31,7 @@ module Dom {
   /*
   Gets the first element to match the given selector from anywhere in the page.
 
-    Dom.getElementById("body section > p:first-child")
+    Dom.getElementBySelector("body section > p:first-child")
   */
   fun getElementBySelector (selector : String) : Maybe(Dom.Element) {
     `


### PR DESCRIPTION
A very straightforward fix that I forgot to include in my last PR.