### PR TITLE
Update `Ast::Constant` to use an `Ast::Variable` for its name

### DIFF
--- a/spec/parsers/variable_spec.cr
+++ b/spec/parsers/variable_spec.cr
@@ -56,3 +56,21 @@ describe "Variable With Dashes!" do
   expect_error ".", Mint::SyntaxError
   expect_error "???", Mint::SyntaxError
 end
+
+describe "Variable Constant!" do
+  subject variable_constant!
+
+  expect_ok "A"
+  expect_ok "ASD"
+  expect_ok "ASD_ASD_ASD"
+  expect_ok "ASD_ASD__ASD"
+  expect_ok "ASD_ASD________ASD"
+  expect_ok "ASD_"
+
+  expect_error " ", Mint::Parser::ConstantExpectedName
+  expect_error ".", Mint::Parser::ConstantExpectedName
+  expect_error "_", Mint::Parser::ConstantExpectedName
+  expect_error "???", Mint::Parser::ConstantExpectedName
+  expect_error "_ASD", Mint::Parser::ConstantExpectedName
+  expect_error "1ASD", Mint::Parser::ConstantExpectedName
+end

--- a/src/ast/constant.cr
+++ b/src/ast/constant.cr
@@ -5,7 +5,7 @@ module Mint
 
       def initialize(@value : Expression,
                      @comment : Comment?,
-                     @name : String,
+                     @name : Variable,
                      @input : Data,
                      @from : Int32,
                      @to : Int32)

--- a/src/compilers/component.cr
+++ b/src/compilers/component.cr
@@ -122,7 +122,7 @@ module Mint
             name = js.variable_of(key)
 
             case
-            when store.constants.any?(&.name.==(original)),
+            when store.constants.any?(&.name.value.==(original)),
                  store.gets.any?(&.name.value.==(original)),
                  store.states.find(&.name.value.==(original))
               memo << js.get(name, "return #{store_name}.#{id};")

--- a/src/compilers/variable.cr
+++ b/src/compilers/variable.cr
@@ -20,7 +20,7 @@ module Mint
             when Ast::Function then entity.name.value
             when Ast::State    then entity.name.value
             when Ast::Get      then entity.name.value
-            when Ast::Constant then entity.name
+            when Ast::Constant then entity.name.value
             end
 
           if store

--- a/src/ls/code_actions/module_actions.cr
+++ b/src/ls/code_actions/module_actions.cr
@@ -12,7 +12,7 @@ module Mint
               .map(&.from)
 
           # Reorder by name and the appropriate order from the original order
