### PR TITLE
Include css class name in compiled output

### DIFF
--- a/spec/compilers/css_definition
+++ b/spec/compilers/css_definition
@@ -13,7 +13,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a + `px 0px`
     };
@@ -27,8 +27,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -36,7 +36,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   margin: var(--a-a);
 }
 `);

--- a/spec/compilers/css_font_face
+++ b/spec/compilers/css_font_face
@@ -20,7 +20,7 @@ component Main {
 class A extends _C {
   render() {
     return _h("div", {
-      className: `a`
+      className: `test_HASH_ID`
     });
   }
 };

--- a/spec/compilers/css_font_face_with_qoutes
+++ b/spec/compilers/css_font_face_with_qoutes
@@ -16,7 +16,7 @@ component Main {
 class A extends _C {
   render() {
     return _h("div", {
-      className: `a`
+      className: `test_HASH_ID`
     });
   }
 };
@@ -24,7 +24,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   font-family: "myFirstFont";
 }
 

--- a/spec/compilers/css_keyframes
+++ b/spec/compilers/css_keyframes
@@ -37,7 +37,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a
     };
@@ -51,8 +51,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };

--- a/spec/compilers/css_media
+++ b/spec/compilers/css_media
@@ -19,7 +19,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a,
       [`--b-a`]: this.a
@@ -34,8 +34,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -43,12 +43,12 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a div {
+.test_HASH_ID div {
   color: var(--a-a);
 }
 
 @media (screen) {
-  .a {
+  .test_HASH_ID {
     color: var(--b-a);
   }
 }

--- a/spec/compilers/css_media_with_if
+++ b/spec/compilers/css_media_with_if
@@ -15,7 +15,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {};
 
     (true ? Object.assign(_, {
@@ -27,8 +27,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -36,12 +36,12 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   color: yellow;
 }
 
 @media (max-width: 300px) {
-  .a {
+  .test_HASH_ID {
     color: var(--a-a);
   }
 }

--- a/spec/compilers/css_selector
+++ b/spec/compilers/css_selector
@@ -19,7 +19,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a
     };
@@ -33,8 +33,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -42,11 +42,11 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a div {
+.test_HASH_ID div {
   color: var(--a-a);
 }
 
-.a:focus {
+.test_HASH_ID:focus {
   color: red;
 }
 `);

--- a/spec/compilers/css_selector_multiple
+++ b/spec/compilers/css_selector_multiple
@@ -20,7 +20,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a
     };
@@ -34,8 +34,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -43,15 +43,15 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a div {
+.test_HASH_ID div {
   color: var(--a-a);
 }
 
-.a:focus {
+.test_HASH_ID:focus {
   color: red;
 }
 
-.a:hover {
+.test_HASH_ID:hover {
   color: red;
 }
 `);

--- a/spec/compilers/css_string
+++ b/spec/compilers/css_string
@@ -23,7 +23,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $unicode_HASH_ID() {
     const _ = {
       [`--a-a`]: `"Hi"` + ` blah ` + this.a + ` ` + `"Here is some content; Thanks ${this.a}"`
     };
@@ -37,8 +37,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `unicode_HASH_ID`,
+      style: _style([this.$unicode_HASH_ID()])
     }, [
       _h("span", {})
     ]);
@@ -48,7 +48,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a span::after {
+.unicode_HASH_ID span::after {
   content: var(--a-a);
 }
 `);

--- a/spec/compilers/css_supports
+++ b/spec/compilers/css_supports
@@ -21,7 +21,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a
     };
@@ -35,8 +35,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -45,7 +45,7 @@ A.displayName = "Main";
 
 _insertStyles(`
 @supports (screen) {
-  .a {
+  .test_HASH_ID {
     color: var(--a-a);
   }
 }

--- a/spec/compilers/css_with_ands
+++ b/spec/compilers/css_with_ands
@@ -21,7 +21,7 @@ component Main {
 class A extends _C {
   render() {
     return _h("div", {
-      className: `a`
+      className: `test_HASH_ID`
     });
   }
 };
@@ -29,15 +29,15 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a:focus {
+.test_HASH_ID:focus {
   color: red;
 }
 
-.a[someattribute] {
+.test_HASH_ID[someattribute] {
   color: red;
 }
 
-.a.someclass {
+.test_HASH_ID.someclass {
   color: red;
 }
 `);

--- a/spec/compilers/css_with_arguments
+++ b/spec/compilers/css_with_arguments
@@ -9,7 +9,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a(a) {
+  $test_HASH_ID(a) {
     const _ = {
       [`--a-a`]: a
     };
@@ -19,8 +19,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a(`red`)])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID(`red`)])
     });
   }
 };
