### PR TITLE
[LS] Code action framework and order entities code action.

### DIFF
--- a/src/ast/node.cr
+++ b/src/ast/node.cr
@@ -40,8 +40,8 @@ module Mint
         end
       end
 
+      property from : Int32
       getter input : Data
-      getter from : Int32
       getter to : Int32
 
       def initialize(@input, @from, @to)

--- a/src/ls/README.md
+++ b/src/ls/README.md
@@ -19,7 +19,7 @@ The feature set is pretty miminal at this point:
 | Find References               | :negative_squared_cross_mark: |                                               |
 | Document Highlights           | :negative_squared_cross_mark: |                                               |
 | Document Symbols              | :negative_squared_cross_mark: |                                               |
-| Code Action                   | :negative_squared_cross_mark: |                                               |
+| Code Action                   | :heavy_check_mark:            | Source Only (see specific section)            |
 | Code Lens                     | :negative_squared_cross_mark: |                                               |
 | Document Link                 | :negative_squared_cross_mark: |                                               |
 | Document Color                | :negative_squared_cross_mark: |                                               |
@@ -30,6 +30,13 @@ The feature set is pretty miminal at this point:
 | Call Hierarchy                | :negative_squared_cross_mark: |                                               |
 | Semantic Tokens               | :negative_squared_cross_mark: |                                               |
 | Monikers                      | :negative_squared_cross_mark: |                                               |
+
+### Code Action
+
+These are the supported code actions:
+
+* Order Entities (Module) - Orders entities in a module alphabetically, constants first then
+  modules, other comments are not reordered, formats the whole file.
 
 ## Implementation
 

--- a/src/ls/code_action.cr
+++ b/src/ls/code_action.cr
@@ -14,15 +14,13 @@ module Mint
       end
 
       def execute(server)
-        if workspace.error
-          [] of LSP::CodeAction
-        else
-          server
-            .nodes_at_cursor(params)
-            .reduce([] of LSP::CodeAction) do |memo, node|
-              memo + actions(node)
-            end
-        end
+        return [] of LSP::CodeAction if workspace.error
+
+        server
+          .nodes_at_cursor(params)
+          .reduce([] of LSP::CodeAction) do |memo, node|
+            memo + actions(node)
+          end
       end
 
       private def workspace

--- a/src/ls/code_action.cr
+++ b/src/ls/code_action.cr
@@ -1,0 +1,33 @@
+module Mint
+  module LS
+    class CodeAction < LSP::RequestMessage
+      property params : LSP::CodeActionParams
+
+      def actions(node : Ast::Module)
+        [
+          ModuleActions.order_entities(node, workspace, params.text_document.uri),
+        ]
+      end
+
+      def actions(node : Ast::Node)
+        [] of LSP::CodeAction
+      end
+
+      def execute(server)
+        if workspace.error
+          [] of LSP::CodeAction
+        else
+          server
+            .nodes_at_cursor(params)
+            .reduce([] of LSP::CodeAction) do |memo, node|
+              memo + actions(node)
+            end
+        end
+      end
+
+      private def workspace
+        Workspace[params.text_document.path]
+      end
+    end
+  end
+end

--- a/src/ls/code_actions/module_actions.cr
+++ b/src/ls/code_actions/module_actions.cr
@@ -1,0 +1,42 @@
+module Mint
+  module LS
+    class CodeAction < LSP::RequestMessage
+      module ModuleActions
+        extend self
+
+        def order_entities(node, workspace, uri)
+          # Save the original order of constants and functions
+          order =
+            (node.functions + node.constants)
+              .sort_by(&.from)
+              .map(&.from)
+
+          # Reorder by name and the appropriate order from the original order
+          (node.constants.sort_by(&.name) +
+            node.functions.sort_by(&.name.value))
+            .each_with_index { |entity, index| entity.from = order[index] }
+
+          # This should not fail since we return on errors earlier
+          formatted =
+            workspace.format(URI.parse(uri).path.to_s)
+
+          # Create a workspace edit of the formatted document
+          edit =
+            LSP::WorkspaceEdit.new({
+              uri => [
+                LSP::TextEdit.new(new_text: formatted, range: LSP::Range.new(
+                  start: LSP::Position.new(line: 0, character: 0),
+                  end: LSP::Position.new(line: 9999, character: 999)
+                )),
+              ],
+            })
+
+          LSP::CodeAction.new(
+            title: "Order Entities",
+            kind: "source",
+            edit: edit)
+        end
+      end
+    end
+  end
+end

