### PR TITLE
Convert type_id from String to a node

### DIFF
--- a/src/ast.cr
+++ b/src/ast.cr
@@ -47,7 +47,7 @@ module Mint
     end
 
     def main : Component?
-      @components.find(&.name.==("Main"))
+      @components.find(&.name.value.==("Main"))
     end
 
     def self.space_separated?(node1, node2)
@@ -92,13 +92,15 @@ module Mint
     def normalize
       @unified_modules =
         @modules
-          .group_by(&.name)
-          .map do |name, modules|
+          .group_by(&.name.value)
+          .map do |_, modules|
             Module.new(
               functions: modules.flat_map(&.functions),
               constants: modules.flat_map(&.constants),
               input: Data.new(input: "", file: ""),
-              name: name,
+              # TODO: We may need to store each modules name node for 
+              # future features, but for now we just store the first
+              name: modules.first.name,
               comments: [] of Comment,
               comment: nil,
               from: 0,

--- a/src/ast.cr
+++ b/src/ast.cr
@@ -98,7 +98,7 @@ module Mint
               functions: modules.flat_map(&.functions),
               constants: modules.flat_map(&.constants),
               input: Data.new(input: "", file: ""),
-              # TODO: We may need to store each modules name node for 
+              # TODO: We may need to store each modules name node for
               # future features, but for now we just store the first
               name: modules.first.name,
               comments: [] of Comment,

--- a/src/ast/component.cr
+++ b/src/ast/component.cr
@@ -17,7 +17,7 @@ module Mint
                      @gets : Array(Get),
                      @uses : Array(Use),
                      @global : Bool,
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/connect.cr
+++ b/src/ast/connect.cr
@@ -4,7 +4,7 @@ module Mint
       getter keys, store
 
       def initialize(@keys : Array(ConnectVariable),
-                     @store : String,
+                     @store : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/directives/documentation.cr
+++ b/src/ast/directives/documentation.cr
@@ -4,7 +4,7 @@ module Mint
       class Documentation < Node
         getter entity
 
-        def initialize(@entity : String,
+        def initialize(@entity : TypeId,
                        @input : Data,
                        @from : Int32,
                        @to : Int32)

--- a/src/ast/enum.cr
+++ b/src/ast/enum.cr
@@ -7,7 +7,7 @@ module Mint
                      @options : Array(EnumOption),
                      @comments : Array(Comment),
                      @comment : Comment?,
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/enum_destructuring.cr
+++ b/src/ast/enum_destructuring.cr
@@ -4,8 +4,8 @@ module Mint
       getter name, option, parameters
 
       def initialize(@parameters : Array(Node),
-                     @option : String,
-                     @name : String?,
+                     @option : TypeId,
+                     @name : TypeId?,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/enum_id.cr
+++ b/src/ast/enum_id.cr
@@ -4,8 +4,8 @@ module Mint
       getter option, name, expressions
 
       def initialize(@expressions : Array(Expression),
-                     @option : String,
-                     @name : String?,
+                     @option : TypeId,
+                     @name : TypeId?,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/enum_option.cr
+++ b/src/ast/enum_option.cr
@@ -5,7 +5,7 @@ module Mint
 
       def initialize(@parameters : Array(Node),
                      @comment : Comment?,
-                     @value : String,
+                     @value : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/html_component.cr
+++ b/src/ast/html_component.cr
@@ -7,7 +7,7 @@ module Mint
                      @comments : Array(Comment),
                      @children : Array(Node),
                      @ref : Variable?,
-                     @component : Variable,
+                     @component : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/module.cr
+++ b/src/ast/module.cr
@@ -7,7 +7,7 @@ module Mint
                      @constants : Array(Constant),
                      @comments : Array(Comment),
                      @comment : Comment?,
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/module_access.cr
+++ b/src/ast/module_access.cr
@@ -5,7 +5,7 @@ module Mint
       getter? constant
 
       def initialize(@variable : Variable,
-                     @name : String,
+                     @name : TypeId,
                      @from : Int32,
                      @input : Data,
                      @to : Int32,

--- a/src/ast/provider.cr
+++ b/src/ast/provider.cr
@@ -8,10 +8,10 @@ module Mint
                      @constants : Array(Constant),
                      @comments : Array(Comment),
                      @states : Array(State),
-                     @subscription : String,
+                     @subscription : TypeId,
                      @comment : Comment?,
                      @gets : Array(Get),
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/record_definition.cr
+++ b/src/ast/record_definition.cr
@@ -6,7 +6,7 @@ module Mint
       def initialize(@fields : Array(RecordDefinitionField),
                      @block_comment : Comment?,
                      @comment : Comment?,
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/store.cr
+++ b/src/ast/store.cr
@@ -9,7 +9,7 @@ module Mint
                      @states : Array(State),
                      @comment : Comment?,
                      @gets : Array(Get),
-                     @name : String,
+                     @name : TypeId,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/type_id.cr
+++ b/src/ast/type_id.cr
@@ -1,10 +1,9 @@
 module Mint
   class Ast
-    class Type < Node
-      getter name, parameters
+    class TypeId < Node
+      getter value
 
-      def initialize(@parameters : Array(TypeOrVariable),
-                     @name : TypeId,
+      def initialize(@value : String,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/ast/use.cr
+++ b/src/ast/use.cr
@@ -4,7 +4,7 @@ module Mint
       getter data, provider, condition
 
       def initialize(@condition : Expression?,
-                     @provider : String,
+                     @provider : TypeId,
                      @data : Record,
                      @input : Data,
                      @from : Int32,

--- a/src/compilers/component.cr
+++ b/src/compilers/component.cr
@@ -110,7 +110,7 @@ module Mint
 
     def compile_component_store_data(node : Ast::Component) : Array(String)
       node.connects.reduce(%w[]) do |memo, item|
-        store = ast.stores.find(&.name.==(item.store))
+        store = ast.stores.find(&.name.value.==(item.store.value))
 
         if store
           item.keys.map do |key|
@@ -145,7 +145,7 @@ module Mint
 
       node.connects.each do |item|
         store =
-          ast.stores.find(&.name.==(item.store))
+          ast.stores.find(&.name.value.==(item.store.value))
 
         if store
           name =

--- a/src/compilers/style.cr
+++ b/src/compilers/style.cr
@@ -11,7 +11,7 @@ module Mint
     end
 
     def _compile(node : Ast::Style, component : Ast::Component) : Nil
-      style_builder.process(node, component.name.gsub('.', '·'))
+      style_builder.process(node, component.name.value.gsub('.', '·'))
     end
   end
 end

--- a/src/compilers/top_level.cr
+++ b/src/compilers/top_level.cr
@@ -25,7 +25,7 @@ module Mint
         new(artifacts, **options)
 
       main =
-        compiler.ast.components.find(&.name.==("Main")).try do |component|
+        compiler.ast.components.find(&.name.value.==("Main")).try do |component|
           globals =
             compiler
               .ast
@@ -55,7 +55,7 @@ module Mint
         new(artifacts, **options)
 
       main =
-        compiler.ast.components.find(&.name.==("Main")).try do |component|
+        compiler.ast.components.find(&.name.value.==("Main")).try do |component|
           globals =
             compiler
               .ast
@@ -147,19 +147,19 @@ module Mint
     # --------------------------------------------------------------------------
 
     def maybe
-      ast.enums.find!(&.name.==("Maybe"))
+      ast.enums.find!(&.name.value.==("Maybe"))
     end
 
     def just
       node =
-        maybe.options.find!(&.value.==("Just"))
+        maybe.options.find!(&.value.value.==("Just"))
 
       js.class_of(node)
     end
 
     def nothing
       node =
-        maybe.options.find!(&.value.==("Nothing"))
+        maybe.options.find!(&.value.value.==("Nothing"))
 
       js.class_of(node)
     end
@@ -167,19 +167,19 @@ module Mint
     # --------------------------------------------------------------------------
 
     def result
-      ast.enums.find!(&.name.==("Result"))
+      ast.enums.find!(&.name.value.==("Result"))
     end
 
     def ok
       node =
-        result.options.find!(&.value.==("Ok"))
+        result.options.find!(&.value.value.==("Ok"))
 
       js.class_of(node)
     end
 
     def err
       node =
-        result.options.find!(&.value.==("Err"))
+        result.options.find!(&.value.value.==("Err"))
 
       js.class_of(node)
     end
@@ -187,7 +187,7 @@ module Mint
     def compiled_web_components
       @web_components.compact_map do |component, tagname|
         node =
-          ast.components.find(&.name.==(component))
+          ast.components.find(&.name.value.==(component))
 
         next unless node
 
@@ -213,7 +213,7 @@ module Mint
     # Wraps the application with the runtime
     def wrap_runtime(body, main = "")
       html_event_module =
-        ast.unified_modules.find!(&.name.==("Html.Event"))
+        ast.unified_modules.find!(&.name.value.==("Html.Event"))
 
       from_event =
         html_event_module.functions.find!(&.name.value.==("fromEvent"))

--- a/src/compilers/variable.cr
+++ b/src/compilers/variable.cr
@@ -13,7 +13,7 @@ module Mint
       case parent
       when Ast::Component
         parent.connects.each do |connect|
-          store = ast.stores.find(&.name.==(connect.store))
+          store = ast.stores.find(&.name.value.==(connect.store.value))
 
           name =
             case entity

--- a/src/documentation_generator.cr
+++ b/src/documentation_generator.cr
@@ -42,27 +42,27 @@ module Mint
         end
 
         json.field "components" do
-          generate ast.components.sort_by(&.name), json
+          generate ast.components.sort_by(&.name.value), json
         end
 
         json.field "stores" do
-          generate ast.stores.sort_by(&.name), json
+          generate ast.stores.sort_by(&.name.value), json
         end
 
         json.field "modules" do
-          generate ast.unified_modules.sort_by(&.name), json
+          generate ast.unified_modules.sort_by(&.name.value), json
         end
 
         json.field "providers" do
-          generate ast.providers.sort_by(&.name), json
+          generate ast.providers.sort_by(&.name.value), json
         end
 
         json.field "records" do
-          generate ast.records.sort_by(&.name), json
+          generate ast.records.sort_by(&.name.value), json
         end
 
         json.field "enums" do
-          generate ast.enums.sort_by(&.name), json
+          generate ast.enums.sort_by(&.name.value), json
         end
       end
     end

--- a/src/documentation_generator/component.cr
+++ b/src/documentation_generator/component.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::Component, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "name", node.name
+        json.field "name" do
+          generate node.name, json
+        end
 
         json.field "connects" do
           generate node.connects, json

--- a/src/documentation_generator/connect.cr
+++ b/src/documentation_generator/connect.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::Connect, json : JSON::Builder)
       json.object do
         json.field "keys", node.keys.map(&.variable.value)
-        json.field "store", node.store
+        json.field "store" do
+          generate node.store, json
+        end
       end
     end
   end

--- a/src/documentation_generator/enum.cr
+++ b/src/documentation_generator/enum.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::Enum, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "name", node.name
+        json.field "name" do
+          generate node.name, json
+        end
 
         json.field "parameters" do
           generate node.parameters, json

--- a/src/documentation_generator/enum_option.cr
+++ b/src/documentation_generator/enum_option.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::EnumOption, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "name", node.value
+        json.field "name" do
+          generate node.value, json
+        end
 
         json.field "parameters" do
           generate node.parameters, json

--- a/src/documentation_generator/module.cr
+++ b/src/documentation_generator/module.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::Module, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "name", node.name
+        json.field "name" do
+          generate node.name, json
+        end
 
         json.field "functions" do
           generate node.functions, json

--- a/src/documentation_generator/provider.cr
+++ b/src/documentation_generator/provider.cr
@@ -3,8 +3,10 @@ module Mint
     def generate(node : Ast::Provider, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "subscription", node.subscription
-        json.field "name", node.name
+        json.field "subscription", node.subscription.value
+        json.field "name" do
+          generate node.name, json
+        end
 
         json.field "functions" do
           generate node.functions, json

--- a/src/documentation_generator/record_definition.cr
+++ b/src/documentation_generator/record_definition.cr
@@ -3,7 +3,9 @@ module Mint
     def generate(node : Ast::RecordDefinition, json : JSON::Builder)
       json.object do
         json.field "description", node.comment.try(&.to_html)
-        json.field "name", node.name
+        json.field "name" do
+          generate node.name, json
+        end
 
         json.field "fields" do
           generate node.fields, json

--- a/src/documentation_generator/store.cr
+++ b/src/documentation_generator/store.cr
@@ -2,7 +2,10 @@ module Mint
   class DocumentationGenerator
     def generate(node : Ast::Store, json : JSON::Builder)
       json.object do
-        json.field "name", node.name
+        json.field "name" do
+          generate node.name, json
+        end
+
         json.field "description", node.comment.try(&.to_html)
 
         json.field "states" do

--- a/src/documentation_generator/type.cr
+++ b/src/documentation_generator/type.cr
@@ -6,7 +6,7 @@ module Mint
           "(#{stringify(node.parameters)})"
         end
 
-      "#{node.name}#{parameters}"
+      "#{stringify node.name}#{parameters}"
     end
 
     def generate(node : Ast::Type, json : JSON::Builder)

--- a/src/documentation_generator/type_id.cr
+++ b/src/documentation_generator/type_id.cr
@@ -1,0 +1,11 @@
+module Mint
+  class DocumentationGenerator
+    def stringify(node : Ast::TypeId)
+      node.value
+    end
+
+    def generate(node : Ast::TypeId, json : JSON::Builder)
+      json.string stringify(node)
+    end
+  end
+end

--- a/src/documentation_generator/use.cr
+++ b/src/documentation_generator/use.cr
@@ -7,7 +7,9 @@ module Mint
         end
 
       json.object do
-        json.field "provider", node.provider
+        json.field "provider" do
+          generate node.provider, json
+        end
         json.field "data", source(node.data)
         json.field "condition", condition
       end

--- a/src/formatters/connect.cr
+++ b/src/formatters/connect.cr
@@ -18,9 +18,9 @@ module Mint
         end
 
       if should_break
-        "connect #{store} exposing {\n#{indent(keys)}\n}"
+        "connect #{format store} exposing {\n#{indent(keys)}\n}"
       else
-        "connect #{store} exposing { #{keys} }"
+        "connect #{format store} exposing { #{keys} }"
       end
     end
   end

--- a/src/formatters/directives/documentation.cr
+++ b/src/formatters/directives/documentation.cr
@@ -1,7 +1,7 @@
 module Mint
   class Formatter
     def format(node : Ast::Directives::Documentation)
-      "@documentation(#{node.entity})"
+      "@documentation(#{format node.entity})"
     end
   end
 end

--- a/src/formatters/enum_destructuring.cr
+++ b/src/formatters/enum_destructuring.cr
@@ -5,12 +5,12 @@ module Mint
         format node.parameters, ", "
 
       name =
-        "#{node.name}::" if node.name
+        "#{format node.name}::" if node.name
 
       if parameters.empty?
-        "#{name}#{node.option}"
+        "#{name}#{format node.option}"
       else
-        "#{name}#{node.option}(#{parameters})"
+        "#{name}#{format node.option}(#{parameters})"
       end
     end
   end

--- a/src/formatters/enum_id.cr
+++ b/src/formatters/enum_id.cr
@@ -12,9 +12,9 @@ module Mint
         end
 
       if node.name
-        "#{node.name}::#{node.option}#{expressions}"
+        "#{format node.name}::#{format node.option}#{expressions}"
       else
-        "#{node.option}#{expressions}"
+        "#{format node.option}#{expressions}"
       end
     end
   end

--- a/src/formatters/enum_option.cr
+++ b/src/formatters/enum_option.cr
@@ -7,7 +7,7 @@ module Mint
       parameters =
         format_parameters(node.parameters)
 
-      "#{comment}#{node.value}#{parameters}"
+      "#{comment}#{format node.value}#{parameters}"
     end
   end
 end

--- a/src/formatters/module.cr
+++ b/src/formatters/module.cr
@@ -12,7 +12,7 @@ module Mint
       comment =
         node.comment.try { |item| "#{format item}\n" }
 
-      "#{comment}module #{node.name} {\n#{indent(body)}\n}"
+      "#{comment}module #{format node.name} {\n#{indent(body)}\n}"
     end
   end
 end

--- a/src/formatters/module_access.cr
+++ b/src/formatters/module_access.cr
@@ -11,7 +11,7 @@ module Mint
           "."
         end
 
-      "#{node.name}#{separator}#{variable}"
+      "#{format node.name}#{separator}#{variable}"
     end
   end
 end

--- a/src/formatters/provider.cr
+++ b/src/formatters/provider.cr
@@ -13,7 +13,7 @@ module Mint
       comment =
         node.comment.try { |item| "#{format(item)}\n" }
 
-      "#{comment}provider #{name} : #{subscription} {\n#{indent(body)}\n}"
+      "#{comment}provider #{format name} : #{format subscription} {\n#{indent(body)}\n}"
     end
   end
 end

--- a/src/formatters/type.cr
+++ b/src/formatters/type.cr
@@ -5,9 +5,9 @@ module Mint
         format node.parameters, ", "
 
       if parameters.empty?
-        node.name
+        format node.name
       else
-        "#{node.name}(#{parameters})"
+        "#{format node.name}(#{parameters})"
       end
     end
   end

--- a/src/formatters/type_id.cr
+++ b/src/formatters/type_id.cr
@@ -1,0 +1,7 @@
+module Mint
+  class Formatter
+    def format(node : Ast::TypeId) : String
+      node.value
+    end
+  end
+end

--- a/src/formatters/use.cr
+++ b/src/formatters/use.cr
@@ -9,7 +9,7 @@ module Mint
           " when {\n#{indent(format(condition))}\n}"
       end
 
-      "use #{node.provider} #{data}#{condition}"
+      "use #{format node.provider} #{data}#{condition}"
     end
   end
 end

--- a/src/js.cr
+++ b/src/js.cr
@@ -174,7 +174,7 @@ module Mint
     end
 
     def display_name(name, real_name) : String
-      %(#{name}.displayName = "#{real_name}")
+      %(#{name}.displayName = "#{real_name.value}")
     end
 
     def object(hash : Hash(String, String)) : String

--- a/src/ls/completion_item/component.cr
+++ b/src/ls/completion_item/component.cr
@@ -45,32 +45,32 @@ module Mint
           case attributes.size
           when .> 3
             <<-MINT
-            <#{node.name}
+            <#{node.name.value}
               #{attributes.join("\n  ")}>
               $0
-            </#{node.name}>
+            </#{node.name.value}>
             MINT
           when .> 0
             <<-MINT
-            <#{node.name} #{attributes.join(" ")}>
+            <#{node.name.value} #{attributes.join(" ")}>
               $0
-            </#{node.name}>
+            </#{node.name.value}>
             MINT
           else
             <<-MINT
-            <#{node.name}>
+            <#{node.name.value}>
               $0
-            </#{node.name}>
+            </#{node.name.value}>
             MINT
           end
 
         LSP::CompletionItem.new(
           kind: LSP::CompletionItemKind::Snippet,
-          filter_text: node.name,
-          sort_text: node.name,
+          filter_text: node.name.value,
+          sort_text: node.name.value,
           insert_text: snippet,
           detail: "Component",
-          label: node.name)
+          label: node.name.value)
       end
     end
   end

--- a/src/ls/completion_item/constant.cr
+++ b/src/ls/completion_item/constant.cr
@@ -1,10 +1,10 @@
 module Mint
   module LS
     class Completion < LSP::RequestMessage
-      def completion_item(node : Ast::Constant, parent_name : String? = nil) : LSP::CompletionItem
+      def completion_item(node : Ast::Constant, parent_name : Ast::TypeId? = nil) : LSP::CompletionItem
         name =
           if parent_name
-            "#{parent_name}:#{node.name}"
+            "#{parent_name.value}:#{node.name}"
           else
             node.name
           end

--- a/src/ls/completion_item/function.cr
+++ b/src/ls/completion_item/function.cr
@@ -1,10 +1,10 @@
 module Mint
   module LS
     class Completion < LSP::RequestMessage
-      def completion_item(node : Ast::Function, parent_name : String? = nil) : LSP::CompletionItem
+      def completion_item(node : Ast::Function, parent_name : Ast::TypeId? = nil) : LSP::CompletionItem
         name =
           if parent_name
-            "#{parent_name}.#{node.name.value}"
+            "#{parent_name.value}.#{node.name.value}"
           else
             node.name.value
           end

--- a/src/ls/completion_item/get.cr
+++ b/src/ls/completion_item/get.cr
@@ -1,10 +1,10 @@
 module Mint
   module LS
     class Completion < LSP::RequestMessage
-      def completion_item(node : Ast::Get, parent_name : String? = nil) : LSP::CompletionItem
+      def completion_item(node : Ast::Get, parent_name : Ast::TypeId? = nil) : LSP::CompletionItem
         name =
           if parent_name
-            "#{parent_name}.#{node.name.value}"
+            "#{parent_name.value}.#{node.name.value}"
           else
             node.name.value
           end

--- a/src/ls/completions/enum.cr
+++ b/src/ls/completions/enum.cr
@@ -4,7 +4,7 @@ module Mint
       def completions(node : Ast::Enum) : Array(LSP::CompletionItem)
         node.options.map do |option|
           name =
-            "#{node.name}::#{option.value}"
+            "#{node.name.value}::#{option.value.value}"
 
           snippet =
             if option.parameters.empty?

--- a/src/ls/definition.cr
+++ b/src/ls/definition.cr
@@ -47,27 +47,7 @@ module Mint
         # Select only the name part of the component
         #   global component MintComponent {
         #                    ^^^^^^^^^^^^^
-
-        start_line, start_column = node.location.start
-
-        node.comment.try do |comment|
-          start_line, start_column = comment.location.end
-        end
-
-        # TODO: Change parser so component name is a node?
-        offset = if node.global?
-                   "global component ".size
-                 else
-                   "component ".size
-                 end
-
-        location = Ast::Node::Location.new(
-          filename: node.location.filename,
-          start: {start_line, start_column + offset},
-          end: {start_line, start_column + offset + node.name.size}
-        )
-
-        selection(location)
+        selection(node.name)
       end
 
       def selection(node : Ast::HtmlAttribute) : LSP::Range
@@ -117,9 +97,9 @@ module Mint
 
       def find_component(workspace : Workspace, name : String) : Ast::Component?
         # Do not include any core component
-        return if Core.ast.components.any?(&.name.== name)
+        return if Core.ast.components.any?(&.name.value.== name)
 
-        workspace.ast.components.find(&.name.== name)
+        workspace.ast.components.find(&.name.value.== name)
       end
 
       def has_link_support?(server : Server)

--- a/src/ls/definition/html_component.cr
+++ b/src/ls/definition/html_component.cr
@@ -3,14 +3,14 @@ module Mint
     class Definition < LSP::RequestMessage
       def html_component(server : Server, workspace : Workspace, stack : Array(Ast::Node))
         with_stack(stack) do |reader|
-          return unless variable = reader.find_next Ast::Variable
+          return unless type_id = reader.find_next Ast::TypeId
 
           return unless html_component = reader.find_next Ast::HtmlComponent
 
           return unless component =
                           find_component(workspace, html_component.component.value)
 
-          location_link server, variable, component
+          location_link server, type_id, component
         end
       end
     end

--- a/src/ls/hover.cr
+++ b/src/ls/hover.cr
@@ -60,8 +60,8 @@ module Mint
             case node
             when Ast::Variable, Ast::TypeId
               # If the first node under the cursor is a `Ast::Variable`
-              # or `LSP::TypeId`, then get the associated nodes 
-              # information and hover that otherwise get the hover 
+              # or `Ast::TypeId`, then get the associated nodes
+              # information and hover that otherwise get the hover
               # information of the parent.
               lookup =
                 workspace.type_checker.variables[node]?

--- a/src/ls/hover.cr
+++ b/src/ls/hover.cr
@@ -58,10 +58,11 @@ module Mint
             parent = stack[1]?
 
             case node
-            when Ast::Variable
-              # If the first node under the cursor is a variable then
-              # get the associated nodes information and hover that
-              # otherwise get the hover information of the parent.
+            when Ast::Variable, Ast::TypeId
+              # If the first node under the cursor is a `Ast::Variable`
+              # or `LSP::TypeId`, then get the associated nodes 
+              # information and hover that otherwise get the hover 
+              # information of the parent.
               lookup =
                 workspace.type_checker.variables[node]?
 

--- a/src/ls/hover/enum.cr
+++ b/src/ls/hover/enum.cr
@@ -13,11 +13,11 @@ module Mint
             params =
               workspace.formatter.format_parameters(option.parameters)
 
-            "**#{option.value}#{params}**#{comment}"
+            "**#{option.value.value}#{params}**#{comment}"
           end
 
         ([
-          "**#{node.name}#{parameters}**\n",
+          "**#{node.name.value}#{parameters}**\n",
           node.comment.try(&.value.strip.+("\n")),
         ] + options).compact
       end

--- a/src/ls/hover/enum_id.cr
+++ b/src/ls/hover/enum_id.cr
@@ -3,7 +3,7 @@ module Mint
     class Hover < LSP::RequestMessage
       def hover(node : Ast::EnumId, workspace) : Array(String)
         item =
-          workspace.ast.enums.find(&.name.==(node.name))
+          workspace.ast.enums.find(&.name.value.==(node.name.try(&.value)))
 
         hover(item, workspace)
       end

--- a/src/ls/hover/function.cr
+++ b/src/ls/hover/function.cr
@@ -11,13 +11,13 @@ module Mint
         name =
           case entity
           when Ast::Component
-            entity.name
+            entity.name.value
           when Ast::Provider
-            entity.name
+            entity.name.value
           when Ast::Store
-            entity.name
+            entity.name.value
           when Ast::Module
-            entity.name
+            entity.name.value
           end
 
         arguments =

--- a/src/ls/hover/get.cr
+++ b/src/ls/hover/get.cr
@@ -9,9 +9,9 @@ module Mint
         name =
           case entity
           when Ast::Component
-            entity.name
+            entity.name.value
           when Ast::Store
-            entity.name
+            entity.name.value
           end
 
         type =

--- a/src/ls/hover/html_component.cr
+++ b/src/ls/hover/html_component.cr
@@ -13,7 +13,7 @@ module Mint
           end
 
         ([
-          "**#{node.name}**\n",
+          "**#{node.name.value}**\n",
           node.comment.try(&.value.strip),
           properties_title,
         ] + properties).compact

--- a/src/ls/hover/type.cr
+++ b/src/ls/hover/type.cr
@@ -6,7 +6,7 @@ module Mint
           workspace
             .ast
             .enums
-            .find(&.name.==(node.name))
+            .find(&.name.value.==(node.name.value))
 
         if enum_node
           hover(enum_node, workspace)
@@ -15,7 +15,7 @@ module Mint
             workspace
               .type_checker
               .records
-              .find(&.name.==(node.name))
+              .find(&.name.==(node.name.value))
               .try(&.to_pretty)
 
           type =

--- a/src/parsers/html_body.cr
+++ b/src/parsers/html_body.cr
@@ -38,9 +38,7 @@ module Mint
 
         closing_tag =
           case tag
-          when Ast::Variable
-            tag.value
-          when Ast::TypeId
+          when Ast::Variable, Ast::TypeId
             tag.value
           else
             tag

--- a/src/parsers/html_body.cr
+++ b/src/parsers/html_body.cr
@@ -17,7 +17,7 @@ module Mint
 
     def html_body(expected_closing_bracket : SyntaxError.class,
                   expected_closing_tag : SyntaxError.class,
-                  tag : Ast::Variable,
+                  tag : Ast::Variable | Ast::TypeId,
                   with_dashes : Bool)
       whitespace
       attributes = many { html_attribute(with_dashes) }
@@ -39,6 +39,8 @@ module Mint
         closing_tag =
           case tag
           when Ast::Variable
+            tag.value
+          when Ast::TypeId
             tag.value
           else
             tag

--- a/src/parsers/html_component.cr
+++ b/src/parsers/html_component.cr
@@ -7,15 +7,9 @@ module Mint
 
     def html_component : Ast::HtmlComponent?
       start do |start_position|
-        component = start do |start_pos|
+        component = start do
           next unless char! '<'
-          next unless value = type_id HtmlComponentExpectedType
-
-          Ast::Variable.new(
-            from: start_pos + 1,
-            to: position,
-            value: value,
-            input: data)
+          type_id HtmlComponentExpectedType
         end
 
         next unless component

--- a/src/parsers/type_id.cr
+++ b/src/parsers/type_id.cr
@@ -1,48 +1,61 @@
 module Mint
   class Parser
-    def type_id!(error : SyntaxError.class) : String
-      name = gather do
-        char(error, &.ascii_uppercase?)
-        letters_numbers_or_underscore
-      end
-
-      raise error unless name
-
-      if char! '.'
-        name += ".#{type_id! error}"
-      end
-
-      name
-    end
-
-    def type_id : String?
-      name = gather do
-        return unless char.ascii_uppercase?
-        step
-        letters_numbers_or_underscore
-      end
-
-      return unless name
-
-      start do
-        if char == '.'
-          other = start do
-            step
-            next_part = type_id
-            next unless next_part
-            next_part
-          end
-
-          next unless other
-
-          name += ".#{other}"
+    def type_id!(error : SyntaxError.class) : Ast::TypeId
+      start do |start_position|
+        value = gather do
+          char(error, &.ascii_uppercase?)
+          letters_numbers_or_underscore
         end
-      end
 
-      name
+        raise error unless value
+
+        if char! '.'
+          other = type_id! error
+          value += ".#{other.value}"
+        end
+
+        Ast::TypeId.new(
+          from: start_position,
+          value: value,
+          to: position,
+          input: data)
+      end
     end
 
-    def type_id(error : SyntaxError.class) : String?
+    def type_id : Ast::TypeId?
+      start do |start_position|
+        value = gather do
+          return unless char.ascii_uppercase?
+          step
+          letters_numbers_or_underscore
+        end
+
+        return unless value
+
+        start do
+          if char == '.'
+            other = start do
+              step
+              next_part = type_id
+              next unless next_part
+              next_part
+            end
+
+            next unless other
+
+            value += ".#{other.value}"
+          end
+        end
+
+        Ast::TypeId.new(
+          from: start_position,
+          value: value,
+          to: position,
+          input: data)
+      end
+    end
+
+    def type_id(error : SyntaxError.class) : Ast::TypeId?
       return unless char.ascii_uppercase?
       type_id! error
     end

--- a/src/type_checker.cr
+++ b/src/type_checker.cr
@@ -143,7 +143,7 @@ module Mint
 
     def resolve_record_definition(name)
       records.find(&.name.==(name)) || begin
-        node = ast.records.find(&.name.==(name))
+        node = ast.records.find(&.name.value.==(name))
 
         if node
           record = check(node)

--- a/src/type_checker/scope.cr
+++ b/src/type_checker/scope.cr
@@ -69,7 +69,7 @@ module Mint
            Ast::Store,
            Ast::Module,
            Ast::Provider
-          node.name
+          node.name.value
         in Ast::InlineFunction,
            Ast::Function,
            Ast::Style
@@ -175,8 +175,8 @@ module Mint
 
       def find(variable : String, node : Ast::Provider)
         if variable == "subscriptions"
-          type = @records.find(&.name.==(node.subscription)) ||
-                 Comparer.normalize(Type.new(node.subscription))
+          type = @records.find(&.name.==(node.subscription.value)) ||
+                 Comparer.normalize(Type.new(node.subscription.value))
           Type.new("Array", [type.as(Checkable)])
         else
           node.functions.find(&.name.value.==(variable)) ||
@@ -255,7 +255,7 @@ module Mint
           when Ast::HtmlComponent
             @ast
               .components
-              .find(&.name.==(item.component.value))
+              .find(&.name.value.==(item.component.value))
               .try do |entity|
                 memo[variable.value] = entity
               end
@@ -271,7 +271,7 @@ module Mint
         component.connects.reduce({} of String => Ast::State) do |memo, item|
           @ast
             .stores
-            .find(&.name.==(item.store))
+            .find(&.name.value.==(item.store.value))
             .try do |store|
               item.keys.each do |key|
                 store
@@ -291,7 +291,7 @@ module Mint
         component.connects.reduce({} of String => Ast::Get) do |memo, item|
           @ast
             .stores
-            .find(&.name.==(item.store))
+            .find(&.name.value.==(item.store.value))
             .try do |store|
               item.keys.each do |key|
                 store
@@ -311,7 +311,7 @@ module Mint
         component.connects.reduce({} of String => Ast::Function) do |memo, item|
           @ast
             .stores
-            .find(&.name.==(item.store))
+            .find(&.name.value.==(item.store.value))
             .try do |store|
               item.keys.each do |key|
                 store
@@ -331,7 +331,7 @@ module Mint
         component.connects.reduce({} of String => Ast::Constant) do |memo, item|
           @ast
             .stores
-            .find(&.name.==(item.store))
+            .find(&.name.value.==(item.store.value))
             .try do |store|
               item.keys.each do |key|
                 store

--- a/src/type_checkers/access.cr
+++ b/src/type_checkers/access.cr
@@ -32,7 +32,7 @@ module Mint
             case ref
             when Ast::HtmlComponent
               component_records
-                .find(&.first.name.==(ref.component.value))
+                .find(&.first.name.value.==(ref.component.value))
                 .try do |entity|
                   memo[variable.value] = entity.first
                 end

--- a/src/type_checkers/case.cr
+++ b/src/type_checkers/case.cr
@@ -51,7 +51,7 @@ module Mint
       case condition
       when Type
         item =
-          ast.enums.find(&.name.==(condition.name))
+          ast.enums.find(&.name.value.==(condition.name))
 
         if item
           not_matched =
@@ -62,7 +62,7 @@ module Mint
                 .any? do |match|
                   case match
                   when Ast::EnumDestructuring
-                    match.option == option.value
+                    match.option.value == option.value.value
                   else
                     false
                   end
@@ -75,7 +75,7 @@ module Mint
 
           options =
             not_matched.map do |option|
-              "#{item.name}::#{formatter.replace_skipped(format(option))}"
+              "#{format item.name}::#{formatter.replace_skipped(format(option))}"
             end
 
           raise CaseEnumNotCovered, {

--- a/src/type_checkers/case_branch.cr
+++ b/src/type_checkers/case_branch.cr
@@ -81,10 +81,10 @@ module Mint
 
     private def destructuring_variables(item : Ast::EnumDestructuring, condition)
       entity =
-        ast.enums.find!(&.name.==(item.name))
+        ast.enums.find!(&.name.value.==(item.name.try &.value))
 
       option =
-        entity.options.find!(&.value.==(item.option))
+        entity.options.find!(&.value.value.==(item.option.value))
 
       case option_param = option.parameters[0]?
       when Ast::EnumRecordDefinition

--- a/src/type_checkers/component.cr
+++ b/src/type_checkers/component.cr
@@ -43,7 +43,7 @@ module Mint
         end
       end
 
-      Record.new(node.name, fields)
+      Record.new(node.name.value, fields)
     end
 
     # Check all nodes that were not checked before
@@ -60,7 +60,7 @@ module Mint
 
     def check(node : Ast::Component) : Checkable
       # Checking for global naming conflict
-      check_global_names node.name, node
+      check_global_names node.name.value, node
 
       # Checking for naming conflicts
       checked =
@@ -73,7 +73,7 @@ module Mint
 
       # Checking for properties in Main
 
-      if node.name == "Main" && (property = node.properties.first?)
+      if node.name.value == "Main" && (property = node.properties.first?)
         raise ComponentMainProperty, {
           "property_node" => property,
           "node"          => node,
@@ -114,7 +114,7 @@ module Mint
 
       # Checking for multiple connects to the same store
       node.connects.each do |connect|
-        other = (node.connects - [connect]).find(&.store.==(connect.store))
+        other = (node.connects - [connect]).find(&.store.value.==(connect.store.value))
 
         raise ComponentMultipleConnects, {
           "name"  => connect.store,
@@ -156,7 +156,7 @@ module Mint
 
       # Checking for multiple same uses of the same provider
       node.uses.each do |use|
-        other = (node.uses - [use]).find(&.provider.==(use.provider))
+        other = (node.uses - [use]).find(&.provider.value.==(use.provider.value))
 
         raise ComponentMultipleUses, {
           "name"  => use.provider,

--- a/src/type_checkers/connect.cr
+++ b/src/type_checkers/connect.cr
@@ -4,7 +4,7 @@ module Mint
     type_error ConnectNotFoundStore
 
     def check(node : Ast::Connect) : Checkable
-      store = ast.stores.find(&.name.==(node.store))
+      store = ast.stores.find(&.name.value.==(node.store.value))
 
       raise ConnectNotFoundStore, {
         "store" => node.store,

--- a/src/type_checkers/connect.cr
+++ b/src/type_checkers/connect.cr
@@ -7,7 +7,7 @@ module Mint
       store = ast.stores.find(&.name.value.==(node.store.value))
 
       raise ConnectNotFoundStore, {
-        "store" => node.store,
+        "store" => node.store.value,
         "node"  => node,
       } unless store
 
@@ -24,7 +24,7 @@ module Mint
 
         raise ConnectNotFoundMember, {
           "key"   => key_value,
-          "store" => node.store,
+          "store" => node.store.value,
           "node"  => node,
         } unless found
 

--- a/src/type_checkers/directives/documentation.cr
+++ b/src/type_checkers/directives/documentation.cr
@@ -7,7 +7,7 @@ module Mint
         ast.components.find(&.name.value.==(node.entity.value))
 
       raise DocumentationDirectiveEntityNotFound, {
-        "name" => node.entity,
+        "name" => node.entity.value,
         "node" => node,
       } unless component
 

--- a/src/type_checkers/directives/documentation.cr
+++ b/src/type_checkers/directives/documentation.cr
@@ -4,7 +4,7 @@ module Mint
 
     def check(node : Ast::Directives::Documentation) : Checkable
       component =
-        ast.components.find(&.name.==(node.entity))
+        ast.components.find(&.name.value.==(node.entity.value))
 
       raise DocumentationDirectiveEntityNotFound, {
         "name" => node.entity,

--- a/src/type_checkers/enum.cr
+++ b/src/type_checkers/enum.cr
@@ -4,7 +4,7 @@ module Mint
     type_error EnumUnusedParameter
 
     def check(node : Ast::Enum) : Checkable
-      check_global_types node.name, node
+      check_global_types node.name.value, node
 
       parameters =
         resolve node.parameters
@@ -22,7 +22,7 @@ module Mint
         } unless used_parameters.includes?(parameter)
       end
 
-      Type.new(node.name, parameters)
+      Type.new(node.name.value, parameters)
     end
 
     def check(parameters : Array(Ast::Node),

--- a/src/type_checkers/enum_destructuring.cr
+++ b/src/type_checkers/enum_destructuring.cr
@@ -6,7 +6,7 @@ module Mint
 
     def check(node : Ast::EnumDestructuring) : Checkable
       parent =
-        ast.enums.find(&.name.==(node.name))
+        ast.enums.find(&.name.value.==(node.name.try &.value))
 
       raise EnumDestructuringTypeMissing, {
         "name" => node.name,
@@ -14,7 +14,7 @@ module Mint
       } unless parent
 
       option =
-        parent.options.find(&.value.==(node.option))
+        parent.options.find(&.value.value.==(node.option.value))
 
       raise EnumDestructuringEnumMissing, {
         "parent_name" => parent.name,

--- a/src/type_checkers/enum_id.cr
+++ b/src/type_checkers/enum_id.cr
@@ -10,11 +10,11 @@ module Mint
     # - constants
     def check(node : Ast::EnumId) : Checkable
       parent =
-        ast.enums.find(&.name.==(node.name))
+        ast.enums.find(&.name.value.==(node.name.try &.value))
 
       if parent
         check(node, parent)
-      elsif parent = records.find(&.name.==(node.option))
+      elsif parent = records.find(&.name.==(node.option.value))
         check(node, parent)
       elsif node.name
         raise EnumIdTypeMissing, {
@@ -23,7 +23,7 @@ module Mint
         }
       else
         variable = Ast::Variable.new(
-          value: node.option,
+          value: node.option.value,
           input: node.input,
           from: node.from,
           to: node.to)
@@ -38,7 +38,7 @@ module Mint
         resolve parent
 
       option =
-        parent.options.find(&.value.==(node.option))
+        parent.options.find(&.value.value.==(node.option.value))
 
       raise EnumIdEnumMissing, {
         "parent_name" => parent.name,
@@ -54,7 +54,7 @@ module Mint
         resolve node.expressions
 
       resolved_type =
-        Type.new(node.option, parameters)
+        Type.new(node.option.value, parameters)
 
       unified =
         Comparer.compare_raw(option_type, resolved_type)

--- a/src/type_checkers/enum_id.cr
+++ b/src/type_checkers/enum_id.cr
@@ -16,9 +16,9 @@ module Mint
         check(node, parent)
       elsif parent = records.find(&.name.==(node.option.value))
         check(node, parent)
-      elsif node.name
+      elsif name = node.name
         raise EnumIdTypeMissing, {
-          "name" => node.name,
+          "name" => name.value,
           "node" => node,
         }
       else
@@ -41,8 +41,8 @@ module Mint
         parent.options.find(&.value.value.==(node.option.value))
 
       raise EnumIdEnumMissing, {
-        "parent_name" => parent.name,
-        "name"        => node.option,
+        "parent_name" => parent.name.value,
+        "name"        => node.option.value,
         "parent"      => parent,
         "node"        => node,
       } unless option

--- a/src/type_checkers/enum_option.cr
+++ b/src/type_checkers/enum_option.cr
@@ -4,7 +4,7 @@ module Mint
       parameters =
         resolve node.parameters
 
-      Type.new(node.value, parameters)
+      Type.new(node.value.value, parameters)
     end
   end
 end

--- a/src/type_checkers/html_attribute.cr
+++ b/src/type_checkers/html_attribute.cr
@@ -76,7 +76,7 @@ module Mint
         raise HtmlAttributeNotFoundComponentProperty, {
           "properties" => component.properties.map(&.name.value),
           "name"       => node.name.value,
-          "component"  => component.name,
+          "component"  => component.name.value,
           "node"       => node,
         } unless prop
 
@@ -89,7 +89,7 @@ module Mint
 
         raise HtmlAttributeComponentPropertyTypeMismatch, {
           "name"      => prop.name.value,
-          "component" => component.name,
+          "component" => component.name.value,
           "expected"  => prop_type,
           "node"      => node,
           "got"       => type,

--- a/src/type_checkers/html_component.cr
+++ b/src/type_checkers/html_component.cr
@@ -7,7 +7,7 @@ module Mint
 
     def check(node : Ast::HtmlComponent) : Checkable
       component =
-        ast.components.find(&.name.==(node.component.value))
+        ast.components.find(&.name.value.==(node.component.value))
 
       raise HtmlComponentNotFoundComponent, {
         "name" => node.component.value,

--- a/src/type_checkers/module.cr
+++ b/src/type_checkers/module.cr
@@ -14,7 +14,7 @@ module Mint
 
     def check(node : Ast::Module) : Checkable
       check_names node.functions, ModuleEntityNameConflict
-      check_global_names node.name, node
+      check_global_names node.name.value, node
 
       NEVER
     end

--- a/src/type_checkers/module_access.cr
+++ b/src/type_checkers/module_access.cr
@@ -55,14 +55,14 @@ module Mint
             entity.constants.find(&.name.==(variable_value))
         else
           raise ModuleAccessNotFoundModule, {
-            "name" => name,
+            "name" => name.value,
             "node" => node,
           }
         end
 
       raise ModuleAccessNotFoundFunction, {
         "name"   => variable_value,
-        "entity" => name,
+        "entity" => name.value,
         "node"   => node,
       } unless item
 

--- a/src/type_checkers/module_access.cr
+++ b/src/type_checkers/module_access.cr
@@ -8,12 +8,12 @@ module Mint
         node.name
 
       entity =
-        ast.unified_modules.find(&.name.==(name)) ||
-          ast.stores.find(&.name.==(name)) ||
-          ast.providers.find(&.name.==(name)) ||
+        ast.unified_modules.find(&.name.value.==(name.value)) ||
+          ast.stores.find(&.name.value.==(name.value)) ||
+          ast.providers.find(&.name.value.==(name.value)) ||
           ast.components
             .select(&.global?)
-            .find(&.name.==(name))
+            .find(&.name.value.==(name.value))
 
       variable_value =
         node.variable.value

--- a/src/type_checkers/provider.cr
+++ b/src/type_checkers/provider.cr
@@ -5,7 +5,7 @@ module Mint
 
     def check(node : Ast::Provider) : Checkable
       # Checking for global naming conflict
-      check_global_names node.name, node
+      check_global_names node.name.value, node
 
       # Checking for naming conflicts
       checked =
@@ -17,7 +17,7 @@ module Mint
 
       # Checking for subscription
       subscription =
-        records.find(&.name.==(node.subscription))
+        records.find(&.name.==(node.subscription.value))
 
       raise ProviderNotFoundSubscription, {
         "name" => node.subscription,

--- a/src/type_checkers/record_definition.cr
+++ b/src/type_checkers/record_definition.cr
@@ -1,7 +1,7 @@
 module Mint
   class TypeChecker
     def check(node : Ast::RecordDefinition) : Checkable
-      check_global_types node.name, node
+      check_global_types node.name.value, node
 
       fields =
         node
@@ -13,7 +13,7 @@ module Mint
           .fields
           .to_h { |field| {field.key.value, field.mapping.try(&.string_value)} }
 
-      type = Record.new(node.name, fields, mappings)
+      type = Record.new(node.name.value, fields, mappings)
       types[node] = type
 
       type

--- a/src/type_checkers/store.cr
+++ b/src/type_checkers/store.cr
@@ -4,7 +4,7 @@ module Mint
 
     def check(node : Ast::Store) : Checkable
       # Checking for global naming conflict
-      check_global_names node.name, node
+      check_global_names node.name.value, node
 
       # Checking for naming conflicts
       checked =

--- a/src/type_checkers/top_level.cr
+++ b/src/type_checkers/top_level.cr
@@ -8,22 +8,22 @@ module Mint
       # Resolve the Main component
       node
         .components
-        .find(&.name.==("Main"))
+        .find(&.name.value.==("Main"))
         .try { |component| resolve component }
 
       node
         .enums
-        .find(&.name.==("Maybe"))
+        .find(&.name.value.==("Maybe"))
         .try { |item| resolve item }
 
       node
         .enums
-        .find(&.name.==("Result"))
+        .find(&.name.value.==("Result"))
         .try { |item| resolve item }
 
       node
         .unified_modules
-        .find(&.name.==("Html.Event"))
+        .find(&.name.value.==("Html.Event"))
         .try do |item|
           resolve item
 
@@ -38,7 +38,7 @@ module Mint
         end
 
       web_components.each do |component|
-        node.components.find(&.name.==(component)).try do |item|
+        node.components.find(&.name.value.==(component)).try do |item|
           resolve item
         end
       end

--- a/src/type_checkers/type.cr
+++ b/src/type_checkers/type.cr
@@ -1,11 +1,11 @@
 module Mint
   class TypeChecker
     def check(node : Ast::Type) : Checkable
-      resolve_record_definition(node.name) || begin
+      resolve_record_definition(node.name.value) || begin
         parameters =
           resolve node.parameters
 
-        Comparer.normalize(Type.new(node.name, parameters))
+        Comparer.normalize(Type.new(node.name.value, parameters))
       end
     end
   end

--- a/src/type_checkers/use.cr
+++ b/src/type_checkers/use.cr
@@ -12,7 +12,7 @@ module Mint
         ast.providers.find(&.name.value.==(node.provider.value))
 
       raise UseNotFoundProvider, {
-        "name" => node.provider,
+        "name" => node.provider.value,
         "node" => node,
       } unless provider
 

--- a/src/type_checkers/use.cr
+++ b/src/type_checkers/use.cr
@@ -9,10 +9,10 @@ module Mint
         node.condition
 
       provider =
-        ast.providers.find(&.name.==(node.provider))
+        ast.providers.find(&.name.value.==(node.provider.value))
 
       raise UseNotFoundProvider, {
-        "name" => node.provider,
+        "name" => node.provider.value,
         "node" => node,
       } unless provider
 
@@ -22,7 +22,7 @@ module Mint
 
       # This is checked by the provider so we assume it's there
       subscription =
-        records.find!(&.name.==(provider.subscription))
+        records.find!(&.name.==(provider.subscription.value))
 
       record =
         resolve node.data

--- a/src/type_checkers/use.cr
+++ b/src/type_checkers/use.cr
@@ -12,7 +12,7 @@ module Mint
         ast.providers.find(&.name.value.==(node.provider.value))
 
       raise UseNotFoundProvider, {
-        "name" => node.provider.value,
+        "name" => node.provider,
         "node" => node,
       } unless provider
 


### PR DESCRIPTION
This PR modifies the `type_id`/`type_id!` methods of the parser to return a new node (`Ast::TypeId`) rather than return a `String`. Any other node affected by this has also been updated.

This should make it easier to implement language server features where it can be useful to exact positions of some nodes. e.g. the `name` of an `Ast::Component`

I've tested this change against the `mint-realworld` repository, running `mint docs` etc and everything seemed OK, but could possible use more testing given how much is changed.