### PR TITLE
Gracefully shut down the test runner in case of uncaught exceptions in JavaScript

### DIFF
--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -49,17 +49,14 @@ module Mint
 
                 window.onerror = (message) => {
                   if (this.socket.readyState === 1) {
-                    console.log("!!1");
                     this.crash(message);
                   } else {
-                    console.log("!!2");
-                    error ||= message;
+                    error = error || message;
                   }
                 }
 
                 this.socket.onopen = () => {
                   if (error != null) {
-                    console.log("!!3");
                     this.crash(error);
                   }
 
@@ -80,7 +77,7 @@ module Mint
               run () {
                 return new Promise((resolve, reject) => {
                   this.next(resolve, reject)
-                }).then(() => this.socket.send("DONE"));
+                }).finally(() => this.socket.send("DONE"));
               }
 
               crash (message) {
@@ -363,7 +360,7 @@ module Mint
               terminal.puts "    |> #{failure.result}".colorize(:red)
             end
 
-           stop_server
+            stop_server
           else
             data = Message.from_json(message)
             case data.type

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -20,7 +20,7 @@ module Mint
           <script src="/runtime.js"></script>
           <script>
             class TestRunner {
-              constructor (suites) {
+              constructor () {
                 this.socket = new WebSocket("ws://#{@flags.browser_host}:#{@flags.browser_port}/")
 
                 window.DEBUG = {
@@ -43,8 +43,6 @@ module Mint
                   }
                 }
 
-                this.suites = suites
-
                 let error = null;
 
                 window.onerror = (message) => {
@@ -61,22 +59,23 @@ module Mint
                   }
 
                   window.addEventListener('unhandledrejection', (event) => {
-                    event.promise.catch(e => crash(e.message));
+                    event.promise.catch(e => this.crash(e.toString()));
                   });
                 }
               }
 
               start (suites) {
+                this.suites = suites;
                 if (this.socket.readState === 1) {
                   this.run();
                 } else {
-                  this.socket.addEventListener("open", this.run);
+                  this.socket.addEventListener("open", () => this.run());
                 }
               }
 
               run () {
                 return new Promise((resolve, reject) => {
-                  this.next(resolve, reject)
+                  this.next(resolve, reject);
                 }).finally(() => this.socket.send("DONE"));
               }
 

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -59,7 +59,7 @@ module Mint
                   }
 
                   window.addEventListener('unhandledrejection', (event) => {
-                    event.promise.catch(e => this.crash(e.toString()));
+                    this.crash(event.reason);
                   });
                 }
               }

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -68,7 +68,7 @@ module Mint
               run () {
                 return new Promise((resolve, reject) => {
                   this.next(resolve, reject);
-                }).catch(e => this.log(e))
+                }).catch(e => this.log(e.reason))
                   .finally(() => this.socket.send("DONE"));
               }
 

--- a/src/test_runner/documentation_reporter.cr
+++ b/src/test_runner/documentation_reporter.cr
@@ -16,6 +16,10 @@ module Mint
 
       def done
       end
+
+      def crashed(message)
+        puts "❗ An internal error occurred while executing a test: #{message}".colorize(:red)
+      end
     end
   end
 end

--- a/src/test_runner/dot_reporter.cr
+++ b/src/test_runner/dot_reporter.cr
@@ -29,6 +29,11 @@ module Mint
       def done
         puts
       end
+
+      def crashed(message)
+        puts
+        puts "❗ An internal error occurred while executing a test: #{message}".colorize(:red)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, when running tests, if the emitted JavaScript is invalid and causes an exception to be thrown (such as in the case of [this commit](https://github.com/mint-lang/mint/commit/98279f24858b0fb09a1893bb62aa4c2a68531de2), which fixed a bug in which missing parentheses caused a syntax error; thanks again for the fix!), the tests would stop running, but the test runner would still be running, still waiting for the `DONE` message that will never arrive, and so the test runner would be hanging forever. This pull request introduces a global handler that catches all unhandled exceptions in promises and sends the `CRASHED` message to the test runner, signalling an "internal error" and shutting down the test server and runner, instead of leaving the test runner hanging.

To test this, I simply renamed the `tests` field in a suite to `test` (while still keeping the `this.suite.tests` line to trigger a `TypeError` in JavaScript), and observed that running `mint test` will indeed display the expected exception message. I'm not sure how to set up a unit test for this handler, since ideally, it should never be used (but in case that the emitted JavaScript is somehow invalid, it provides a recovery mechanism).

Currently, only the error message in the JavaScript exception is displayed (as opposed to the entire stack trace). Please let me know if this (or any other aspects of the pull request) should be changed.