### PR TITLE
Update Clipboard.set to restore clobbered global state

### DIFF
--- a/core/source/Clipboard.mint
+++ b/core/source/Clipboard.mint
@@ -1,57 +1,56 @@
 /* This module has functions for manipulating the clipboard. */
 module Clipboard {
   /* Sets the clipboards content to the given value. */
-  fun set (value : String) : String {
-    try {
-      `
-      (() => {
-        // Create a textarea element
-        const textarea = document.createElement("textarea")
+  fun set (value : String) : Promise(Never, String) {
+    `
+    (() => {
+      // Create a textarea element
+      const textarea = document.createElement("textarea")
 
-        // Position it on the screen
-        textarea.style.position = "fixed"
-        textarea.style.left = "10px"
-        textarea.style.top = "10px"
-        textarea.style.opacity = 0
+      // Position it on the screen
+      textarea.style.position = "fixed"
+      textarea.style.left = "10px"
+      textarea.style.top = "10px"
+      textarea.style.opacity = 0
 
-        // Add it to the DOM
-        document.body.appendChild(textarea)
+      // Add it to the DOM
+      document.body.appendChild(textarea)
 
-        // Remember the currently focused element
-        const lastActive = document.activeElement
+      // Remember the currently focused element
+      const lastActive = document.activeElement
 
-        // Focus it and set value
-        textarea.focus()
-        textarea.value = #{value}
+      // Focus it and set value
+      textarea.focus()
+      textarea.value = #{value}
 
-        // Create a selection range and set value
-        const range = document.createRange()
-        range.selectNodeContents(textarea)
+      // Create a selection range and set value
+      const range = document.createRange()
+      range.selectNodeContents(textarea)
 
-        // Get selection and replace current selection
-        const selection = window.getSelection()
-        const lastRanges = Array.from({length: selection.rangeCount}, (_, i) => selection.getRangeAt(i))
-        selection.removeAllRanges()
-        selection.addRange(range)
+      // Get selection and replace current selection
+      const selection = window.getSelection()
+      const lastRanges = Array.from({length: selection.rangeCount}, (_, i) => selection.getRangeAt(i))
+      selection.removeAllRanges()
+      selection.addRange(range)
 
-        // Select all the text
-        textarea.setSelectionRange(0, 999999)
+      // Select all the text
+      textarea.setSelectionRange(0, 999999)
 
-        // Copy to clipboard
-        document.execCommand("copy")
+      // Copy to clipboard
+      document.execCommand("copy")
 
-        // Remove textarea from the DOM
-        textarea.remove()
+      // Remove textarea from the DOM
+      textarea.remove()
 
-        // Refocus the previous active element
-        lastActive.focus()
+      // Refocus the previous active element
+      lastActive.focus()
 
-        // Restore previous range(s)
-        selection.removeAllRanges()
-        for(range of lastRanges) selection.addRange(range)
-      })()
-      `
-      value
-    }
+      // Restore previous range(s)
+      selection.removeAllRanges()
+      for(range of lastRanges) selection.addRange(range)
+
+      return #{value}
+    })()
+    `
   }
 }

--- a/core/source/Clipboard.mint
+++ b/core/source/Clipboard.mint
@@ -1,43 +1,57 @@
 /* This module has functions for manipulating the clipboard. */
 module Clipboard {
   /* Sets the clipboards content to the given value. */
-  fun set (value : String) : Promise(Never, Void) {
-    `
-    (() => {
-      // Create a textarea element
-      const textarea = document.createElement("textarea");
+  fun set (value : String) : String {
+    try {
+      `
+      (() => {
+        // Create a textarea element
+        const textarea = document.createElement("textarea")
 
-      // Position it on the screen
-      textarea.style.position = "fixed";
-      textarea.style.left = "10px";
-      textarea.style.top = "10px";
-      textarea.style.opacity = 0;
+        // Position it on the screen
+        textarea.style.position = "fixed"
+        textarea.style.left = "10px"
+        textarea.style.top = "10px"
+        textarea.style.opacity = 0
 
-      // Add it to the DOM
-      document.body.appendChild(textarea)
+        // Add it to the DOM
+        document.body.appendChild(textarea)
 
-      // Focus it and set value
-      textarea.focus()
-      textarea.value = #{value}
+        // Remember the currently focused element
+        const lastActive = document.activeElement
 
-      // Create a selection range and set value
-      const range = document.createRange();
-      range.selectNodeContents(textarea);
+        // Focus it and set value
+        textarea.focus()
+        textarea.value = #{value}
 
-      // Get selection and replace current selection
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      selection.addRange(range);
+        // Create a selection range and set value
+        const range = document.createRange()
+        range.selectNodeContents(textarea)
 
-      // Select all the text
-      textarea.setSelectionRange(0, 999999);
+        // Get selection and replace current selection
+        const selection = window.getSelection()
+        const lastRanges = Array.from({length: selection.rangeCount}, (_, i) => selection.getRangeAt(i))
+        selection.removeAllRanges()
+        selection.addRange(range)
 
-      // Copy to clipboard
-      document.execCommand("copy");
+        // Select all the text
+        textarea.setSelectionRange(0, 999999)
 
-      // Remove textarea from the DOM
-      textarea.remove()
-    })()
-    `
+        // Copy to clipboard
+        document.execCommand("copy")
+
+        // Remove textarea from the DOM
+        textarea.remove()
+
+        // Refocus the previous active element
+        lastActive.focus()
+
+        // Restore previous range(s)
+        selection.removeAllRanges()
+        for(range of lastRanges) selection.addRange(range)
+      })()
+      `
+      value
+    }
   }
 }


### PR DESCRIPTION
The `Clipboard.set` method clobbers the global state, removing focus from the current active element and removing all content selections. This PR updates the method to remember the initial active element and selection(s), restoring them after the clipboard operation is complete.

It also updates `Clipboard.set` to return its argument for convenient chaining and removes `;` which was put at the end of some lines but not others, and isn't necessary.