### PR TITLE
Rename manifest.json to manifest.webmanifest

### DIFF
--- a/src/builder.cr
+++ b/src/builder.cr
@@ -38,8 +38,8 @@ module Mint
         File.write Path[DIST_DIR, "index.html"], IndexHtml.render(Environment::BUILD, relative, skip_service_worker, skip_icons)
       end
 
-      terminal.measure "#{COG} Writing manifest.json..." do
-        File.write "dist/manifest.json", manifest(json, skip_icons)
+      terminal.measure "#{COG} Writing manifest.webmanifest..." do
+        File.write "dist/manifest.webmanifest", manifest(json, skip_icons)
       end
 
       unless skip_icons

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -29,7 +29,7 @@ module Mint
 
             t.title json.application.title.to_s
 
-            t.link(rel: "manifest", href: path_for("manifest.json"))
+            t.link(rel: "manifest", href: path_for("manifest.webmanifest"))
 
             json.application.meta.each do |name, content|
               next if name == "charset"


### PR DESCRIPTION
Specification suggest using .webmanifest in place of .json -- see https://www.w3.org/TR/appmanifest/ 

Also picked up by webhint lint -- see https://webhint.io/docs/user-guide/hints/hint-manifest-file-extension