### PR TITLE
Parser: avoid string allocations in some cases to improve performance

### DIFF
--- a/src/parser.cr
+++ b/src/parser.cr
@@ -140,14 +140,14 @@ module Mint
     end
 
     def keyword_ahead(word) : Bool
-      result = input[position, word.size].join
-      result == word
+      word.each_char_with_index do |char, i|
+        return false unless input[position + i]? == char
+      end
+      true
     end
 
     def keyword(word) : Bool
-      result = input[position, word.size].join
-
-      if result == word
+      if keyword_ahead(word)
         @position += word.size
         true
       else

--- a/src/parsers/expression.cr
+++ b/src/parsers/expression.cr
@@ -5,22 +5,19 @@ module Mint
     end
 
     def array_access_or_call(lhs)
-      case input[position, 2].join
-      when "&."
+      case {char, next_char}
+      when {'&', '.'}
         access(lhs, safe: true)
-      when "&("
+      when {'&', '('}
         call(lhs, safe: true)
+      when {'.', _}
+        access(lhs)
+      when {'(', _}
+        call(lhs)
+      when {'[', _}
+        array_access(lhs)
       else
-        case char
-        when '.'
-          access(lhs)
-        when '('
-          call(lhs)
-        when '['
-          array_access(lhs)
-        else
-          lhs
-        end
+        lhs
       end
     end
 


### PR DESCRIPTION
Hi!

Congratulations on [Mint now being a language recognized by GitHub](https://twitter.com/mint_lang/status/1496368756011974656?s=20&t=-wjyxOpSrkprdifRCZf1ZQ)! 🎉 

To celebrate, because Mint is written in Crystal, I decided to do a small contribution with the only thing I know to do: optimize things 😅 

This PR avoids doing `input[position, ...].join` in a couple of places where this can be avoided. When you do that it will involve two memory allocations: one for the intermediate array, and another one for the string. Instead of that, we can just iterate over the `input` array and check if it matches what we want.

Here's the benchmark I used. I created a "foo.cr" at the root with these contents:

```crystal
require "./src/all"
require "benchmark"

filename = "./core/source/Provider/ElementSize.mint"
source = File.read(filename)
Benchmark.ips do |x|
  x.report("parse") do
    Mint::Parser.parse(source, filename)
  end
end
```

Then I ran it like this:

```
crystal run --release foo.cr
```

The output before this PR is:

```
parse   2.39k (417.57µs) (±10.04%)  598kB/op  fastest
```

The output with this PR is:

```
parse   8.55k (117.00µs) (± 4.06%)  83.9kB/op  fastest
```

So about 4 times faster, and consuming about 7 times less memory.

Some final notes:
- The parser is already pretty fast before this PR (it takes **microseconds** to parse files) so I don't think this optimization will have a visible effect, though maybe it does when a lot of files will need to be parsed. With less memory consumed it also means the GC will have to do less work, so maybe things will be overall faster.
- It's totally fine to close this PR if you don't like the final code. The code before this PR is extremely clear (everywhere! I'm impressed about the level of clarity. I'm actually a bit jealous, I wish I could write code like that... 😊 ) and this change makes it slightly less clear.
- If it's also fine with you, I could look for optimization opportunities in the compiler, or somewhere else. I read on the main github page that Mint's goal is to be able to compile fast, so maybe making it faster while retaining overall code clarity will be good. 