### PR TITLE
Replace time_format shard with TimeFormat module

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -44,10 +44,6 @@ shards:
     git: https://github.com/mosop/string_inflection.git
     version: 0.2.1
 
-  time_format:
-    git: https://github.com/vladfaust/time_format.cr.git
-    version: 0.1.1
-
   tree_template:
     git: https://github.com/gdotdesign/tree_template.git
     version: 0.1.0+git.commit.7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3

--- a/shard.yml
+++ b/shard.yml
@@ -20,9 +20,6 @@ dependencies:
   tree_template:
     github: gdotdesign/tree_template
     commit: 7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3
-  time_format:
-    github: vladfaust/time_format.cr
-    version: ~> 0.1.1
   dotenv:
     github: gdotdesign/cr-dotenv
     version: ~> 1.0.0

--- a/src/all.cr
+++ b/src/all.cr
@@ -1,7 +1,6 @@
 require "string_inflection"
 require "baked_file_system"
 require "tree_template"
-require "time_format"
 require "file_utils"
 require "colorize"
 require "markd"

--- a/src/utils/time_format.cr
+++ b/src/utils/time_format.cr
@@ -1,0 +1,32 @@
+module Mint
+  module TimeFormat
+    SECONDS_IN_MINUTE      =        60
+    MILLISECONDS_IN_SECOND =     1_000
+    MICROSECONDS_IN_SECOND = 1_000_000
+
+    def self.auto(time : Time::Span) : String
+      time_f = time.to_f
+
+      return minutes(time_f) if time_f / SECONDS_IN_MINUTE >= 1
+      return seconds(time_f) if time_f >= 1
+      return milliseconds(time_f) if time_f * MILLISECONDS_IN_SECOND >= 1
+      microseconds(time_f)
+    end
+
+    private def self.minutes(time_f : Float) : String
+      "#{(time_f / SECONDS_IN_MINUTE).round(2)}m"
+    end
+
+    private def self.seconds(time_f : Float) : String
+      "#{time_f.round(3)}s"
+    end
+
+    private def self.milliseconds(time_f : Float) : String
+      "#{(time_f * MILLISECONDS_IN_SECOND).round(3)}ms"
+    end
+
+    private def self.microseconds(time_f : Float) : String
+      "#{(time_f * MICROSECONDS_IN_SECOND).to_i}μs"
+    end
+  end
+end


### PR DESCRIPTION
[time_format](https://github.com/vladfaust/time_format.cr) is archived and does not support Crystal 1.0.0. While the shard is very small, Mint does not even use it all. I created a `Mint::TimeFormat` module that keeps the same API used in the project but contains only the code that Mint uses.