### PR TITLE
Remove compact calls after many and list calls

### DIFF
--- a/src/parser.cr
+++ b/src/parser.cr
@@ -209,7 +209,7 @@ module Mint
       result
     end
 
-    def list(terminator : Char?, separator : Char, &block : -> T) : Array(T) forall T
+    def list(terminator : Char?, separator : Char, &block : -> T?) : Array(T) forall T
       result = [] of T
 
       loop do

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -192,7 +192,7 @@ module Mint
     # Consuming many things
     # ----------------------------------------------------------------------------
 
-    def many(parse_whitespace : Bool = true, &block : -> T) : Array(T) forall T
+    def many(parse_whitespace : Bool = true, &block : -> T?) : Array(T) forall T
       result = [] of T
 
       loop do

--- a/src/parsers/array_destructuring.cr
+++ b/src/parsers/array_destructuring.cr
@@ -18,7 +18,7 @@ module Mint
         items =
           [head.as(Ast::Node)].concat(list(terminator: ']', separator: ',') do
             variable || spread
-          end.compact)
+          end)
 
         whitespace
 

--- a/src/parsers/array_literal.cr
+++ b/src/parsers/array_literal.cr
@@ -11,7 +11,7 @@ module Mint
         items = list(
           terminator: ']',
           separator: ','
-        ) { expression }.compact
+        ) { expression }
         whitespace
 
         char "]", ArrayExpectedClosingBracket

--- a/src/parsers/block.cr
+++ b/src/parsers/block.cr
@@ -3,13 +3,13 @@ module Mint
     def block_with_comments(opening_bracket : SyntaxError.class,
                             closing_bracket : SyntaxError.class)
       block(opening_bracket, closing_bracket) do
-        head_comments = many { comment }.compact
+        head_comments = many { comment }
         whitespace
 
         result = yield
         whitespace
 
-        tail_comments = many { comment }.compact
+        tail_comments = many { comment }
         {head_comments, result, tail_comments}
       end
     end

--- a/src/parsers/call.cr
+++ b/src/parsers/call.cr
@@ -14,7 +14,7 @@ module Mint
         arguments = list(
           terminator: ')',
           separator: ','
-        ) { expression.as(Ast::Expression?) }.compact
+        ) { expression.as(Ast::Expression?) }
         whitespace
 
         char ')', CallExpectedClosingParentheses

--- a/src/parsers/case.cr
+++ b/src/parsers/case.cr
@@ -25,7 +25,7 @@ module Mint
           opening_bracket: CaseExpectedOpeningBracket,
           closing_bracket: CaseExpectedClosingBracket
         ) do
-          items = many { case_branch(for_css) || comment }.compact
+          items = many { case_branch(for_css) || comment }
           raise CaseExpectedBranches if items.empty?
           items
         end

--- a/src/parsers/case_branch.cr
+++ b/src/parsers/case_branch.cr
@@ -20,7 +20,7 @@ module Mint
 
         expression =
           if for_css
-            many { css_definition }.compact
+            many { css_definition }
           else
             expression! CaseBranchExpectedExpression
           end

--- a/src/parsers/component.cr
+++ b/src/parsers/component.cr
@@ -34,7 +34,7 @@ module Mint
               use ||
               get ||
               self.comment
-          end.compact
+          end
 
           raise ComponentExpectedBody if items.empty?
 

--- a/src/parsers/connect.cr
+++ b/src/parsers/connect.cr
@@ -20,7 +20,7 @@ module Mint
           opening_bracket: ConnectExpectedOpeningBracket,
           closing_bracket: ConnectExpectedClosingBracket
         ) do
-          items = list(terminator: '{', separator: ',') { connect_variable }.compact
+          items = list(terminator: '{', separator: ',') { connect_variable }
           raise ConnectExpectedKeys if items.empty?
           items
         end

--- a/src/parsers/css_font_face.cr
+++ b/src/parsers/css_font_face.cr
@@ -10,7 +10,7 @@ module Mint
         definitions = block(
           opening_bracket: CssFontFaceExpectedOpeningBracket,
           closing_bracket: CssFontFaceExpectedClosingBracket) do
