### PR TITLE
Fix `The event handler is already finished.` error in Service Worker

### DIFF
--- a/src/utils/service_worker.ecr
+++ b/src/utils/service_worker.ecr
@@ -55,6 +55,5 @@ self.addEventListener('fetch', event => {
     response = fetch(event.request)
   }
 
-  response
-    .then(actualResponse => event.respondWith(actualResponse))
+  event.respondWith(response)
 })


### PR DESCRIPTION
Fixes #490 (see [this SO thread](https://stackoverflow.com/questions/46838778/service-worker-error-event-already-responded-to) for details)