### PR TITLE
Replace tree_template with ECR

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -36,7 +36,3 @@ shards:
     git: https://github.com/luislavena/radix.git
     version: 0.4.1
 
-  tree_template:
-    git: https://github.com/gdotdesign/tree_template.git
-    version: 0.1.0+git.commit.7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3
-

--- a/shard.yml
+++ b/shard.yml
@@ -14,9 +14,6 @@ dependencies:
   admiral:
     github: jwaldrip/admiral.cr
     version: ~> 1.11.2
-  tree_template:
-    github: gdotdesign/tree_template
-    commit: 7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3
   dotenv:
     github: gdotdesign/cr-dotenv
     version: ~> 1.0.0

--- a/src/all.cr
+++ b/src/all.cr
@@ -1,5 +1,5 @@
 require "baked_file_system"
-require "tree_template"
+require "ecr"
 require "file_utils"
 require "colorize"
 require "markd"

--- a/src/sandbox_server.cr
+++ b/src/sandbox_server.cr
@@ -93,24 +93,20 @@ module Mint
           build:      false,
         })
 
-      template =
-        TreeTemplate.new(formatter: TreeTemplate::PrettyFormatter) do |t|
-          t.doctype :html5
+      <<-HTML
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+        </head>
+        <body>
+          <script>
+            #{runtime + script}
+          </script>
+        </body>
+      </html>
+      HTML
 
-          t.html do
-            t.head do
-              t.meta(charset: "utf-8")
-            end
-
-            t.body do
-              t.script do
-                t.unsafe runtime + script
-              end
-            end
-          end
-        end
-
-      template.render
     rescue error : Error
       error.to_html
     rescue error

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -1,5 +1,3 @@
-require "ecr"
-
 module Mint
   class TestRunner
     class Message

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -19,92 +19,10 @@ module Mint
       end
     end
 
-    def to_s(io : IO)
-      application = json.application
-
-      template = TreeTemplate.new(formatter: TreeTemplate::PrettyFormatter) do |t|
-        t.doctype :html5
-
-        t.html do
-          t.head do
-            t.meta(charset: application.meta["charset"]? || "utf-8")
-
-            t.title application.title.to_s
-
-            t.link(rel: "manifest", href: path_for("manifest.webmanifest"))
-
-            application.meta.each do |name, content|
-              next if name == "charset"
-              t.meta(name: name, content: content)
-            end
-
-            t.meta(name: "theme-color", content: application.theme)
-
-            # Insert the extra head content
-            t.unsafe application.head
-
-            unless @no_icons || application.icon.empty?
-              ICON_SIZES.each do |size|
-                t.link(
-                  rel: "icon",
-                  type: "image/png",
-                  href: path_for("icon-#{size}x#{size}.png"),
-                  sizes: "#{size}x#{size}"
-                )
-              end
-
-              {152, 167, 180}.each do |size|
-                t.link(
-                  rel: "apple-touch-icon-precomposed",
-                  href: path_for("icon-#{size}x#{size}.png")
-                )
-              end
-            end
-
-            if SourceFiles.external_stylesheets?
-              t.link(
-                rel: "stylesheet",
-                href: path_for("external-stylesheets.css")
-              )
-            end
-          end
-
-          t.body do
-            # In development runtime comes separately and
-            # the live reload script necessary.
-            if env.development?
-              t.script(src: path_for("runtime.js")) { }
-
-              if @live_reload
-                t.script(src: path_for("live-reload.js")) { }
-              end
-            else
-              unless @no_service_worker
-                t.script(type: "text/javascript") do
-                  t.unsafe <<-JS
-                    if ('serviceWorker' in navigator) {
-                      window.addEventListener('load', function() {
-                        navigator.serviceWorker.register('/service-worker.js')
-                      })
-                    }
-                    JS
-                end
-              end
-            end
-
-            if SourceFiles.external_javascripts?
-              t.script(src: path_for("external-javascripts.js")) { }
-            end
-
-            t.script(src: path_for("index.js")) { }
-
-            t.noscript do
-              t.text "This application requires JavaScript."
-            end
-          end
-        end
-      end
-      io << template.render
+    private def application
+      json.application
     end
+
+    ECR.def_to_s "#{__DIR__}/index.html.ecr"
   end
 end

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -23,6 +23,6 @@ module Mint
       json.application
     end
 
-    ECR.def_to_s "#{__DIR__}/index.html.ecr"
+    ECR.def_to_s "#{__DIR__}/index_html.ecr"
   end
 end

--- a/src/utils/index_html.ecr
+++ b/src/utils/index_html.ecr
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="<%= application.meta["charset"]? || "utf-8" %>" />
+    <title>TEST: <%= application.title %></title>
+    <link rel="manifest" href="<%= path_for("manifest.webmanifest") %>" />
+    <% application.meta.each do |name, content| %>
+      <% next if name == "charset" %>
+      <meta name="<%= name %>" content="<%= content %>" /> 
+    <% end %>
+    <meta name="theme-color" content="<%= application.theme %>" /> 
+    <%= application.head %>
+
+    <% unless @no_icons || application.icon.empty? %>
+      <% ICON_SIZES.each do |size| %>
+        <link rel="icon" type="image/png" href="<%= path_for("icon-#{size}x#{size}.png") %>" size="<%= "#{size}x#{size}" %>" />
+      <% end %>
+      <% {152, 167, 180}.each do |size| %>
+        <link rel="apple-touch-icon-precomposed" href="<%= path_for("icon-#{size}x#{size}.png") %>" />
+      <% end %>
+    <% end %>
+
+    <% if SourceFiles.external_stylesheets? %>
+      <link rel="stylesheet" href="<%= path_for("external-stylesheets.css") %>" />
+    <% end %>
+  </head>
+  <body>
+    <%# In development runtime comes separately and %>
+    <%# the live reload script necessary. %>
+    <% if env.development? %>
+      <script src="<%= path_for("runtime.js") %>"></script>
+      <% if @live_reload %>
+        <script src="<%= path_for("live-reload.js") %>"></script>
+      <% end %>
+    <% else %>
+      <% unless @no_service_worker %>
+        <script type="text/javascript">
+          if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+              navigator.serviceWorker.register('/service-worker.js');
+            });
+          }
+        </script>
+      <% end %>
+    <% end %>
+
+    <% if SourceFiles.external_javascripts? %>
+      <script src="<%= path_for("external-javascripts.js") %>"></script>
+    <% end %>
+
+    <script src="<%= path_for("index.js") %>"></script>
+    <noscript>This application requires JavaScript.</noscript>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #422 

`TreeTemplate` usage in `src/sandbox_server.cr` seemed to be simple enough to warrant replacing with a heredoc instead of an ECR template.