-          (node.constants.sort_by(&.name) +
+          (node.constants.sort_by(&.name.value) +
             node.functions.sort_by(&.name.value))
             .each_with_index { |entity, index| entity.from = order[index] }
 

--- a/src/ls/code_actions/provider_actions.cr
+++ b/src/ls/code_actions/provider_actions.cr
@@ -13,7 +13,7 @@ module Mint
 
           # Reorder by name and the appropriate order from the original order
           (node.states.sort_by(&.name.value) +
-            node.constants.sort_by(&.name) +
+            node.constants.sort_by(&.name.value) +
             node.gets.sort_by(&.name.value) +
             node.functions.sort_by(&.name.value))
             .each_with_index { |entity, index| entity.from = order[index] }

--- a/src/ls/completion_item/constant.cr
+++ b/src/ls/completion_item/constant.cr
@@ -4,9 +4,9 @@ module Mint
       def completion_item(node : Ast::Constant, parent_name : Ast::TypeId? = nil) : LSP::CompletionItem
         name =
           if parent_name
-            "#{parent_name.value}:#{node.name}"
+            "#{parent_name.value}:#{node.name.value}"
           else
-            node.name
+            node.name.value
           end
 
         LSP::CompletionItem.new(

--- a/src/parsers/constant.cr
+++ b/src/parsers/constant.cr
@@ -12,16 +12,7 @@ module Mint
         next unless keyword "const"
         whitespace
 
-        head =
-          gather { chars &.ascii_uppercase? }
-
-        tail =
-          gather { chars { |char| char.ascii_uppercase? || char.ascii_number? || char == '_' } }
-
-        raise ConstantExpectedName unless head || tail
-
-        name =
-          "#{head}#{tail}"
+        name = variable_constant!
 
         whitespace
         char '=', ConstantExpectedEqualSign

--- a/src/parsers/variable.cr
+++ b/src/parsers/variable.cr
@@ -41,6 +41,26 @@ module Mint
       end
     end
 
+    def variable_constant! : Ast::Variable
+      start do |start_position|
+        head =
+          gather { chars &.ascii_uppercase? }
+
+        tail =
+          gather { chars { |char| char.ascii_uppercase? || char.ascii_number? || char == '_' } }
+
+        raise ConstantExpectedName unless head
+
+        value = "#{head}#{tail}"
+
+        Ast::Variable.new(
+          from: start_position,
+          value: value,
+          to: position,
+          input: data)
+      end
+    end
+
     def variable!(error : SyntaxError.class, track = true) : Ast::Variable
       variable(track) || raise error
     end

--- a/src/type_checker/scope.cr
+++ b/src/type_checker/scope.cr
@@ -163,7 +163,7 @@ module Mint
 
       def find(variable : String, node : Ast::Module)
         node.functions.find(&.name.value.==(variable)) ||
-          node.constants.find(&.name.==(variable))
+          node.constants.find(&.name.value.==(variable))
       end
 
       def find(variable : String, node : Ast::Store)
@@ -191,7 +191,7 @@ module Mint
           node.gets.find(&.name.value.==(variable)) ||
           node.properties.find(&.name.value.==(variable)) ||
           node.states.find(&.name.value.==(variable)) ||
-          node.constants.find(&.name.==(variable)) ||
+          node.constants.find(&.name.value.==(variable)) ||
           refs(component)[variable]? ||
           store_constants(component)[variable]? ||
           store_states(component)[variable]? ||
@@ -200,7 +200,7 @@ module Mint
       end
 
       def find(variable : String, node : Ast::Suite)
-        node.constants.find(&.name.==(variable))
+        node.constants.find(&.name.value.==(variable))
       end
 
       def find(variable : String, node : Ast::Node)
@@ -336,7 +336,7 @@ module Mint
               item.keys.each do |key|
                 store
                   .constants
-                  .find(&.name.==(key.variable.value))
+                  .find(&.name.value.==(key.variable.value))
                   .try do |function|
                     memo[(key.name || key.variable).value] = function
                   end

--- a/src/type_checkers/connect.cr
+++ b/src/type_checkers/connect.cr
@@ -20,7 +20,7 @@ module Mint
           store.functions.find(&.name.value.==(key_value)) ||
             store.states.find(&.name.value.==(key_value)) ||
             store.gets.find(&.name.value.==(key_value)) ||
-            store.constants.find(&.name.==(key_value))
+            store.constants.find(&.name.value.==(key_value))
 
         raise ConnectNotFoundMember, {
           "key"   => key_value,

--- a/src/type_checkers/module_access.cr
+++ b/src/type_checkers/module_access.cr
@@ -41,18 +41,18 @@ module Mint
           end
         when Ast::Module
           entity.functions.find(&.name.value.==(variable_value)) ||
-            entity.constants.find(&.name.==(variable_value))
+            entity.constants.find(&.name.value.==(variable_value))
         when Ast::Component
           entity.properties.find(&.name.value.==(variable_value)) ||
             entity.functions.find(&.name.value.==(variable_value)) ||
             entity.states.find(&.name.value.==(variable_value)) ||
-            entity.constants.find(&.name.==(variable_value)) ||
+            entity.constants.find(&.name.value.==(variable_value)) ||
             entity.gets.find(&.name.value.==(variable_value))
         when Ast::Store
           entity.functions.find(&.name.value.==(variable_value)) ||
             entity.states.find(&.name.value.==(variable_value)) ||
             entity.gets.find(&.name.value.==(variable_value)) ||
-            entity.constants.find(&.name.==(variable_value))
+            entity.constants.find(&.name.value.==(variable_value))
         else
           raise ModuleAccessNotFoundModule, {
             "name" => name.value,


### PR DESCRIPTION
This PR updates `Ast::Constant` to use an `Ast::Variable` for its name, rather than a string. This will be useful for future changes to the language server.

Unfortunately, similar to the recent `Ast::TypeId` change, it includes a lot of `.value`'s, although there were a couple of places where I didn't seem to need to add it such as in the formatter.

This PR also fixes a bug where some invalid constants were allowed, notably ones that start with a number or underscore. (e.g `_CONSTANT`, `1CONSTANT`)

