### PR TITLE
Abstract away differences between standards and quirks modes

### DIFF
--- a/core/source/Window.mint
+++ b/core/source/Window.mint
@@ -41,22 +41,66 @@ module Window {
 
   /* Returns the scrollable height of the window in pixels. */
   fun scrollHeight : Number {
-    `document.body.scrollHeight`
+    `
+    (() => {
+      const body = document.body
+      const html = document.documentElement
+
+      return Math.max(
+        body.scrollHeight, html.scrollHeight,
+        body.offsetHeight, html.offsetHeight,
+        body.clientHeight, html.clientHeight
+      )
+    })()
+    `
   }
 
   /* Returns the scrollable width of the window in pixels. */
   fun scrollWidth : Number {
-    `document.body.scrollWidth`
+    `
+    (() => {
+      const body = document.body
+      const html = document.documentElement
+
+      return Math.max(
+        body.scrollWidth, html.scrollWidth,
+        body.offsetWidth, html.offsetWidth,
+        body.clientWidth, html.clientWidth
+      )
+    })()
+    `
   }
 
   /* Returns the horizontal scroll position of the window in pixels. */
   fun scrollLeft : Number {
-    `document.body.scrollLeft`
+    `
+    (() => {
+      const body = document.body
+      const html = document.documentElement
+
+      return Math.max(
+        body.scrollLeft, html.scrollLeft,
+        body.offsetLeft, html.offsetLeft,
+        body.clientLeft, html.clientLeft
+      )
+    })()
+    `
   }
 
   /* Returns the vertical scroll position of the window in pixels. */
   fun scrollTop : Number {
-    `document.body.scrollTop`
+    `
+    (() => {
+      const body = document.body
+      const html = document.documentElement
+
+      return Math.max(
+        body.scrollTop, html.scrollTop,
+        body.offsetTop, html.offsetTop,
+        body.clientTop, html.clientTop
+      )
+    })()
+    `
   }
 
   /* Sets the horizontal scroll position of the window in pixels. */

--- a/core/source/Window.mint
+++ b/core/source/Window.mint
@@ -73,34 +73,12 @@ module Window {
 
   /* Returns the horizontal scroll position of the window in pixels. */
   fun scrollLeft : Number {
-    `
-    (() => {
-      const body = document.body
-      const html = document.documentElement
-
-      return Math.max(
-        body.scrollLeft, html.scrollLeft,
-        body.offsetLeft, html.offsetLeft,
-        body.clientLeft, html.clientLeft
-      )
-    })()
-    `
+    `window.pageXOffset`
   }
 
   /* Returns the vertical scroll position of the window in pixels. */
   fun scrollTop : Number {
-    `
-    (() => {
-      const body = document.body
-      const html = document.documentElement
-
-      return Math.max(
-        body.scrollTop, html.scrollTop,
-        body.offsetTop, html.offsetTop,
-        body.clientTop, html.clientTop
-      )
-    })()
-    `
+    `window.pageYOffset`
   }
 
   /* Sets the horizontal scroll position of the window in pixels. */

--- a/core/tests/tests/Window.mint
+++ b/core/tests/tests/Window.mint
@@ -96,7 +96,7 @@ suite "Window.height" {
 
 suite "Window.scrollWidth" {
   test "returns the scrollable width" {
-    Window.scrollWidth() == `document.body.scrollWidth`
+    Window.scrollWidth() == `(document.documentElement.scrollWidth || document.body.scrollWidth)`
   }
 
   test "returns the scrollable width when overflown" {
@@ -112,7 +112,7 @@ suite "Window.scrollWidth" {
 
 suite "Window.scrollHeight" {
   test "returns the scrollable height" {
-    Window.scrollHeight() == `document.body.scrollHeight`
+    Window.scrollHeight() == `(document.documentElement.scrollHeight || document.body.scrollHeight)`
   }
 
   test "returns the scrollable height when overflown" {
@@ -126,7 +126,7 @@ suite "Window.scrollHeight" {
 
 suite "Window.scrollLeft" {
   test "returns the left scroll position" {
-    Window.scrollLeft() == `document.body.scrollLeft`
+    Window.scrollLeft() == `(document.documentElement.scrollLeft || document.body.scrollLeft)`
   }
 
   test "returns the left scroll position when scrolled" {
@@ -143,7 +143,7 @@ suite "Window.scrollLeft" {
 
 suite "Window.scrollTop" {
   test "returns the left scroll position" {
-    Window.scrollTop() == `document.body.scrollTop`
+    Window.scrollTop() == `(document.documentElement.scrollTop || document.body.scrollTop)`
   }
 
   test "returns the left scroll position when scrolled" {

--- a/core/tests/tests/Window.mint
+++ b/core/tests/tests/Window.mint
@@ -126,7 +126,7 @@ suite "Window.scrollHeight" {
 
 suite "Window.scrollLeft" {
   test "returns the left scroll position" {
-    Window.scrollLeft() == `(document.documentElement.scrollLeft || document.body.scrollLeft)`
+    Window.scrollLeft() == `window.pageXOffset`
   }
 
   test "returns the left scroll position when scrolled" {
@@ -143,7 +143,7 @@ suite "Window.scrollLeft" {
 
 suite "Window.scrollTop" {
   test "returns the left scroll position" {
-    Window.scrollTop() == `(document.documentElement.scrollTop || document.body.scrollTop)`
+    Window.scrollTop() == `window.pageYOffset`
   }
 
   test "returns the left scroll position when scrolled" {

--- a/src/test_runner.ecr
+++ b/src/test_runner.ecr
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Nature of the issue is described in more detail within this SO thread: https://stackoverflow.com/questions/7435843/window-top-document-body-scrolltop-not-working-in-chrome-or-firefox

Affects `Window.scroll{Width,Height,Left,Top}` methods.