### PR TITLE
Add timestamp to AnimationFrame

### DIFF
--- a/core/source/AnimationFrame.mint
+++ b/core/source/AnimationFrame.mint
@@ -5,7 +5,7 @@ module AnimationFrame {
 
     id = AnimationFrame.request(() { Debug.log("Hello") })
   */
-  fun request (method : Function(a)) : Number {
+  fun request (method : Function(Number, a)) : Number {
     `requestAnimationFrame(#{method})`
   }
 

--- a/core/source/Provider/AnimationFrame.mint
+++ b/core/source/Provider/AnimationFrame.mint
@@ -1,6 +1,6 @@
 /* Represents a subscription for `Provider.AnimationFrame` */
 record Provider.AnimationFrame.Subscription {
-  frames : Function(Promise(Never, Void))
+  frames : Function(Number, Promise(Never, Void))
 }
 
 /* A provider for the `requestAnimationFrame` API. */
@@ -9,10 +9,10 @@ provider Provider.AnimationFrame : Provider.AnimationFrame.Subscription {
   state id : Number = -1
 
   /* Call the subscribers. */
-  fun process : Promise(Never, Void) {
+  fun process (timestamp : Number) : Promise(Never, Void) {
     try {
       for (subscription of subscriptions) {
-        subscription.frames()
+        subscription.frames(timestamp)
       }
 
       next { id = AnimationFrame.request(process) }

--- a/core/source/Test/Context.mint
+++ b/core/source/Test/Context.mint
@@ -95,7 +95,7 @@ module Test.Context {
     #{context}.step((item) => {
       let actual = #{method}(item)
 
-      if (actual == #{value}) {
+      if (_compare(actual, #{value})) {
         return item
       } else {
         throw \`Assertion failed ${actual} == ${value}\`

--- a/core/tests/tests/Provider/AnimationFrame.mint
+++ b/core/tests/tests/Provider/AnimationFrame.mint
@@ -1,7 +1,12 @@
 component Test.Provider.AnimationFrame {
   state frames : Number = 0
 
-  use Provider.AnimationFrame { frames = () : Promise(Never, Void) { next { frames = frames + 1 } } }
+  use Provider.AnimationFrame {
+    frames =
+      (timestamp : Number) : Promise(Never, Void) {
+        next { frames = frames + 1 }
+      }
+  }
 
   fun render : Html {
     <div>

--- a/core/tests/tests/Provider/AnimationFrame.mint
+++ b/core/tests/tests/Provider/AnimationFrame.mint
@@ -1,28 +1,30 @@
 component Test.Provider.AnimationFrame {
-  state frames : Number = 0
+  state timestamp : Number = 0
 
   use Provider.AnimationFrame {
     frames =
       (timestamp : Number) : Promise(Never, Void) {
-        next { frames = frames + 1 }
+        next { timestamp = timestamp }
       }
   }
 
   fun render : Html {
     <div>
-      <{ Number.toString(frames) }>
+      <{ Number.toString(timestamp) }>
     </div>
   }
 }
 
 suite "Provider.AnimationFrame.frames" {
   test "called on an animation frame" {
-    with Test.Html {
-      <Test.Provider.AnimationFrame/>
-      |> start()
-      |> assertTextOf("div", "1")
-      |> assertTextOf("div", "2")
-      |> assertTextOf("div", "3")
+    with Test.Context {
+      with Test.Html {
+        <Test.Provider.AnimationFrame/>
+          |> start()
+          |> find("div")
+          |> map(Dom.getTextContent)
+          |> assertNotEqual("0")
+      }
     }
   }
 }


### PR DESCRIPTION
This adds the expected `Number` argument from `requestAnimationFrame` so that consumers can calculate the time step difference, etc.

Fixes #445