### PR TITLE
Remove unused string_inflection shard

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -40,10 +40,6 @@ shards:
     git: https://github.com/luislavena/radix.git
     version: 0.4.1
 
-  string_inflection:
-    git: https://github.com/mosop/string_inflection.git
-    version: 0.2.1
-
   tree_template:
     git: https://github.com/gdotdesign/tree_template.git
     version: 0.1.0+git.commit.7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3

--- a/shard.yml
+++ b/shard.yml
@@ -5,9 +5,6 @@ authors:
   - Szikszai Gusztáv
 
 dependencies:
-  string_inflection:
-    github: mosop/string_inflection
-    version: ~> 0.2.1
   baked_file_system:
     github: schovi/baked_file_system
     version: ~> 0.10.0

--- a/src/all.cr
+++ b/src/all.cr
@@ -1,4 +1,3 @@
-require "string_inflection"
 require "baked_file_system"
 require "tree_template"
 require "file_utils"


### PR DESCRIPTION
[string_inflection](https://github.com/mosop/string_inflection) is another dependency that has not been updated to support Crystal 1.0.0.

Conveniently, Mint doesn't actually use it. From what I can find, the dependency hasn't been used since [the very beginning](https://github.com/mint-lang/mint/commit/f53e8f71254075b3efbc4701e6b567ed0dd81c26#diff-cbaa8062ee0fcfb5af8adfd98f69af4766b9ad5bb5e79158abe8da34f6fd7de0R8-R9).