### PR TITLE
Use native crystal code for PNG resizing

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -32,6 +32,10 @@ shards:
     git: https://github.com/icyleaf/markd.git
     version: 0.4.0
 
+  png_util:
+    git: https://github.com/matthewmcgarvey/png_util.git
+    version: 0.1.0
+
   radix:
     git: https://github.com/luislavena/radix.git
     version: 0.4.1

--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,9 @@ dependencies:
   markd:
     github: icyleaf/markd
     version: ~> 0.4.0
+  png_util:
+    github: matthewmcgarvey/png_util
+    version: ~> 0.1.0
 
 development_dependencies:
   ameba:

--- a/src/all.cr
+++ b/src/all.cr
@@ -8,6 +8,7 @@ require "uuid"
 require "html"
 require "json"
 require "xml"
+require "png_util"
 
 MINT_ENV = {} of String => String
 

--- a/src/utils/icon_generator.cr
+++ b/src/utils/icon_generator.cr
@@ -3,22 +3,12 @@ module Mint
     extend self
 
     def convert(image, size)
-      output =
-        IO::Memory.new
-
-      error =
-        IO::Memory.new
-
-      status =
-        Process.run(
-          "convert #{image} -resize #{size}x#{size} -",
-          shell: true, error: error, output: output)
-
-      if status.success?
-        output.to_s
-      else
-        ""
-      end
+      canvas = PNGUtil.read(image)
+      size = size.to_i32
+      canvas.resize(size, size)
+      output = IO::Memory.new
+      PNGUtil.write(canvas, output)
+      output.to_s
     end
   end
 end


### PR DESCRIPTION
Uses https://github.com/matthewmcgarvey/png_util for PNG resizing rather than piping out to ImageMagick.

## Performance Summary

**ImageMagick (--release):** 664ms
**PNGUtil:** 612ms
**PNGUtil (--release):** 148ms (4.5 times faster than ImageMagick!)