--- a/src/ls/initialize.cr
+++ b/src/ls/initialize.cr
@@ -60,7 +60,7 @@ module Mint
             type_definition_provider: false,
             implementation_provider: false,
             folding_range_provider: false,
-            code_action_provider: false,
+            code_action_provider: true,
             declaration_provider: false,
             definition_provider: false,
             references_provider: false,

--- a/src/ls/server.cr
+++ b/src/ls/server.cr
@@ -10,6 +10,7 @@ module Mint
       method "textDocument/willSaveWaitUntil", WillSaveWaitUntil
       method "textDocument/formatting", Formatting
       method "textDocument/completion", Completion
+      method "textDocument/codeAction", CodeAction
       method "textDocument/didChange", DidChange
       method "textDocument/hover", Hover
 
@@ -29,16 +30,20 @@ module Mint
       end
 
       # Returns the nodes at the given cursor (position)
-      def nodes_at_cursor(params : LSP::TextDocumentPositionParams) : Array(Ast::Node)
-        workspace =
-          Mint::Workspace[params.path]
-
-        position =
-          params.position
-
-        workspace.ast.nodes
-          .select(&.input.file.==(params.path))
+      def nodes_at_cursor(path : String, position : LSP::Position) : Array(Ast::Node)
+        Mint::Workspace[path]
+          .ast
+          .nodes
+          .select(&.input.file.==(path))
           .select!(&.location.contains?(position.line + 1, position.character))
+      end
+
+      def nodes_at_cursor(params : LSP::TextDocumentPositionParams) : Array(Ast::Node)
+        nodes_at_cursor(params.path, params.position)
+      end
+
+      def nodes_at_cursor(params : LSP::CodeActionParams) : Array(Ast::Node)
+        nodes_at_cursor(params.text_document.path, params.range.start)
       end
     end
   end

--- a/src/lsp/protocol/code_action.cr
+++ b/src/lsp/protocol/code_action.cr
@@ -1,0 +1,85 @@
+module LSP
+  #  Code Action options.
+  struct CodeAction
+    include JSON::Serializable
+
+    # A struct for the disabled field to keep the comments from the
+    # specification.
+    struct Disabled
+      include JSON::Serializable
+
+      # Human readable description of why the code action is currently
+      # disabled.
+      #
+      # This is displayed in the code actions UI.
+      property reason : String
+    end
+
+    # A short, human-readable, title for this code action.
+    property title : String
+
+    # The kind of the code action.
+    #
+    # Used to filter code actions.
+    property kind : String?
+
+    # The diagnostics that this code action resolves.
+    property diagnostics : Array(Diagnostic)?
+
+    # Marks this as a preferred action. Preferred actions are used by the
+    # `auto fix` command and can be targeted by keybindings.
+    #
+    # A quick fix should be marked preferred if it properly addresses the
+    # underlying error. A refactoring should be marked preferred if it is the
+    # most reasonable choice of actions to take.
+    #
+    # @since 3.15.0
+    @[JSON::Field(key: "isPreferred")]
+    property is_preferred : Bool?
+
+    # Marks that the code action cannot currently be applied.
+    #
+    # Clients should follow the following guidelines regarding disabled code
+    # actions:
+    #
+    # - Disabled code actions are not shown in automatic lightbulbs code
+    #   action menus.
+    #
+    # - Disabled actions are shown as faded out in the code action menu when
+    #   the user request a more specific type of code action, such as
+    #   refactorings.
+    #
+    # - If the user has a keybinding that auto applies a code action and only
+    #   a disabled code actions are returned, the client should show the user
+    #   an error message with `reason` in the editor.
+    #
+    # @since 3.16.0
+    property disabled : Disabled?
+
+    # The workspace edit this code action performs.
+    property edit : WorkspaceEdit?
+
+    # A command this code action executes. If a code action
+    # provides an edit and a command, first the edit is
+    # executed and then the command.
+    property command : Command?
+
+    # A data entry field that is preserved on a code action between
+    # a `textDocument/codeAction` and a `codeAction/resolve` request.
+    #
+    # @since 3.16.0
+    property data : String?
+
+    def initialize(
+      @title,
+      @kind,
+      @edit,
+      @diagnostics = [] of Diagnostic,
+      @is_preferred = false,
+      @disabled = nil,
+      @command = nil,
+      @data = nil
+    )
+    end
+  end
+end