-          many { comment || css_definition }.compact
+          many { comment || css_definition }
         end
 
         Ast::CssFontFace.new(

--- a/src/parsers/css_keyframes.cr
+++ b/src/parsers/css_keyframes.cr
@@ -17,7 +17,7 @@ module Mint
         selectors = block(
           opening_bracket: CssKeyframesExpectedOpeningBracket,
           closing_bracket: CssKeyframesExpectedClosingBracket) do
-          many { comment || css_selector(true) }.compact
+          many { comment || css_selector(true) }
         end
 
         Ast::CssKeyframes.new(

--- a/src/parsers/css_selector.cr
+++ b/src/parsers/css_selector.cr
@@ -17,7 +17,7 @@ module Mint
           opening_bracket: CssSelectorExpectedOpeningBracket,
           closing_bracket: CssSelectorExpectedClosingBracket) do
           if only_definitions
-            many { comment || css_definition }.compact
+            many { comment || css_definition }
           else
             css_body
           end

--- a/src/parsers/enum.cr
+++ b/src/parsers/enum.cr
@@ -23,7 +23,7 @@ module Mint
           parameters.concat list(
             terminator: ')',
             separator: ','
-          ) { type_variable }.compact
+          ) { type_variable }
 
           whitespace
           char ')', EnumExpectedClosingParentheses

--- a/src/parsers/enum.cr
+++ b/src/parsers/enum.cr
@@ -33,7 +33,7 @@ module Mint
           opening_bracket: EnumExpectedOpeningBracket,
           closing_bracket: EnumExpectedClosingBracket
         ) do
-          many { enum_option || self.comment }.compact
+          many { enum_option || self.comment }
         end
 
         options = [] of Ast::EnumOption

--- a/src/parsers/enum_destructuring.cr
+++ b/src/parsers/enum_destructuring.cr
@@ -18,7 +18,7 @@ module Mint
           parameters.concat list(
             terminator: ')',
             separator: ','
-          ) { type_variable }.compact
+          ) { type_variable }
 
           whitespace
           char ')', EnumDestructuringExpectedClosingParentheses

--- a/src/parsers/enum_id.cr
+++ b/src/parsers/enum_id.cr
@@ -25,7 +25,7 @@ module Mint
             expressions.concat list(
               terminator: ')',
               separator: ','
-            ) { expression }.compact
+            ) { expression }
           end
 
           whitespace

--- a/src/parsers/enum_option.cr
+++ b/src/parsers/enum_option.cr
@@ -17,7 +17,7 @@ module Mint
           parameters.concat list(
             terminator: ')',
             separator: ','
-          ) { enum_record_definition || type_variable || type }.compact
+          ) { enum_record_definition || type_variable || type }
 
           whitespace
           char ')', EnumOptionExpectedClosingParentheses

--- a/src/parsers/enum_record.cr
+++ b/src/parsers/enum_record.cr
@@ -6,7 +6,7 @@ module Mint
           list(
             terminator: ')',
             separator: ','
-          ) { record_field }.compact
+          ) { record_field }
 
         skip if fields.empty?
 

--- a/src/parsers/enum_record_definition.cr
+++ b/src/parsers/enum_record_definition.cr
@@ -6,7 +6,7 @@ module Mint
           list(
             terminator: ')',
             separator: ','
-          ) { record_definition_field }.compact
+          ) { record_definition_field }
 
         skip if fields.empty?
 

--- a/src/parsers/for.cr
+++ b/src/parsers/for.cr
@@ -19,7 +19,7 @@ module Mint
         arguments = list(
           terminator: ')',
           separator: ','
-        ) { variable }.compact
+        ) { variable }
 
         whitespace
         keyword! "of", ForExpectedOf

--- a/src/parsers/function.cr
+++ b/src/parsers/function.cr
@@ -25,7 +25,7 @@ module Mint
           arguments.concat list(
             terminator: ')',
             separator: ','
-          ) { argument }.compact
+          ) { argument }
 
           whitespace
           char ')', FunctionExpectedClosingParentheses

--- a/src/parsers/html_body.cr
+++ b/src/parsers/html_body.cr
@@ -21,7 +21,7 @@ module Mint
                   tag : Ast::Variable,
                   with_dashes : Bool)
       whitespace
-      attributes = many { html_attribute(with_dashes) }.compact
+      attributes = many { html_attribute(with_dashes) }
       whitespace
 
       self_closing = char! '/'
@@ -33,7 +33,7 @@ module Mint
       unless self_closing
         items = many do
           html_content.as(Ast::Node | Ast::Comment?)
-        end.compact
+        end
 
         whitespace
 
@@ -59,7 +59,7 @@ module Mint
         end
       end
 
