### PR TITLE
Implement lint command feature

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -25,6 +25,7 @@ module Mint
     register_sub_command docs, type: Docs
     register_sub_command loc, type: Loc
     register_sub_command ls, type: Ls
+    register_sub_command lint, type: Lint
 
     def run
       execute "Help" do

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -26,16 +26,16 @@ module Mint
         errors = [] of String
         sources = [] of String
 
+        ast =
+          Ast.new
+            .merge(Core.ast)
+
         begin
           sources =
             Dir.glob(SourceFiles.all)
         rescue ex
           ex_handler errors, ex
         end
-
-        ast =
-          Ast.new
-            .merge(Core.ast)
 
         sources.reduce(ast) do |memo, file|
           parsed = Parser.parse(file)

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -10,12 +10,6 @@ module Mint
         default: false,
         required: false
 
-      define_flag output : String,
-        description: "The output filename",
-        default: "lint.json",
-        required: false,
-        short: "o"
-
       def run
         execute "Linting" do
           lint
@@ -23,8 +17,8 @@ module Mint
       end
 
       def lint
-        errors = [] of String
         sources = [] of String
+        errors = [] of Exception
 
         ast =
           Ast.new
@@ -47,7 +41,7 @@ module Mint
           ex_handler errors, ex
         end
 
-        if errors.size == 0
+        if errors.empty?
           type_checker =
             TypeChecker.new(ast)
 
@@ -65,7 +59,7 @@ module Mint
         end
 
         if flags.json
-          File.write(flags.output, errors)
+          puts errors.compact_map(&.message.presence).to_json
         end
 
         if errors.size > 0
@@ -74,9 +68,7 @@ module Mint
       end
 
       def ex_handler(errors, ex)
-        if ex.message.is_a?(String)
-          errors << ex.message.as(String).to_json
-        end
+        errors << ex
 
         puts ex
       end

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -28,7 +28,7 @@ module Mint
           sources =
             Dir.glob(SourceFiles.all)
         rescue ex
-          ex_handler errors, ex
+          errors << ex
         end
 
         sources.reduce(ast) do |memo, file|
@@ -38,7 +38,7 @@ module Mint
             memo.merge parsed
           end
         rescue ex
-          ex_handler errors, ex
+          errors << ex
         end
 
         if errors.empty?
@@ -51,7 +51,7 @@ module Mint
             begin
               type_checker.check
             rescue ex
-              ex_handler errors, ex
+              errors << ex
             else
               done = true
             end
@@ -60,15 +60,11 @@ module Mint
 
         if flags.json
           puts errors.compact_map(&.message.presence).to_json
+        else
+          puts errors
         end
 
         exit(errors.empty? ? 0 : 1)
-      end
-
-      def ex_handler(errors, ex)
-        errors << ex
-
-        puts ex
       end
     end
   end

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -33,9 +33,6 @@ module Mint
           Ast.new
             .merge(Core.ast)
 
-        runtime =
-          Assets.read("runtime.js")
-
         errors = [] of String
 
         terminal.measure "  #{ARROW} Parsing #{sources.size} source files... " do

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -33,7 +33,9 @@ module Mint
 
         sources.reduce(ast) do |memo, file|
           begin
-            parsed = Parser.parse(file)
+            parsed =
+              Parser.parse(file)
+
             memo.merge(parsed)
           rescue ex
             errors << ex

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -62,9 +62,7 @@ module Mint
           puts errors.compact_map(&.message.presence).to_json
         end
 
-        if errors.size > 0
-          exit 1
-        end
+        exit(errors.empty? ? 0 : 1)
       end
 
       def ex_handler(errors, ex)

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -1,0 +1,80 @@
+module Mint
+  class Cli < Admiral::Command
+    class Lint < Admiral::Command
+      include Command
+
+      define_help description: "Lints the project"
+
+      define_flag json : Bool,
+        description: "Output errors to a JSON file",
+        default: false,
+        required: false
+
+      define_flag output : String,
+        description: "The output filename",
+        default: "lint.json",
+        required: false,
+        short: "o"
+
+      def run
+        execute "Linting" do
+          lint
+        end
+      end
+
+      def lint
+        json =
+          MintJson.parse_current
+
+        sources =
+          Dir.glob(SourceFiles.all)
+
+        ast =
+          Ast.new
+            .merge(Core.ast)
+
+        runtime =
+          Assets.read("runtime.js")
+
+        errors = [] of String
+
+        terminal.measure "  #{ARROW} Parsing #{sources.size} source files... " do
+          sources.reduce(ast) do |memo, file|
+            parsed = Parser.parse(file)
+
+            if memo
+              memo.merge parsed
+            end
+          rescue ex
+            ex_handler errors, ex
+          end
+        end
+
+        type_checker =
+          TypeChecker.new(ast)
+
+        terminal.measure "  #{ARROW} Type checking: " do
+          type_checker.check
+        rescue ex
+          ex_handler errors, ex
+        end
+
+        if flags.json
+          File.write(flags.output, errors)
+        end
+
+        if errors.size > 0
+          exit 1
+        end
+      end
+
+      def ex_handler(errors, ex)
+        if ex.message.is_a?(String)
+          errors << ex.message.as(String).to_json
+        end
+
+        puts ex
+      end
+    end
+  end
+end

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -61,7 +61,7 @@ module Mint
         if flags.json
           puts errors.compact_map(&.message.presence).to_json
         else
-          puts errors
+          errors.each { |error| puts error }
         end
 
         exit(errors.empty? ? 0 : 1)

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -32,13 +32,13 @@ module Mint
         end
 
         sources.reduce(ast) do |memo, file|
-          parsed = Parser.parse(file)
-
-          if memo
-            memo.merge parsed
+          begin
+            parsed = Parser.parse(file)
+            memo.merge(parsed)
+          rescue ex
+            errors << ex
           end
-        rescue ex
-          errors << ex
+          memo
         end
 
         if errors.empty?

--- a/src/commands/lint.cr
+++ b/src/commands/lint.cr
@@ -45,16 +45,12 @@ module Mint
           type_checker =
             TypeChecker.new(ast)
 
-          done = false
-
-          while !done
-            begin
-              type_checker.check
-            rescue ex
-              errors << ex
-            else
-              done = true
-            end
+          loop do
+            type_checker.check
+          rescue ex
+            errors << ex
+          else
+            break
           end
         end
 


### PR DESCRIPTION
As I said before, I have no experience with Crystal, so this could all be completely useless. If anything, it's a start for someone else to pick up and finish off.

This PR addresses #405.

# What

Following `compile.cr` as an example, and considering the points raised in #405, I've made an implementation of a new command for Mint: `mint lint`.

# How

- boolean flag `--json`, writes the output as an array to the STDOUT
- any error in `mint.json` **is** logged, but **isn't** captured within the JSON output
- parses all files and outputs any error it finds
- outputs only the first type-error it finds
- `exit 1` if there are any errors

## Notes

It would be really useful if all type-errors could be outputted instead of only the first one, again, no idea if this is doable.

Any parse errors cause a type-error (in my test project at least) which is misleading:

<img width="585" alt="Screenshot 2021-04-24 at 20 37 22" src="https://user-images.githubusercontent.com/59598622/115970822-e5fb3b00-a53c-11eb-8a92-676c72cb3c50.png">

Not the end of the world, but worth noting.