### PR TITLE
`try` can return a result directly

### DIFF
--- a/spec/formatters/try_with_catch
+++ b/spec/formatters/try_with_catch
@@ -6,7 +6,7 @@ module Result {
 
 module A {
   fun test : String {
-    try{x=Result.error("hello")}catch String => a {"blah"}
+    try{x=Result.error("hello")x}catch String => a {"blah"}
   }
 }
 --------------------------------------------------------------------------------
@@ -21,6 +21,8 @@ module A {
     try {
       x =
         Result.error("hello")
+
+      x
     } catch String => a {
       "blah"
     }

--- a/spec/formatters/try_with_catch_all
+++ b/spec/formatters/try_with_catch_all
@@ -6,7 +6,7 @@ module Result {
 
 module A {
   fun test : String {
-    try{x=Result.error("hello") y=Result.error(0)}catch String => a {"blah"}catch{"X"}
+    try{x=Result.error("hello") y=Result.error(0)y}catch String => a {"blah"}catch{"X"}
   }
 }
 --------------------------------------------------------------------------------
@@ -24,6 +24,8 @@ module A {
 
       y =
         Result.error(0)
+
+      y
     } catch String => a {
       "blah"
     } catch {


### PR DESCRIPTION
I took this test https://github.com/mint-lang/mint/blob/master/spec/compilers/try_with_catches_and_return_result and the docs as indication that it is the intention that `try` returns its last statement directly even if it is a Result.

This PR does 2 things:
1) `try` now directly returns its last statement even if it is a `Result`
2) If a non final statement in a `try` is a `Result` but its error type is a type variable then it is not catchable. I think this is fine, as I think this is only the case if the error is not possible but I'm not positive this is always the case in mint.

Happy to push this in what ever direction works for mint. By no means trying to influence the semantics of `try` just bug fixing. If the current functionality of `try` is the correct functionality and it is the docs that are wrong I'm happy to close this and fix the docs!

fixes: #380 