-      {attributes || [] of Ast::HtmlAttribute,
+      {attributes,
        children,
        comments}
     end

--- a/src/parsers/html_element.cr
+++ b/src/parsers/html_element.cr
@@ -18,9 +18,7 @@ module Mint
         styles = [] of Ast::HtmlStyle
 
         if keyword_ahead "::"
-          styles.concat(many(parse_whitespace: false) do
-            html_style
-          end.compact)
+          styles = many(parse_whitespace: false) { html_style }
 
           raise HtmlElementExpectedStyle if styles.empty?
         end

--- a/src/parsers/html_expression.cr
+++ b/src/parsers/html_expression.cr
@@ -7,7 +7,7 @@ module Mint
         skip unless keyword "<{"
 
         whitespace
-        expressions = many { expression }.compact
+        expressions = many { expression }
         whitespace
 
         keyword! "}>", HtmlExpressionExpectedClosingTag

--- a/src/parsers/html_fragment.cr
+++ b/src/parsers/html_fragment.cr
@@ -21,7 +21,7 @@ module Mint
 
         many do
           html_content.as(Ast::Node | Ast::Comment?)
-        end.compact.each do |item|
+        end.each do |item|
           case item
           when Ast::Comment
             comments << item

--- a/src/parsers/html_style.cr
+++ b/src/parsers/html_style.cr
@@ -17,18 +17,14 @@ module Mint
         if char! '('
           whitespace
 
-          list(terminator: ')', separator: ',') do
-            if item = expression
-              arguments << item
-            end
-          end
+          arguments = list(terminator: ')', separator: ',') { expression }
 
           whitespace
           char ')', HtmlStyleExpectedClosingParentheses
         end
 
         Ast::HtmlStyle.new(
-          arguments: arguments.compact,
+          arguments: arguments,
           from: start_position,
           to: position,
           input: data,

--- a/src/parsers/if.cr
+++ b/src/parsers/if.cr
@@ -28,7 +28,7 @@ module Mint
             closing_bracket: IfExpectedTruthyClosingBracket
           ) do
             if for_css
-              many { css_definition }.compact
+              many { css_definition }
             else
               expression! IfExpectedTruthyExpression
             end
@@ -51,7 +51,7 @@ module Mint
                 closing_bracket: IfExpectedFalsyClosingBracket
               ) do
                 if for_css
-                  many { css_definition }.compact
+                  many { css_definition }
                 else
                   expression! IfExpectedFalsyExpression
                 end

--- a/src/parsers/inline_function.cr
+++ b/src/parsers/inline_function.cr
@@ -15,7 +15,7 @@ module Mint
         arguments = list(
           terminator: ')',
           separator: ','
-        ) { argument }.compact
+        ) { argument }
 
         whitespace
         char ')', InlineFunctionExpectedClosingParentheses

--- a/src/parsers/js.cr
+++ b/src/parsers/js.cr
@@ -9,7 +9,7 @@ module Mint
 
         value = many(parse_whitespace: false) do
           (not_interpolation_part('`') || interpolation).as(Ast::Interpolation | String?)
-        end.compact
+        end
 
         char '`', JsExpectedClosingTick
 

--- a/src/parsers/module.cr
+++ b/src/parsers/module.cr
@@ -17,8 +17,8 @@ module Mint
         items = block(
           opening_bracket: ModuleExpectedOpeningBracket,
           closing_bracket: ModuleExpectedClosingBracket) do
-          many { function || constant || self.comment }.compact
-        end.compact
+          many { function || constant || self.comment }
+        end
 
         functions = [] of Ast::Function
         constants = [] of Ast::Constant

--- a/src/parsers/parallel.cr
+++ b/src/parsers/parallel.cr
@@ -14,7 +14,7 @@ module Mint
           opening_bracket: ParallelExpectedOpeningBracket,
           closing_bracket: ParallelExpectedClosingBracket
         ) do
-          results = many { statement(Ast::Statement::Parent::Sequence) || comment }.compact
+          results = many { statement(Ast::Statement::Parent::Sequence) || comment }
 
           raise ParallelExpectedStatement if results
                                                .reject(Ast::Comment)
@@ -26,7 +26,7 @@ module Mint
         then_branch = then_block
 
         whitespace
-        catches = many { catch }.compact
+        catches = many { catch }
 
         whitespace
         catch_all = self.catch_all