--- a/src/lsp/protocol/code_action_context.cr
+++ b/src/lsp/protocol/code_action_context.cr
@@ -1,0 +1,23 @@
+module LSP
+  class CodeActionContext
+    include JSON::Serializable
+
+    # An array of diagnostics known on the client side overlapping the range
+    # provided to the `textDocument/codeAction` request. They are provided so
+    # that the server knows which errors are currently presented to the user
+    # for the given range. There is no guarantee that these accurately reflect
+    # the error state of the resource. The primary parameter
+    # to compute code actions is the provided range.
+    property diagnostics : Array(Diagnostic)
+
+    # Requested kind of actions to return.
+    #
+    # Actions not of this kind are filtered out by the client before being
+    # shown. So servers can omit computing them.
+    property only : Array(String)?
+
+    # The reason why code actions were requested.
+    @[JSON::Field(key: "triggerKind", converter: Enum::ValueConverter(LSP::CodeActionTriggerKind))]
+    property trigger_kind : CodeActionTriggerKind?
+  end
+end

--- a/src/lsp/protocol/code_action_params.cr
+++ b/src/lsp/protocol/code_action_params.cr
@@ -1,0 +1,15 @@
+module LSP
+  class CodeActionParams
+    include JSON::Serializable
+
+    # The document in which the command was invoked.
+    @[JSON::Field(key: "textDocument")]
+    property text_document : TextDocumentIdentifier
+
+    # Context carrying additional information.
+    property context : CodeActionContext
+
+    # The range for which the command was invoked.
+    property range : Range
+  end
+end

--- a/src/lsp/protocol/code_action_trigger_kind.cr
+++ b/src/lsp/protocol/code_action_trigger_kind.cr
@@ -1,0 +1,12 @@
+module LSP
+  enum CodeActionTriggerKind
+    # Code actions were explicitly requested by the user or by an extension.
+    Invoked = 1
+
+    # Code actions were requested automatically.
+    #
+    # This typically happens when current selection in a file changes, but can
+    # also be triggered when file content changes.
+    Automatic = 2
+  end
+end

--- a/src/lsp/protocol/code_description.cr
+++ b/src/lsp/protocol/code_description.cr
@@ -1,0 +1,8 @@
+module LSP
+  struct CodeDescription
+    include JSON::Serializable
+
+    # An URI to open with more information about the diagnostic error.
+    property uri : String
+  end
+end

--- a/src/lsp/protocol/command.cr
+++ b/src/lsp/protocol/command.cr
@@ -1,0 +1,15 @@
+module LSP
+  struct Command
+    include JSON::Serializable
+
+    # Title of the command, like `save`.
+    property title : String
+
+    # The identifier of the actual command handler.
+    property command : String
+
+    # Arguments that the command handler should be
+    # invoked with.
+    property arguments : Array(String)?
+  end
+end

