### PR TITLE
Time conversions from and to UNIX Timespamps, plus a small typo fix.

### DIFF
--- a/core/source/Time.mint
+++ b/core/source/Time.mint
@@ -51,7 +51,7 @@ module Time {
   }
 
   /*
-  Retruns a new UTC date from the given parameters.
+  Returns a new UTC date from the given parameters.
 
     Time.from(2018, 4, 5)
   */
@@ -187,5 +187,21 @@ module Time {
       return DateFNS.distanceInWordsStrict(#{now}, #{other}, { addSuffix: true })
     })()
     `
+  }
+
+  /* Returns the time respective to the given UNIX Timestamp (in Milliseconds) */
+  fun fromUnixTimestampInMs (timestamp : Number) : Time {
+  `
+    (() => {
+      const time = new Date()
+      time.setTime(#{timestamp})
+      return time
+    })()
+    `
+  }
+
+  /* Returns the UNIX Timestamp (in Milliseconds) respective to the given time */
+  fun toUnixTimestampInMs (time : Time) : Number {
+    `#{time}.getTime()`
   }
 }

--- a/core/source/Time.mint
+++ b/core/source/Time.mint
@@ -191,7 +191,7 @@ module Time {
 
   /* Returns the time respective to the given UNIX Timestamp (in Milliseconds) */
   fun fromUnixTimestampInMs (timestamp : Number) : Time {
-  `
+    `
     (() => {
       return new Date(#{timestamp})
     })()

--- a/core/source/Time.mint
+++ b/core/source/Time.mint
@@ -193,9 +193,7 @@ module Time {
   fun fromUnixTimestampInMs (timestamp : Number) : Time {
   `
     (() => {
-      const time = new Date()
-      time.setTime(#{timestamp})
-      return time
+      return new Date(#{timestamp})
     })()
     `
   }

--- a/core/tests/tests/Time.mint
+++ b/core/tests/tests/Time.mint
@@ -74,3 +74,17 @@ suite "Time.nextWeek" {
     |> Time.toIso()) == "2018-04-12T00:00:00.000Z"
   }
 }
+
+suite "Time.fromUnixTimestampInMs" {
+  test "returns the UTC time respective to the given UNIX Timestamp (in Milliseconds" {
+    (Time.fromUnixTimestampInMs(1522886400000)
+    |> Time.toIso()) == "2018-04-05T00:00:00.000Z"
+  }
+}
+suite "Time.toUnixTimestampInMs" {
+  test "returns the UNIX Timestamp (in Milliseconds) respective to the given time" {
+    (Time.from(2018, 4, 5)
+    |> Time.toUnixTimestampInMs()) == 1522886400000
+  }
+}
+

--- a/core/tests/tests/Time.mint
+++ b/core/tests/tests/Time.mint
@@ -76,15 +76,14 @@ suite "Time.nextWeek" {
 }
 
 suite "Time.fromUnixTimestampInMs" {
-  test "returns the UTC time respective to the given UNIX Timestamp (in Milliseconds" {
+  test "returns the UTC time from the given UNIX Timestamp (in Milliseconds)" {
     (Time.fromUnixTimestampInMs(1522886400000)
     |> Time.toIso()) == "2018-04-05T00:00:00.000Z"
   }
 }
 suite "Time.toUnixTimestampInMs" {
-  test "returns the UNIX Timestamp (in Milliseconds) respective to the given time" {
+  test "returns the UNIX Timestamp (in Milliseconds)" {
     (Time.from(2018, 4, 5)
     |> Time.toUnixTimestampInMs()) == 1522886400000
   }
 }
-

--- a/core/tests/tests/Time.mint
+++ b/core/tests/tests/Time.mint
@@ -81,6 +81,7 @@ suite "Time.fromUnixTimestampInMs" {
     |> Time.toIso()) == "2018-04-05T00:00:00.000Z"
   }
 }
+
 suite "Time.toUnixTimestampInMs" {
   test "returns the UNIX Timestamp (in Milliseconds)" {
     (Time.from(2018, 4, 5)


### PR DESCRIPTION
Based on the conversation #521 this PR introduces methods that convert between Unix Timestamps and an object/instance of the Javascript `Date` class to the `Time` module. Since the `Time` type is basically just an object/instance of the Javascript `Date` class, this effectively converts between `Time` and an UNIX Timestamp.

It was also pointed out that ideally UTC should be used as much as possible, and after looking into Javascript's `Date` class it appears that `setTime` and `getTime` don't make any assumptions regarding Timezones and that loading a Timestamp won't change the Timezone, which felt like the most clear way to do this.

Tests use the standard "April 5th, 2018" date used in other tests, and the code was based off of the code already used in the `Time` module, especially `now` and `nextWeek` which were used as a reference for how to initialize a `Date` and load a `Time` at first, though in the case of `toUnixTimestampInMs` it was later dropped in favor of simply using `#{time}.getTime()`.