--- a/src/parsers/provider.cr
+++ b/src/parsers/provider.cr
@@ -26,7 +26,7 @@ module Mint
           opening_bracket: ProviderExpectedOpeningBracket,
           closing_bracket: ProviderExpectedClosingBracket
         ) do
-          items = many { function || state || constant || self.comment }.compact
+          items = many { function || state || constant || self.comment }
           raise ProviderExpectedBody if items
                                           .select(Ast::Function)
                                           .empty?

--- a/src/parsers/record.cr
+++ b/src/parsers/record.cr
@@ -11,11 +11,7 @@ module Mint
         unless char! '}'
           whitespace
 
-          fields.concat(
-            list(
-              terminator: '}',
-              separator: ','
-            ) { record_field }.compact)
+          fields = list(terminator: '}', separator: ',') { record_field }
 
           whitespace
           char '}', RecordExpectedClosingBracket

--- a/src/parsers/record_constructor.cr
+++ b/src/parsers/record_constructor.cr
@@ -18,7 +18,7 @@ module Mint
           list(
             terminator: ')',
             separator: ','
-          ) { expression }.compact
+          ) { expression }
 
         whitespace
         char ')', RecordConstructorExpectedClosingParentheses

--- a/src/parsers/record_definition.cr
+++ b/src/parsers/record_definition.cr
@@ -21,7 +21,7 @@ module Mint
             list(
               terminator: '}',
               separator: ','
-            ) { record_definition_field }.compact,
+            ) { record_definition_field },
             self.comment,
           }
         end

--- a/src/parsers/record_update.cr
+++ b/src/parsers/record_update.cr
@@ -25,7 +25,7 @@ module Mint
         fields = list(
           terminator: '}',
           separator: ','
-        ) { record_field.as(Ast::RecordField?) }.compact
+        ) { record_field.as(Ast::RecordField?) }
 
         raise RecordUpdateExpectedFields if fields.empty?
 

--- a/src/parsers/regexp_literal.cr
+++ b/src/parsers/regexp_literal.cr
@@ -12,7 +12,7 @@ module Mint
 
         value = many(parse_whitespace: false) do
           not_interpolation_part('/', stop_on_interpolation: false)
-        end.compact.join
+        end.join
 
         char "/", RegexpLiteralExpectedClosingSlash
 

--- a/src/parsers/route.cr
+++ b/src/parsers/route.cr
@@ -23,10 +23,7 @@ module Mint
         arguments = [] of Ast::Argument
 
         if char! '('
-          arguments.concat list(
-            terminator: ')',
-            separator: ','
-          ) { argument }.compact
+          arguments = list(terminator: ')', separator: ',') { argument }
           whitespace
           char ')', RouteExpectedClosingParentheses
         end

--- a/src/parsers/routes.cr
+++ b/src/parsers/routes.cr
@@ -12,7 +12,7 @@ module Mint
           opening_bracket: RoutesExpectedOpeningBracket,
           closing_bracket: RoutesExpectedClosingBracket
         ) do
-          items = many { comment || route }.compact
+          items = many { comment || route }
 
           raise RoutesExpectedRoute if items
                                          .reject(Ast::Comment)

--- a/src/parsers/sequence.cr
+++ b/src/parsers/sequence.cr
@@ -14,7 +14,7 @@ module Mint
           opening_bracket: SequenceExpectedOpeningBracket,
           closing_bracket: SequenceExpectedClosingBracket
         ) do
-          results = many { statement(Ast::Statement::Parent::Sequence) || comment }.compact
+          results = many { statement(Ast::Statement::Parent::Sequence) || comment }
 
           raise SequenceExpectedStatement if results
                                                .select(Ast::Statement)
@@ -23,7 +23,7 @@ module Mint
         end
 
         whitespace
-        catches = many { catch }.compact
+        catches = many { catch }
 
         whitespace
         catch_all = self.catch_all

--- a/src/parsers/store.cr
+++ b/src/parsers/store.cr
@@ -19,7 +19,7 @@ module Mint
           opening_bracket: StoreExpectedOpeningBracket,
           closing_bracket: StoreExpectedClosingBracket
         ) do
-          items = many { state || function || get || constant || self.comment }.compact
+          items = many { state || function || get || constant || self.comment }
 
           raise StoreExpectedBody if items
                                        .reject(Ast::Comment)

--- a/src/parsers/string_literal.cr
+++ b/src/parsers/string_literal.cr
@@ -19,7 +19,7 @@ module Mint
           else
             not_interpolation_part('"')
           end.as(Ast::Interpolation | String?)
