### PR TITLE
Allow index argument in for expressions.

### DIFF
--- a/spec/compilers/for_with_index
+++ b/spec/compilers/for_with_index
@@ -1,6 +1,6 @@
 component Main {
   fun render : Array(Html) {
-    for (item of ["A", "B"]) {
+    for (item, index of ["A", "B"]) {
       <div>
         <{ item }>
       </div>
@@ -16,6 +16,8 @@ class A extends _C {
       let _i = 0;
 
       for (let a of _1) {
+        const b = _i;
+
         _0.push(_h("div", {}, [
           a
         ]));

--- a/spec/type_checking/for
+++ b/spec/type_checking/for
@@ -7,6 +7,36 @@ component Main {
     }
   }
 }
+--------------------------------------------------------------------------------
+component Main {
+  fun render : Array(Html) {
+    for (item, index of ["A", "B"]) {
+      <div>
+        <{ item }>
+      </div>
+    }
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun render : Array(Html) {
+    for (key, value of `` as Map(String, String)) {
+      <div>
+        <{ key }>
+      </div>
+    }
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun render : Array(Html) {
+    for (key, value, index of `` as Map(String, String)) {
+      <div>
+        <{ key }>
+      </div>
+    }
+  }
+}
 -----------------------------------------------------------------ForTypeMismatch
 component Main {
   fun render : Array(Html) {
@@ -17,11 +47,10 @@ component Main {
     }
   }
 }
-
 --------------------------------------------------ForArrayOrSetArgumentsMismatch
 component Main {
   fun render : Array(Html) {
-    for (item, item2 of ["A", "B"]) {
+    for (item, item2, item3 of ["A", "B"]) {
       <div>
         <{ item }>
       </div>

--- a/src/compilers/for_expression.cr
+++ b/src/compilers/for_expression.cr
@@ -1,17 +1,33 @@
 module Mint
   class Compiler
     def _compile(node : Ast::For) : String
+      subject_type =
+        cache[node.subject]
+
       body =
         compile node.body
 
       subject =
         compile node.subject
 
-      arguments =
-        if node.arguments.size == 1
-          js.variable_of(node.arguments[0])
+      arguments, index_arg =
+        if (subject_type.name == "Array" && node.arguments.size == 1) ||
+           (subject_type.name == "Set" && node.arguments.size == 1) ||
+           (subject_type.name == "Map" && node.arguments.size == 2)
+          if node.arguments.size == 1
+            {js.variable_of(node.arguments[0]), nil}
+          else
+            {js.array(node.arguments.map { |arg| js.variable_of(arg) }), nil}
+          end
         else
-          js.array(node.arguments.map { |arg| js.variable_of(arg) })
+          if node.arguments.size == 2
+            {js.variable_of(node.arguments[0]), node.arguments[1]}
+          else
+            {
+              js.array(node.arguments[0..1].map { |arg| js.variable_of(arg) }),
+              node.arguments[2],
+            }
+          end
         end
 
       condition =
@@ -22,18 +38,24 @@ module Mint
           JS
         end
 
+      index =
+        if index_arg
+          "const #{js.variable_of(index_arg.not_nil!)} = _i"
+        end
+
       contents =
         if condition
-          js.statements([condition, "_0.push(#{body})"])
+          [condition, index, "_0.push(#{body})", "_i++"]
         else
-          "_0.push(#{body})"
+          [index, "_0.push(#{body})", "_i++"]
         end
 
       js.iif do
         js.statements([
           "const _0 = []",
           "const _1 = #{subject}",
-          js.for("let #{arguments} of _1", contents),
+          "let _i = 0",
+          js.for("let #{arguments} of _1", js.statements(contents.compact)),
           js.return("_0"),
         ])
       end

--- a/src/compilers/for_expression.cr
+++ b/src/compilers/for_expression.cr
@@ -40,7 +40,7 @@ module Mint
 
       index =
         if index_arg
-          "const #{js.variable_of(index_arg.not_nil!)} = _i"
+          "const #{js.variable_of(index_arg)} = _i"
         end
 
       contents =

--- a/src/type_checkers/for_expression.cr
+++ b/src/type_checkers/for_expression.cr
@@ -25,18 +25,22 @@ module Mint
 
       raise ForMapArgumentsMismatch, {
         "node" => node,
-      } if is_map && node.arguments.size != 2
+      } if is_map && ![2, 3].includes?(node.arguments.size)
 
       raise ForArrayOrSetArgumentsMismatch, {
         "node" => node,
-      } if is_array_or_set && node.arguments.size != 1
+      } if is_array_or_set && ![1, 2].includes?(node.arguments.size)
 
       arguments =
         node
           .arguments
           .each_with_index
           .reduce([] of Tuple(String, Checkable, Ast::Node)) do |memo, (argument, index)|
-            memo << {argument.value, subject.parameters[index], argument}
+            memo << if (is_map && index == 2) || (is_array_or_set && index == 1)
+              {argument.value, NUMBER, argument}
+            else
+              {argument.value, subject.parameters[index], argument}
+            end
           end
 
       type = scope(arguments) do

--- a/src/type_checkers/for_expression.cr
+++ b/src/type_checkers/for_expression.cr
@@ -25,11 +25,11 @@ module Mint
 
       raise ForMapArgumentsMismatch, {
         "node" => node,
-      } if is_map && ![2, 3].includes?(node.arguments.size)
+      } if is_map && !node.arguments.size.in?(2, 3)
 
       raise ForArrayOrSetArgumentsMismatch, {
         "node" => node,
-      } if is_array_or_set && ![1, 2].includes?(node.arguments.size)
+      } if is_array_or_set && !node.arguments.size.in?(1, 2)
 
       arguments =
         node


### PR DESCRIPTION
This PR implements the `index` as the last argument for `for` expressions:

it's the second argument for `Set(a)` and `Array(a)`:

```
for (item, index of ["Item1", "Item2"]) {
  index
}
```

and the third argument for `Map(key, value)`:

```
for (key, value, index of Map.empty()) {
  key
} 
```

Resolves #418 