@@ -28,7 +28,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   color: var(--a-a);
 }
 `);

--- a/spec/compilers/css_with_case
+++ b/spec/compilers/css_with_case
@@ -17,7 +17,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {};
 
     (() => {
@@ -39,8 +39,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -48,7 +48,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   color: var(--a-a, yellow);
 }
 `);

--- a/spec/compilers/css_with_else_if
+++ b/spec/compilers/css_with_else_if
@@ -18,7 +18,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a(a) {
+  $base_HASH_ID(a) {
     const _ = {};
 
     (_compare(a, `red`) ? Object.assign(_, {
@@ -33,8 +33,8 @@ class A extends _C {
   render() {
     return _h("div", {}, [
       _h("div", {
-        className: `a`,
-        style: _style([this.$a(`blue`)])
+        className: `base_HASH_ID`,
+        style: _style([this.$base_HASH_ID(`blue`)])
       })
     ]);
   }
@@ -43,7 +43,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.base_HASH_ID {
   height: 20px;
   background: var(--a-a);
 }

--- a/spec/compilers/css_with_if
+++ b/spec/compilers/css_with_if
@@ -15,7 +15,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {};
 
     (true ? Object.assign(_, {
@@ -29,8 +29,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -38,7 +38,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   color: var(--a-a, yellow);
 }
 `);

--- a/spec/compilers/css_with_if_and_case
+++ b/spec/compilers/css_with_if_and_case
@@ -20,7 +20,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {};
 
     (() => {
@@ -48,8 +48,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -57,7 +57,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   color: var(--a-a, yellow);
 }
 `);

--- a/spec/compilers/css_with_if_same_condition
+++ b/spec/compilers/css_with_if_same_condition
@@ -23,7 +23,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a() {
+  $test_HASH_ID() {
     const _ = {};
 
     (true ? Object.assign(_, {
@@ -43,8 +43,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -52,11 +52,11 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a .tag {
+.test_HASH_ID .tag {
   color: var(--a-a);
 }
 
-.a .string {
+.test_HASH_ID .string {
   color: var(--b-a);
 }
 `);

--- a/spec/compilers/html_attribute_class_with_style
+++ b/spec/compilers/html_attribute_class_with_style
@@ -12,7 +12,7 @@ component Main {
 class A extends _C {
   render() {
     return _h("div", {
-      className: `something` + ` a`
+      className: `something` + ` base_HASH_ID`
     });
   }
 };
@@ -20,7 +20,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.base_HASH_ID {
   width: 100%;
 }
 `);

--- a/spec/compilers/html_with_multiple_styles
+++ b/spec/compilers/html_with_multiple_styles
@@ -16,7 +16,7 @@ component Main {
 class A extends _C {
   render() {
     return _h("div", {
-      className: `a b`
+      className: `one_HASH_ID two_HASH_ID`
     });
   }
 };
@@ -24,11 +24,11 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.one_HASH_ID {
   color: red;
 }
 
-.b {
+.two_HASH_ID {
   color: blue;
 }
 `);

--- a/spec/compilers/html_with_multiple_styles_and_parameters
+++ b/spec/compilers/html_with_multiple_styles_and_parameters
@@ -14,7 +14,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $b(a) {
+  $two_HASH_ID(a) {
     const _ = {
       [`--a-a`]: a
     };
@@ -24,8 +24,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a b`,
-      style: _style([this.$b(`blue`)])
+      className: `one_HASH_ID two_HASH_ID`,
+      style: _style([this.$two_HASH_ID(`blue`)])
     });
   }
 };
@@ -33,11 +33,11 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.one_HASH_ID {
   color: red;
 }
 
-.b {
+.two_HASH_ID {
   color: var(--a-a);
 }
 `);

--- a/spec/compilers/html_with_multiple_styles_and_parameters_2
+++ b/spec/compilers/html_with_multiple_styles_and_parameters_2
@@ -14,7 +14,7 @@ component Main {
 }
 --------------------------------------------------------------------------------
 class A extends _C {
-  $a(a) {
+  $one_HASH_ID(a) {
     const _ = {
       [`--a-a`]: a
     };
@@ -22,7 +22,7 @@ class A extends _C {
     return _;
   }
 
-  $b(b) {
+  $two_HASH_ID(b) {
     const _ = {
       [`--b-a`]: b
     };
@@ -32,8 +32,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a b`,
-      style: _style([this.$a(`red`), this.$b(`blue`)])
+      className: `one_HASH_ID two_HASH_ID`,
+      style: _style([this.$one_HASH_ID(`red`), this.$two_HASH_ID(`blue`)])
     });
   }
 };
@@ -41,11 +41,11 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.one_HASH_ID {
   color: var(--a-a);
 }
 
-.b {
+.two_HASH_ID {
   color: var(--b-a);
 }
 `);

--- a/spec/compilers/html_with_pseudos
+++ b/spec/compilers/html_with_pseudos
@@ -33,7 +33,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a,
       [`--b-a`]: this.b,
@@ -53,8 +53,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -62,17 +62,17 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   background: var(--a-a);
   color: red;
 }
 
-.a:hover {
+.test_HASH_ID:hover {
   background: var(--b-a);
   color: cyan;
 }
 
-.a div {
+.test_HASH_ID div {
   font-family: var(--c-a);
   color: blue;
 }

--- a/spec/compilers/html_with_style
+++ b/spec/compilers/html_with_style
@@ -28,7 +28,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a,
       [`--a-b`]: this.a,
@@ -49,8 +49,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a()])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID()])
     });
   }
 };
@@ -58,7 +58,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   -webkit-touch-callout: none;
   border-color: var(--a-a);

--- a/spec/compilers/html_with_style_and_custom_style
+++ b/spec/compilers/html_with_style_and_custom_style
@@ -25,7 +25,7 @@ class A extends _C {
     });
   }
 
-  $a() {
+  $test_HASH_ID() {
     const _ = {
       [`--a-a`]: this.a
     };
@@ -43,8 +43,8 @@ class A extends _C {
 
   render() {
     return _h("div", {
-      className: `a`,
-      style: _style([this.$a(), this.b])
+      className: `test_HASH_ID`,
+      style: _style([this.$test_HASH_ID(), this.b])
     });
   }
 };
@@ -52,7 +52,7 @@ class A extends _C {
 A.displayName = "Main";
 
 _insertStyles(`
-.a {
+.test_HASH_ID {
   background: var(--a-a);
   color: red;
 }

--- a/spec/compilers_spec.cr
+++ b/spec/compilers_spec.cr
@@ -12,6 +12,7 @@ Dir
       # Parse the sample
       ast = Mint::Parser.parse(sample, file)
       ast.class.should eq(Mint::Ast)
+      ast.components.each(&.hash_id=("HASH_ID"))
 
       # Compare results
       result = Mint::Compiler.compile_bare(Mint::TypeChecker.check(ast), {

--- a/spec/style_builder_spec.cr
+++ b/spec/style_builder_spec.cr
@@ -60,10 +60,33 @@ describe Mint::StyleBuilder do
     style =
       parser.style.should_not be_nil
 
-    builder = Mint::StyleBuilder.new(css_prefix: "foo")
+    builder = Mint::StyleBuilder.new(css_prefix: "foo_")
     builder.process(style, "HASH_ID")
 
     compiled = builder.compile
     compiled.should contain(".foo_test_HASH_ID div span pre a {")
+  end
+
+  it "optimizes class names if optimize is set" do
+    example =
+      <<-MINT
+        style test {
+          div {
+            background: red;
+          }
+        }
+      MINT
+
+    parser =
+      Mint::Parser.new(example.strip, "test.mint")
+
+    style =
+      parser.style.should_not be_nil
+
+    builder = Mint::StyleBuilder.new(optimize: true)
+    builder.process(style, "HASH_ID")
+
+    compiled = builder.compile
+    compiled.should contain(".a div {")
   end
 end

--- a/spec/style_builder_spec.cr
+++ b/spec/style_builder_spec.cr
@@ -60,10 +60,10 @@ describe Mint::StyleBuilder do
     style =
       parser.style.should_not be_nil
 
-    builder = Mint::StyleBuilder.new(css_prefix: "foo-")
-    builder.process(style)
+    builder = Mint::StyleBuilder.new(css_prefix: "foo")
+    builder.process(style, "HASH_ID")
 
     compiled = builder.compile
-    compiled.should contain(".foo-a div span pre a {")
+    compiled.should contain(".foo_test_HASH_ID div span pre a {")
   end
 end

--- a/src/all.cr
+++ b/src/all.cr
@@ -8,6 +8,7 @@ require "uuid"
 require "html"
 require "json"
 require "xml"
+require "digest/md5"
 
 MINT_ENV = {} of String => String
 

--- a/src/ast/component.cr
+++ b/src/ast/component.cr
@@ -1,10 +1,10 @@
 module Mint
   class Ast
     class Component < Node
-      getter properties, connects, styles, states, comments, hash_id
+      getter properties, connects, styles, states, comments
       getter functions, gets, uses, name, comment, refs, constants
       getter? global
-      getter hash_id : String
+      property hash_id : String
 
       def initialize(@refs : Array(Tuple(Variable, Node)),
                      @properties : Array(Property),

--- a/src/ast/component.cr
+++ b/src/ast/component.cr
@@ -1,9 +1,10 @@
 module Mint
   class Ast
     class Component < Node
-      getter properties, connects, styles, states, comments
+      getter properties, connects, styles, states, comments, hash_id
       getter functions, gets, uses, name, comment, refs, constants
       getter? global
+      getter hash_id : String
 
       def initialize(@refs : Array(Tuple(Variable, Node)),
                      @properties : Array(Property),
@@ -21,6 +22,7 @@ module Mint
                      @input : Data,
                      @from : Int32,
                      @to : Int32)
+        @hash_id = Digest::MD5.hexdigest(@name)[0, 5]
       end
 
       def owns?(node)

--- a/src/compiler.cr
+++ b/src/compiler.cr
@@ -14,7 +14,7 @@ module Mint
 
     def initialize(@artifacts : TypeChecker::Artifacts, @optimize = false, css_prefix = nil, @relative = false, @build = false)
       @style_builder =
-        StyleBuilder.new(css_prefix: css_prefix)
+        StyleBuilder.new(css_prefix: css_prefix, optimize: @optimize)
 
       @js =
         Js.new(optimize: @optimize)

--- a/src/compilers/style.cr
+++ b/src/compilers/style.cr
@@ -15,7 +15,7 @@ module Mint
     end
 
     def _compile(node : Ast::Style, component : Ast::Component) : Nil
-      style_builder.process node
+      style_builder.process(node, component.hash_id)
     end
   end
 end

--- a/src/style_builder.cr
+++ b/src/style_builder.cr
@@ -10,9 +10,24 @@ module Mint
     @cache = {} of Tuple(B, T) => String
     @current = {} of B => String
 
-    def of(subject : T, base : B)
+    # def of(subject : T, base : B)
+    #   @cache[{base, subject}] ||= begin
+    #     @current[base] = (@current[base]? || INITIAL).succ
+    #   end
+    # end
+
+    def of(subject : T, base : B, hash_id : String? = nil)
       @cache[{base, subject}] ||= begin
-        @current[base] = (@current[base]? || INITIAL).succ
+        case subject
+        when Ast::Style
+          temp = "_#{subject.name.value}"
+          if hash_id
+            temp = "#{temp}_#{hash_id}"
+          end
+          temp
+        else
+          @current[base] = (@current[base]? || INITIAL).succ
+        end
       end
     end
   end
@@ -192,14 +207,14 @@ module Mint
       false
     end
 
-    def prefixed_class_name(node)
-      @css_prefix.to_s + style_pool.of(node, nil)
+    def prefixed_class_name(node, hash_id : String? = nil)
+      @css_prefix.to_s + style_pool.of(node, nil, hash_id)
     end
 
     # The main entry point for processing a "style" tag.
-    def process(node : Ast::Style)
+    def process(node : Ast::Style, hash_id : String)
       selectors =
-        [".#{prefixed_class_name(node)}"]
+        [".#{prefixed_class_name(node, hash_id)}"]
 
       process(node.body, nil, nil, selectors, %w[], node)
     end

--- a/src/style_builder.cr
+++ b/src/style_builder.cr
@@ -16,9 +16,9 @@ module Mint
     def of(subject : T, base : B, hash_id : String? = nil)
       @cache[{base, subject}] ||= begin
         if subject.is_a?(Ast::Style) && !@optimize
-          temp = "#{subject.name.value}"
-          temp = "#{temp}_#{hash_id}" if hash_id
-          temp
+          class_name = subject.name.value
+          class_name = "#{class_name}_#{hash_id}" if hash_id
+          class_name
         else
           @current[base] = (@current[base]? || INITIAL).succ
         end

--- a/src/style_builder.cr
+++ b/src/style_builder.cr
@@ -10,20 +10,14 @@ module Mint
     @cache = {} of Tuple(B, T) => String
     @current = {} of B => String
 
-    # def of(subject : T, base : B)
-    #   @cache[{base, subject}] ||= begin
-    #     @current[base] = (@current[base]? || INITIAL).succ
-    #   end
-    # end
+    def initialize(@optimize : Bool = false)
+    end
 
     def of(subject : T, base : B, hash_id : String? = nil)
       @cache[{base, subject}] ||= begin
-        case subject
-        when Ast::Style
-          temp = "_#{subject.name.value}"
-          if hash_id
-            temp = "#{temp}_#{hash_id}"
-          end
+        if subject.is_a?(Ast::Style) && !@optimize
+          temp = "#{subject.name.value}"
+          temp = "#{temp}_#{hash_id}" if hash_id
           temp
         else
           @current[base] = (@current[base]? || INITIAL).succ
@@ -142,11 +136,11 @@ module Mint
     getter selectors, property_pool, name_pool, style_pool, variables, ifs
     getter cases
 
-    def initialize(@css_prefix : String? = nil)
+    def initialize(@css_prefix : String? = nil, @optimize : Bool = false)
       # Three name pools so there would be no clashes,
       # which also good for optimizations.
       @property_pool = NamePool(String, String).new
-      @style_pool = NamePool(Ast::Node, Nil).new
+      @style_pool = NamePool(Ast::Node, Nil).new(optimize: @optimize)
       @name_pool = NamePool(String, Nil).new
 
       # This is the main data structure:


### PR DESCRIPTION
Related to #115 

Instead of iterating through the alphabet, this keeps the class name and pairs it with a unique hash connected to each style's component.

Normally having a `base` class in mint would generate something like `aa` as the class when you inspect the browser. Now it will look like `_base_c1010`

This does not update the variables. I'm not entirely sure how they work right so I didn't try to figure out how they could fit into this. There's also a ton of failing tests. I haven't quite figured out how to keep the hash id consistent int tests and I wanted to get feedback on this implementation anyways.

The connected issue talks about only mangling them in the final build. I'm not too sure if that's necessary. Let me know and I'll try to figure out how that works.