### PR TITLE
Fix service-worker generation issue

### DIFF
--- a/src/utils/service_worker.cr
+++ b/src/utils/service_worker.cr
@@ -27,7 +27,7 @@ module Mint
     def precache_urls
       files
         .join(",\n") do |file|
-          path_for(file.relative_to(DIST_DIR))
+          %('#{path_for(file.relative_to(DIST_DIR))}')
         end
     end
 


### PR DESCRIPTION
Introduced in #500
`precache_urls` variable items are missing quotes