### PR TITLE
Refactorings working towards nested destructuring

### DIFF
--- a/src/ast/enum_destructuring.cr
+++ b/src/ast/enum_destructuring.cr
@@ -3,7 +3,7 @@ module Mint
     class EnumDestructuring < Node
       getter name, option, parameters
 
-      def initialize(@parameters : Array(TypeVariable),
+      def initialize(@parameters : Array(Node),
                      @option : String,
                      @name : String,
                      @input : Data,

--- a/src/ast/tuple_destructuring.cr
+++ b/src/ast/tuple_destructuring.cr
@@ -3,7 +3,7 @@ module Mint
     class TupleDestructuring < Node
       getter parameters
 
-      def initialize(@parameters : Array(Variable),
+      def initialize(@parameters : Array(Node),
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/compilers/case_branch.cr
+++ b/src/compilers/case_branch.cr
@@ -55,8 +55,11 @@ module Mint
           variables =
             case lookups[match].as(Ast::EnumOption).parameters[0]?
             when Ast::EnumRecordDefinition
-              match.parameters.map do |param|
-                "const #{js.variable_of(param)} = #{variable}._0.#{param.value}"
+              match.parameters.compact_map do |param|
+                case param
+                when Ast::TypeVariable
+                  "const #{js.variable_of(param)} = #{variable}._0.#{param.value}"
+                end
               end
             else
               match.parameters.map_with_index do |param, index1|

--- a/src/compilers/enum_destructuring.cr
+++ b/src/compilers/enum_destructuring.cr
@@ -1,0 +1,28 @@
+module Mint
+  class Compiler
+    def _compile(node : Ast::EnumDestructuring, variable : String) : Tuple(String, Array(String))
+      variables =
+        case lookups[node].as(Ast::EnumOption).parameters[0]?
+        when Ast::EnumRecordDefinition
+          node.parameters.compact_map do |param|
+            case param
+            when Ast::TypeVariable
+              "const #{js.variable_of(param)} = #{variable}._0.#{param.value}"
+            end
+          end
+        else
+          node.parameters.map_with_index do |param, index1|
+            "const #{js.variable_of(param)} = #{variable}._#{index1}"
+          end
+        end
+
+      name =
+        js.class_of(lookups[node])
+
+      {
+        "#{variable} instanceof #{name}",
+        variables,
+      }
+    end
+  end
+end

--- a/src/compilers/tuple_destructuring.cr
+++ b/src/compilers/tuple_destructuring.cr
@@ -1,0 +1,15 @@
+module Mint
+  class Compiler
+    def _compile(node : Ast::TupleDestructuring, variable : String) : Tuple(String, Array(String))
+      variables =
+        node
+          .parameters
+          .join(',') { |param| js.variable_of(param) }
+
+      {
+        "Array.isArray(#{variable})",
+        ["const [#{variables}] = #{variable}"],
+      }
+    end
+  end
+end

--- a/src/parsers/enum_destructuring.cr
+++ b/src/parsers/enum_destructuring.cr
@@ -12,7 +12,7 @@ module Mint
 
         option = type_id! EnumDestructuringExpectedOption
 
-        parameters = [] of Ast::TypeVariable
+        parameters = [] of Ast::Node
 
         if char! '('
           parameters.concat list(

--- a/src/parsers/tuple_destructuring.cr
+++ b/src/parsers/tuple_destructuring.cr
@@ -15,8 +15,9 @@ module Mint
 
         skip unless head
 
-        parameters = [head].concat(
-          list(terminator: '}', separator: ',') { variable })
+        parameters = [] of Ast::Node
+        parameters << head
+        parameters.concat(list(terminator: '}', separator: ',') { variable })
 
         whitespace
 

--- a/src/type_checkers/case_branch.cr
+++ b/src/type_checkers/case_branch.cr
@@ -111,8 +111,11 @@ module Mint
 
     private def destructuring_variables(item : Ast::TupleDestructuring, condition)
       item.parameters.map_with_index do |variable, index|
-        {variable.value, condition.parameters[index], variable}
-      end
+        case variable
+        when Ast::Variable
+          {variable.value, condition.parameters[index], variable}
+        end
+      end.compact
     end
 
     private def destructuring_variables(item : Ast::ArrayDestructuring, condition)

--- a/src/type_checkers/case_branch.cr
+++ b/src/type_checkers/case_branch.cr
@@ -45,17 +45,7 @@ module Mint
             "node"  => node,
           } if spreads > 1
 
-          variables =
-            item.items.compact_map do |variable|
-              case variable
-              when Ast::Variable
-                {variable.value, condition.parameters[0], variable}
-              when Ast::Spread
-                {variable.variable.value, condition, variable.variable}
-              end
-            end
-
-          scope(variables) do
+          scope(destructuring_variables(item, condition)) do
             resolve_expression(node)
           end
         when Ast::TupleDestructuring
@@ -70,57 +60,70 @@ module Mint
             "node" => item,
           } if item.parameters.size > condition.parameters.size
 
-          variables =
-            item.parameters.map_with_index do |variable, index|
-              {variable.value, condition.parameters[index], variable}
-            end
-
-          scope(variables) do
+          scope(destructuring_variables(item, condition)) do
             resolve_expression(node)
           end
         when Ast::EnumDestructuring
           check_match(item, condition)
 
-          entity =
-            ast.enums.find(&.name.==(item.name)).not_nil!
-
-          option =
-            entity.options.find(&.value.==(item.option)).not_nil!
-
-          variables =
-            case option_param = option.parameters[0]?
-            when Ast::EnumRecordDefinition
-              item.parameters.map do |param|
-                record =
-                  resolve(option_param).as(Record)
-
-                {param.value, record.fields[param.value], param}
-              end
-            else
-              item.parameters.map_with_index do |param, index|
-                option_type =
-                  resolve(option.parameters[index]).not_nil!
-
-                mapping = {} of String => Checkable
-
-                entity.parameters.each_with_index do |param2, index2|
-                  mapping[param2.value] = condition.parameters[index2]
-                end
-
-                resolved_type =
-                  Comparer.fill(option_type, mapping)
-
-                {param.value, resolved_type.not_nil!, param}
-              end
-            end
-
-          scope(variables) do
+          scope(destructuring_variables(item, condition)) do
             resolve_expression(node)
           end
         else
           check_match(item, condition)
         end
       end || resolve_expression(node)
+    end
+
+    private def destructuring_variables(item : Ast::EnumDestructuring, condition)
+      entity =
+        ast.enums.find(&.name.==(item.name)).not_nil!
+
+      option =
+        entity.options.find(&.value.==(item.option)).not_nil!
+
+      case option_param = option.parameters[0]?
+      when Ast::EnumRecordDefinition
+        item.parameters.map do |param|
+          record =
+            resolve(option_param).as(Record)
+
+          {param.value, record.fields[param.value], param}
+        end
+      else
+        item.parameters.map_with_index do |param, index|
+          option_type =
+            resolve(option.parameters[index]).not_nil!
+
+          mapping = {} of String => Checkable
+
+          entity.parameters.each_with_index do |param2, index2|
+            mapping[param2.value] = condition.parameters[index2]
+          end
+
+          resolved_type =
+            Comparer.fill(option_type, mapping)
+
+          {param.value, resolved_type.not_nil!, param}
+        end
+      end
+    end
+
+    private def destructuring_variables(item : Ast::TupleDestructuring, condition)
+      item.parameters.map_with_index do |variable, index|
+        {variable.value, condition.parameters[index], variable}
+      end
+    end
+
+    private def destructuring_variables(item : Ast::ArrayDestructuring, condition)
+      item.items.compact_map do |variable|
+        case variable
+        when Ast::Variable
+          {variable.value, condition.parameters[0], variable}
+        when Ast::Spread
+          {variable.variable.value, condition, variable.variable}
+        end
+      end
     end
   end
 end

--- a/src/type_checkers/scope.cr
+++ b/src/type_checkers/scope.cr
@@ -120,7 +120,7 @@ module Mint
         when Ast::Variable
           node if target.value == variable
         when Ast::TupleDestructuring
-          target.parameters.find(&.value.==(variable)).try do |item|
+          target.parameters.select(Ast::Variable).find(&.value.==(variable)).try do |item|
             {node, target.parameters.index(item).not_nil!}
           end
         end
@@ -131,7 +131,7 @@ module Mint
         when Ast::Variable
           node if target.value == variable
         when Ast::TupleDestructuring
-          target.parameters.find(&.value.==(variable)).try do |item|
+          target.parameters.select(Ast::Variable).find(&.value.==(variable)).try do |item|
             {node, target.parameters.index(item).not_nil!}
           end
         end


### PR DESCRIPTION
Related to #226 

I don't want to drop a 1000-2000 PR, and I already have some questions so might as well pull out as much refactoring code as makes sense at this point.

A lot of this was pulled from https://github.com/mint-lang/mint/pull/283 as I have been learning why it was written the way it was.

Hopefully these are good enough refactorings on their own aside from preparing for nested destructuring.

## Changes

- extracted methods for getting destructuring variable in `type_checkers/case_branch.cr` since it will be moved to recursion to get nested variables
- `Ast::EnumDestructuring`, `Ast::TupleDestructuring`, and `Ast::ArrayDestructuring` all have parameters as `[] of Ast::Node` since they will hold more than one type for destructuring
- Extracted `_compile` methods for the destructurings as they will also have a recursive aspect for destructurings

## Questions

- In `type_checkers/scope.cr` I'm not sure what that is doing and how that will support destructurings going forward. Is selecting only variables good enough? I'll have to dig into nested's once they're added I suppose?
- Type checking is not clear to my right now. Even with the current code I'm not sure how `type_checkers/case_branch.cr` does type checking. It kind of looks like `type_checkers/case.cr` is doing some Tuple counting. Is there a way we could refactor (if that is type checking) to a place where they could be called for nested destructurings?

## Current Struggles

This is my first time working in Mint's compilers so everything's kind of new. Apart from that, some things that have caused me a hard time:

- A lot / most methods don't have a return type specified so when I change a return type the expected type vs got type compile-time errors are pretty confusing. Seeing an expected type that is the union of 3 Tuples with 5 items in each is really difficult to parse visually.
- I've been doing some "puts debugging" with tests and using the specs that read in the files are pretty handy but you have to write the name of the file you want into the spec if you want to run just one. Would it be possible to change the process that reads in the files and creates the specs to do it with a macro so that I could pass a line number to run a specific spec?
- No docs on anything in the compilers so a lot of times I have no idea what the thing is that I'm working with. For example, what's the `condition` [here](https://github.com/mint-lang/mint/blob/d7055a1ad6950c2779160b58c935b35c12503b74/src/type_checkers/case_branch.cr#L31)? I've just been ignoring anything I don't understand