### PR TITLE
Update HtmlComponentExpectedClosingBracket error message

### DIFF
--- a/src/messages/html_component_expected_closing_bracket.cr
+++ b/src/messages/html_component_expected_closing_bracket.cr
@@ -2,16 +2,22 @@ message HtmlComponentExpectedClosingBracket do
   title "Syntax Error"
 
   block do
-    text "I found a"
-    bold "slash"
-    code "/"
-    text "which indicates that the component does not have children. A"
-    bold "closing bracket"
-    code ">"
-    text "must follow the slash."
+    text "I could not parse further. I was looking for one of the following:"
   end
 
-  was_looking_for "closing bracket", got, ">"
+  list [
+    "an attribute for the component",
+    "a reference to the component \"as component\"",
+    "\"/>\" for self closing components",
+    "\">\" for non self closing components",
+  ]
+
+  block do
+    text "but found"
+    code got
+    text "instead."
+    text "You can read more about components here: https://www.mint-lang.com/guide/reference/components"
+  end
 
   snippet node
 end


### PR DESCRIPTION
Let me know if there's better wording. I tried to add a Link class to put the link in an anchor tag but I kept getting a missing hash key exception.

<img width="1105" alt="CleanShot 2020-10-06 at 00 29 54@2x" src="https://user-images.githubusercontent.com/17329408/95162341-13cc8e00-076b-11eb-9c6c-d87795541286.png">