--- a/src/lsp/protocol/diagnostic.cr
+++ b/src/lsp/protocol/diagnostic.cr
@@ -1,0 +1,46 @@
+module LSP
+  struct Diagnostic
+    include JSON::Serializable
+
+    # The range at which the message applies.
+    property range : Range
+
+    # The diagnostic's severity. Can be omitted. If omitted it is up to the
+    # client to interpret diagnostics as error, warning, info or hint.
+    @[JSON::Field(converter: Enum::ValueConverter(LSP::DiagnosticSeverity))]
+    property severity : DiagnosticSeverity?
+
+    # The diagnostic's code, which might appear in the user interface.
+    property code : Int32 | String
+
+    # An optional property to describe the error code.
+    #
+    # @since 3.16.0
+    @[JSON::Field(key: "codeDescription")]
+    property code_description : CodeDescription?
+
+    # A human-readable string describing the source of this
+    # diagnostic, e.g. 'typescript' or 'super lint'.
+    property source : String?
+
+    # The diagnostic's message.
+    property message : String?
+
+    # Additional metadata about the diagnostic.
+    #
+    # @since 3.15.0
+    property tags : Array(DiagnosticTag)?
+
+    # An array of related diagnostic information, e.g. when symbol-names within
+    # a scope collide all definitions can be marked via this property.
+    @[JSON::Field(key: "relatedInformation")]
+    property related_information : Array(DiagnosticRelatedInformation)?
+
+    # A data entry field that is preserved between a
+    # `textDocument/publishDiagnostics` notification and
+    # `textDocument/codeAction` request.
+    #
+    # @since 3.16.0
+    property data : String?
+  end
+end

--- a/src/lsp/protocol/diagnostic_related_information.cr
+++ b/src/lsp/protocol/diagnostic_related_information.cr
@@ -1,0 +1,11 @@
+module LSP
+  struct DiagnosticRelatedInformation
+    include JSON::Serializable
+
+    # The location of this related diagnostic information.
+    property location : Location
+
+    # The message of this related diagnostic information.
+    property message : String
+  end
+end

--- a/src/lsp/protocol/diagnostic_severity.cr
+++ b/src/lsp/protocol/diagnostic_severity.cr
@@ -1,0 +1,15 @@
+module LSP
+  enum DiagnosticSeverity
+    # Reports an error.
+    Error = 1
+
+    # Reports a warning.
+    Warning = 2
+
+    # Reports an information.
+    Information = 3
+
+    # Reports a hint.
+    Hint = 4
+  end
+end

--- a/src/lsp/protocol/diagnostic_tag.cr
+++ b/src/lsp/protocol/diagnostic_tag.cr
@@ -1,0 +1,14 @@
+module LSP
+  enum DiagnosticTag
+    # Unused or unnecessary code.
+    #
+    # Clients are allowed to render diagnostics with this tag faded out
+    # instead of having an error squiggle.
+    Unnecessary = 1
+
+    # Deprecated or obsolete code.
+    #
+    # Clients are allowed to rendered diagnostics with this tag strike through.
+    Deprecated = 2
+  end
+end

--- a/src/lsp/protocol/location.cr
+++ b/src/lsp/protocol/location.cr
@@ -1,0 +1,8 @@
+module LSP
+  struct Location
+    include JSON::Serializable
+
+    property range : Range
+    property uri : String
+  end
+end

--- a/src/lsp/protocol/text_document_identifier.cr
+++ b/src/lsp/protocol/text_document_identifier.cr
@@ -4,5 +4,10 @@ module LSP
 
     # The text document's URI.
     property uri : String
+
+    # Returns the path of the URI
+    def path
+      URI.parse(uri).try(&.path).to_s
+    end
   end
 end

--- a/src/lsp/protocol/text_document_position_params.cr
+++ b/src/lsp/protocol/text_document_position_params.cr
@@ -11,16 +11,10 @@ module LSP
 
     # Non part of the specification.
     @[JSON::Field(ignore: true)]
-    @uri : URI?
-
-    # Parses the URI
-    def uri
-      @uri ||= URI.parse(text_document.uri)
-    end
 
     # Returns the path of the URI
     def path
-      uri.try(&.path).to_s
+      text_document.path
     end
   end
 end


### PR DESCRIPTION
This pull request adds the framework for handling [code actions] in the language server and a code action to reorder the entities (constants and functions) in a module. I added this first because I'm going through the core library and didn't want to manually reorder them :joy: 