### PR TITLE
Fix `mint init` files not formatted with `mint format`

### DIFF
--- a/src/app_init/app/source/Link.mint
+++ b/src/app_init/app/source/Link.mint
@@ -5,7 +5,7 @@ component Link {
   style link {
     font-size: calc(10px + 2vmin);
     text-decoration: none;
-    color:  #DDDDDD;
+    color: #DDDDDD;
 
     &:hover {
       text-decoration: underline;
@@ -13,8 +13,12 @@ component Link {
   }
 
   fun render : Html {
-    <a::link href="#{href}" target="_blank">
+    <a::link
+      href="#{href}"
+      target="_blank">
+
       <{ children }>
+
     </a>
   }
 }

--- a/src/app_init/app/source/Logo.mint
+++ b/src/app_init/app/source/Logo.mint
@@ -6,12 +6,29 @@ component Logo {
     }
 
     @keyframes shake {
-      0% { transform: translate(1px, 1px) rotate(0deg); }
-      3% { transform: translate(-1px, -2px) rotate(-1deg); }
-      6% { transform: translate(-3px, 0px) rotate(1deg); }
-      9% { transform: translate(3px, 2px) rotate(0deg); }
-      12% { transform: translate(1px, -1px) rotate(1deg); }
-      15% { transform: translate(0px, 0px) rotate(-1deg); }
+      0% {
+        transform: translate(1px, 1px) rotate(0deg);
+      }
+
+      3% {
+        transform: translate(-1px, -2px) rotate(-1deg);
+      }
+
+      6% {
+        transform: translate(-3px, 0px) rotate(1deg);
+      }
+
+      9% {
+        transform: translate(3px, 2px) rotate(0deg);
+      }
+
+      12% {
+        transform: translate(1px, -1px) rotate(1deg);
+      }
+
+      15% {
+        transform: translate(0px, 0px) rotate(-1deg);
+      }
     }
   }
 


### PR DESCRIPTION
When running `mint init` and creating a new project, two of the files were immediately invalid from running `mint format`. This replaces the unformatted files with formatted ones from `mint format` so that `init` will output fully valid files.