### PR TITLE
Fix service-worker generation issue

### DIFF
--- a/src/utils/service_worker.cr
+++ b/src/utils/service_worker.cr
@@ -10,7 +10,7 @@ module Mint
     end
 
     protected def path_for(url)
-      @relative ? url : "/#{url}"
+      %('#{@relative ? "" : "/"}#{url}')
     end
 
     ECR.def_to_s "#{__DIR__}/service_worker.ecr"


### PR DESCRIPTION
Introduced in #500 
`precache_urls` variable items are missing quotes