### PR TITLE
Update dependencies

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,11 +6,11 @@ shards:
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.0.0
+    version: 1.0.1
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
-    version: 1.2.1
+    version: 1.2.2
 
   baked_file_system:
     git: https://github.com/schovi/baked_file_system.git

--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,11 @@ version: 2.0
 shards:
   admiral:
     git: https://github.com/jwaldrip/admiral.cr.git
-    version: 1.11.5
+    version: 1.12.1
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.0.1
+    version: 1.2.0
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
@@ -22,15 +22,15 @@ shards:
 
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
-    version: 0.2.2
+    version: 0.3.0
 
   kemal:
     git: https://github.com/kemalcr/kemal.git
-    version: 1.1.2
+    version: 1.3.0
 
   markd:
     git: https://github.com/icyleaf/markd.git
-    version: 0.4.2
+    version: 0.5.0
 
   radix:
     git: https://github.com/luislavena/radix.git

--- a/shard.yml
+++ b/shard.yml
@@ -10,21 +10,21 @@ dependencies:
     version: ~> 0.10.0
   kemal:
     github: kemalcr/kemal
-    version: ~> 1.1.0
+    version: ~> 1.3.0
   admiral:
     github: jwaldrip/admiral.cr
-    version: ~> 1.11.2
+    version: ~> 1.12.1
   dotenv:
     github: gdotdesign/cr-dotenv
     version: ~> 1.0.0
   markd:
     github: icyleaf/markd
-    version: ~> 0.4.0
+    version: ~> 0.5.0
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.0.0
+    version: ~> 1.2.0
 
 targets:
   mint:


### PR DESCRIPTION
Almost all dependencies are outdated. This patch updates all of them to their latest releases.

This removes a compiler warning from old kemal version which is fixed in the newest release.

I'd suggest loosening the version restrictions a bit to allow minor release progressions as well. That should work fine with these shards. But for now I kept the strong version pinning.