### PR TITLE
Update enum destructuring to look like creating enums

### DIFF
--- a/core/source/Array.mint
+++ b/core/source/Array.mint
@@ -491,7 +491,7 @@ module Array {
       [],
       (memo : Array(a), item : Maybe(a)) : Array(a) {
         case (item) {
-          Maybe::Just value => Array.push(value, memo)
+          Maybe::Just(value) => Array.push(value, memo)
           Maybe::Nothing => memo
         }
       },

--- a/core/source/Dom.mint
+++ b/core/source/Dom.mint
@@ -154,7 +154,7 @@ module Dom {
   */
   fun focus (maybeElement : Maybe(Dom.Element)) : Promise(Never, Void) {
     case (maybeElement) {
-      Maybe::Just element =>
+      Maybe::Just(element) =>
         sequence {
           focusWhenVisible(element)
 
@@ -212,7 +212,7 @@ module Dom {
   Returns if the given base element contains the given element (as a maybe).
 
     case (Dom.getElementBySelector("body")) {
-      Maybe::Just body =>
+      Maybe::Just(body) =>
         try {
           div =
             Dom.getElementBySelector("div")
@@ -260,7 +260,7 @@ module Dom {
       	Dom.getElementById("my-div")
 
       case (outcome) {
-        Maybe::Just element => Dom.getAttribute("id", element) == "my-div"
+        Maybe::Just(element) => Dom.getAttribute("id", element) == "my-div"
         Maybe::Nothing => false
       }
     }

--- a/core/source/Maybe.mint
+++ b/core/source/Maybe.mint
@@ -48,7 +48,7 @@ module Maybe {
   */
   fun map (func : Function(a, b), maybe : Maybe(a)) : Maybe(b) {
     case (maybe) {
-      Maybe::Just value => Maybe::Just(func(value))
+      Maybe::Just(value) => Maybe::Just(func(value))
       Maybe::Nothing => Maybe::Nothing
     }
   }
@@ -62,7 +62,7 @@ module Maybe {
   fun withDefault (defaultValue : a, maybe : Maybe(a)) : a {
     case (maybe) {
       Maybe::Nothing => defaultValue
-      Maybe::Just value => value
+      Maybe::Just(value) => value
     }
   }
 
@@ -74,7 +74,7 @@ module Maybe {
   */
   fun toResult (error : b, maybe : Maybe(a)) : Result(b, a) {
     case (maybe) {
-      Maybe::Just value => Result::Ok(value)
+      Maybe::Just(value) => Result::Ok(value)
       Maybe::Nothing => Result::Err(error)
     }
   }
@@ -89,7 +89,7 @@ module Maybe {
   fun flatten (maybe : Maybe(Maybe(a))) : Maybe(a) {
     case (maybe) {
       Maybe::Nothing => Maybe::Nothing
-      Maybe::Just value => value
+      Maybe::Just(value) => value
     }
   }
 
@@ -120,7 +120,7 @@ module Maybe {
   */
   fun andThen (transform : Function(a, Maybe(b)), maybe : Maybe(a)) : Maybe(b) {
     case (maybe) {
-      Maybe::Just value => transform(value)
+      Maybe::Just(value) => transform(value)
       Maybe::Nothing => Maybe::Nothing
     }
   }

--- a/core/source/Provider/ElementSize.mint
+++ b/core/source/Provider/ElementSize.mint
@@ -34,7 +34,7 @@ provider Provider.ElementSize : Provider.ElementSize.Subscription {
 
       for (subscription of subscriptions) {
         case (subscription.element) {
-          Maybe::Just element =>
+          Maybe::Just(element) =>
             try {
               ResizeObserver.observe(element, observer)
               void

--- a/core/source/Provider/Intersection.mint
+++ b/core/source/Provider/Intersection.mint
@@ -29,7 +29,7 @@ provider Provider.Intersection : Provider.Intersection.Subscription {
             } else {
               try {
                 case (subscription.element) {
-                  Maybe::Just observed =>
+                  Maybe::Just(observed) =>
                     try {
                       IntersectionObserver.unobserve(observed, observer)
                       Maybe::Nothing
@@ -47,7 +47,7 @@ provider Provider.Intersection : Provider.Intersection.Subscription {
       newObservers =
         for (subscription of subscriptions) {
           case (subscription.element) {
-            Maybe::Just observed =>
+            Maybe::Just(observed) =>
               Maybe::Just(
                 {
                   subscription,

--- a/core/source/Provider/Mutation.mint
+++ b/core/source/Provider/Mutation.mint
@@ -20,7 +20,7 @@ provider Provider.Mutation : Provider.Mutation.Subscription {
     for (entry of entries) {
       for (subscription of subscriptions) {
         case (subscription.element) {
-          Maybe::Just element =>
+          Maybe::Just(element) =>
             if (Dom.contains(entry.target, element)) {
               subscription.changes()
             } else {
@@ -44,7 +44,7 @@ provider Provider.Mutation : Provider.Mutation.Subscription {
       /* For each subscription observe the given elements. */
       for (subscription of subscriptions) {
         case (subscription.element) {
-          Maybe::Just element =>
+          Maybe::Just(element) =>
             try {
               MutationObserver.observe(element, true, true, observer)
               subscription.changes()

--- a/core/source/Result.mint
+++ b/core/source/Result.mint
@@ -36,7 +36,7 @@ module Result {
   */
   fun withDefault (defaultValue : b, input : Result(a, b)) : b {
     case (input) {
-      Result::Ok value => value
+      Result::Ok(value) => value
       Result::Err => defaultValue
     }
   }
@@ -52,7 +52,7 @@ module Result {
   */
   fun withError (defaultError : a, input : Result(a, b)) : a {
     case (input) {
-      Result::Err value => value
+      Result::Err(value) => value
       Result::Ok => defaultError
     }
   }
@@ -68,7 +68,7 @@ module Result {
   */
   fun map (func : Function(b, c), input : Result(a, b)) : Result(a, c) {
     case (input) {
-      Result::Ok value => Result::Ok(func(value))
+      Result::Ok(value) => Result::Ok(func(value))
       Result::Err => input
     }
   }
@@ -84,7 +84,7 @@ module Result {
   */
   fun mapError (func : Function(a, c), input : Result(a, b)) : Result(c, b) {
     case (input) {
-      Result::Err value => Result::Err(func(value))
+      Result::Err(value) => Result::Err(func(value))
       Result::Ok => input
     }
   }
@@ -126,15 +126,15 @@ module Result {
   */
   fun toMaybe (result : Result(a, b)) : Maybe(b) {
     case (result) {
-      Result::Ok value => Maybe::Just(value)
+      Result::Ok(value) => Maybe::Just(value)
       Result::Err => Maybe::Nothing
     }
   }
 
   fun join (input : Result(error, Result(error, value))) : Result(error, value) {
     case (input) {
-      Result::Err error => Result::Err(error)
-      Result::Ok value => value
+      Result::Err(error) => Result::Err(error)
+      Result::Ok(value) => value
     }
   }
 

--- a/core/source/Validation.mint
+++ b/core/source/Validation.mint
@@ -182,7 +182,7 @@ module Validation {
         item : Maybe(Tuple(String, String))
       ) : Map(String, Array(String)) {
         case (item) {
-          Maybe::Just error =>
+          Maybe::Just(error) =>
             try {
               {key, message} =
                 error

--- a/spec/compilers/case_with_enum_destructuring
+++ b/spec/compilers/case_with_enum_destructuring
@@ -11,9 +11,9 @@ component Main {
   fun test (b : C(a)) : a {
     case (b) {
       C::X => ""
-      C::D a =>
+      C::D(a) =>
         case (a) {
-          A::B c =>
+          A::B(c) =>
             c
         }
     }

--- a/spec/compilers/enum_record
+++ b/spec/compilers/enum_record
@@ -6,7 +6,7 @@ enum A {
 component Main {
   fun render : String {
     case (A::B(name = "Joe", color = "Blue")) {
-      A::B name color => ""
+      A::B(name, color) => ""
       A::C => ""
     }
   }

--- a/spec/formatters/enum_record
+++ b/spec/formatters/enum_record
@@ -6,7 +6,7 @@ enum A {
 component Main {
   fun render : String {
     case (A::B(name = "Joe", color = "Blue")) {
-      A::B name color => ""
+      A::B(name, color) => ""
       A::C => ""
     }
   }
@@ -20,7 +20,7 @@ enum A {
 component Main {
   fun render : String {
     case (A::B(name = "Joe", color = "Blue")) {
-      A::B name color => ""
+      A::B(name, color) => ""
       A::C => ""
     }
   }

--- a/spec/type_checking/access_call
+++ b/spec/type_checking/access_call
@@ -38,7 +38,7 @@ component Test {
 component Main {
   fun handleClick : String {
     case (test) {
-      Maybe::Just component => component.something("asd")
+      Maybe::Just(component) => component.something("asd")
       Maybe::Nothing => "asd"
     }
   }
@@ -68,7 +68,7 @@ component Test {
 component Main {
   fun handleClick : String {
     case (test) {
-      Maybe::Just component => handleComponent(component)
+      Maybe::Just(component) => handleComponent(component)
       Maybe::Nothing => "asd"
     }
   }

--- a/spec/type_checking/enum_record
+++ b/spec/type_checking/enum_record
@@ -6,7 +6,7 @@ enum A {
 component Main {
   fun render : String {
     case (A::B(name = "Joe", color = "Blue")) {
-      A::B name color => ""
+      A::B(name, color) => ""
       A::C => ""
     }
   }

--- a/src/formatters/enum_destructuring.cr
+++ b/src/formatters/enum_destructuring.cr
@@ -2,12 +2,12 @@ module Mint
   class Formatter
     def format(node : Ast::EnumDestructuring)
       parameters =
-        format node.parameters, " "
+        format node.parameters, ", "
 
       if parameters.empty?
         "#{node.name}::#{node.option}"
       else
-        "#{node.name}::#{node.option} #{parameters}"
+        "#{node.name}::#{node.option}(#{parameters})"
       end
     end
   end

--- a/src/messages/enum_destructuring_expected_closing_parentheses.cr
+++ b/src/messages/enum_destructuring_expected_closing_parentheses.cr
@@ -1,0 +1,16 @@
+message EnumDestructuringExpectedClosingParentheses do
+  title "Syntax Error"
+
+  block do
+    text "I was looking for the"
+    bold "closing parenthesis"
+    code ")"
+    text "of the destructuring of an"
+    bold "enum"
+    text "but found"
+    code got
+    text "instead."
+  end
+
+  snippet node
+end

--- a/src/parsers/enum_destructuring.cr
+++ b/src/parsers/enum_destructuring.cr
@@ -2,6 +2,7 @@ module Mint
   class Parser
     syntax_error EnumDestructuringExpectedDoubleColon
     syntax_error EnumDestructuringExpectedOption
+    syntax_error EnumDestructuringExpectedClosingParentheses
 
     def enum_destructuring
       start do |start_position|
@@ -11,7 +12,17 @@ module Mint
 
         option = type_id! EnumDestructuringExpectedOption
 
-        parameters = many { type_variable }.compact
+        parameters = [] of Ast::TypeVariable
+
+        if char! '('
+          parameters.concat list(
+            terminator: ')',
+            separator: ','
+          ) { type_variable }.compact
+
+          whitespace
+          char ')', EnumDestructuringExpectedClosingParentheses
+        end
 
         self << Ast::EnumDestructuring.new(
           parameters: parameters,


### PR DESCRIPTION
Related to https://github.com/mint-lang/mint/issues/226

In order to support nested destructuring of Enum's, Mint will have to be able to distinguish nesting. Tuple's and Array's are fine since they are comma delimited, but Enums are not. This will be a breaking change, but updating the destructuring syntax to look like how you create them allows for someone to implement the next step.

## Before

```mint
enum UserState {
  LoggedIn(User, Config)
  Visitor
}

fun isLoggedIn (userState : UserState) : Bool {
  case (userState) {
    UserState::LoggedIn user config => true /* space delimited */
    UserState::Visitor => false
  }
}
```

## After

```mint
enum UserState {
  LoggedIn(User, Config)
  Visitor
}

fun isLoggedIn (userState : UserState) : Bool {
  case (userState) {
    UserState::LoggedIn(user, config) => true /* Wrapped in parens, comma delimited */
    UserState::Visitor => false
  }
}
```