### PR TITLE
Fix typo in Array.mint

### DIFF
--- a/core/source/Array.mint
+++ b/core/source/Array.mint
@@ -645,7 +645,7 @@ module Array {
   /*
   Returns the index of the given item in the given array.
 
-    Arrray.indexOf("a", ["a","b","c"]) == 1
+    Array.indexOf("a", ["a","b","c"]) == 1
   */
   fun indexOf (item : a, array : Array(a)) : Number {
     `


### PR DESCRIPTION
Noticed this while reading the docs at https://www.mint-lang.com/api/modules/Array. I assume [`docs.json`](https://github.com/mint-lang/mint-website-rails/blob/master/app/assets/docs.json) is generated from the source code.