-        end.compact
+        end
 
         char '"', StringExpectedEndQuote
         whitespace

--- a/src/parsers/style.cr
+++ b/src/parsers/style.cr
@@ -31,7 +31,7 @@ module Mint
           opening_bracket: StyleExpectedOpeningBracket,
           closing_bracket: StyleExpectedClosingBracket
         ) do
-          many { css_keyframes || css_font_face || css_node }.compact
+          many { css_keyframes || css_font_face || css_node }
         end
 
         self << Ast::Style.new(
@@ -53,7 +53,7 @@ module Mint
     end
 
     def css_body
-      many { css_node }.compact
+      many { css_node }
     end
 
     def css_definition_or_selector

--- a/src/parsers/style.cr
+++ b/src/parsers/style.cr
@@ -18,10 +18,7 @@ module Mint
         if char! '('
           whitespace
 
-          arguments.concat list(
-            terminator: ')',
-            separator: ','
-          ) { argument }.compact
+          arguments = list(terminator: ')', separator: ',') { argument }
 
           whitespace
           char ')', StyleExpectedClosingParentheses

--- a/src/parsers/suite.cr
+++ b/src/parsers/suite.cr
@@ -20,7 +20,7 @@ module Mint
           opening_bracket: SuiteExpectedOpeningBracket,
           closing_bracket: SuiteExpectedClosingBracket
         ) do
-          items = many { test || constant || comment }.compact
+          items = many { test || constant || comment }
 
           raise SuiteExpectedTests if items
                                         .reject(Ast::Comment)

--- a/src/parsers/top_level.cr
+++ b/src/parsers/top_level.cr
@@ -29,7 +29,7 @@ module Mint
           store ||
           suite ||
           comment
-      end.compact
+      end
 
       items.each do |item|
         case item

--- a/src/parsers/try.cr
+++ b/src/parsers/try.cr
@@ -14,7 +14,7 @@ module Mint
           opening_bracket: TryExpectedOpeningBracket,
           closing_bracket: TryExpectedClosingBracket
         ) do
-          items = many { statement(Ast::Statement::Parent::Try) || comment }.compact
+          items = many { statement(Ast::Statement::Parent::Try) || comment }
 
           raise TryExpectedStatement if items
                                           .reject(Ast::Comment)
@@ -24,7 +24,7 @@ module Mint
         end
 
         whitespace
-        catches = many { catch }.compact
+        catches = many { catch }
 
         whitespace
         catch_all = self.catch_all

--- a/src/parsers/tuple_destructuring.cr
+++ b/src/parsers/tuple_destructuring.cr
@@ -16,7 +16,7 @@ module Mint
         skip unless head
 
         parameters = [head].concat(
-          list(terminator: '}', separator: ',') { variable }.compact)
+          list(terminator: '}', separator: ',') { variable })
 
         whitespace
 

--- a/src/parsers/tuple_literal.cr
+++ b/src/parsers/tuple_literal.cr
@@ -10,7 +10,7 @@ module Mint
         items = list(
           terminator: '}',
           separator: ','
-        ) { bool_literal }.compact
+        ) { bool_literal }
         whitespace
 
         skip unless char! '}'
@@ -31,7 +31,7 @@ module Mint
         items = list(
           terminator: '}',
           separator: ','
-        ) { expression }.compact
+        ) { expression }
         whitespace
 
         char "}", TupleLiteralExpectedClosingBracket

--- a/src/parsers/type.cr
+++ b/src/parsers/type.cr
@@ -21,7 +21,7 @@ module Mint
           whitespace
           raise TypeExpectedTypeOrVariable unless type
           type
-        end.compact
+        end
         char ')', TypeExpectedClosingParentheses
       end
 

--- a/src/parsers/where.cr
+++ b/src/parsers/where.cr
@@ -12,7 +12,7 @@ module Mint
           opening_bracket: WhereExpectedOpeningBracket,
           closing_bracket: WhereExpectedClosingBracket
         ) do
-          items = many { where_statement || comment }.compact
+          items = many { where_statement || comment }
 
           raise WhereExpectedWhere if items
                                         .reject(Ast::Comment)


### PR DESCRIPTION
many and list already stop if they encounter a falsey/nil value. There's no need to return an Array of nilable items. The means a **TON** of `.compact` calls can be removed.