### PR TITLE
LSP: Add Go to Definition support for Enum/Type/Connect

### DIFF
--- a/spec/language_server/definition/core_component
+++ b/spec/language_server/definition/core_component
@@ -4,6 +4,21 @@ component Test {
       <div/>
     </Unless>
   }
+
+  fun aborted : Http.Error {
+    Http.Error::Aborted
+  }
+
+  state error : Http.Error = Http.Error::Aborted
+
+  fun toString (error : Http.Error) : String {
+    case error {
+      Http.Error::Aborted => "Aborted"
+      Http.Error::NetworkError => "NetworkError"
+      Http.Error::Timeout => "Timeout"
+      Http.Error::BadUrl => "BadUrl"
+    }
+  }
 }
 ------------------------------------------------------------------file test.mint
 {
@@ -38,6 +53,51 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
+  "id": 2,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 16
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 11,
+      "character": 29
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 15,
+      "character": 18
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
   "result": null,
   "id": 0
 }
@@ -46,5 +106,23 @@ component Test {
   "jsonrpc": "2.0",
   "result": null,
   "id": 1
+}
+------------------------------------------------------------------------response
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 2
+}
+------------------------------------------------------------------------response
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 3
+}
+------------------------------------------------------------------------response
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 4
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/connect
+++ b/spec/language_server/definition/location/connect
@@ -1,0 +1,60 @@
+/* Comment for Theme store. */
+store Theme {
+  state darkMode = false
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { darkMode }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 10
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    },
+    "uri": "file://#{root_path}/store.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/connect_variable_constant
+++ b/spec/language_server/definition/location/connect_variable_constant
@@ -1,0 +1,60 @@
+/* Comment for Theme store. */
+store Theme {
+  const CONSTANT = true
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { CONSTANT }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 16
+      }
+    },
+    "uri": "file://#{root_path}/store.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/connect_variable_function
+++ b/spec/language_server/definition/location/connect_variable_function
@@ -1,0 +1,62 @@
+/* Comment for Theme store. */
+store Theme {
+  fun name {
+    "Theme"
+  }
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { name }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 10
+      }
+    },
+    "uri": "file://#{root_path}/store.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/connect_variable_get
+++ b/spec/language_server/definition/location/connect_variable_get
@@ -1,0 +1,62 @@
+/* Comment for Theme store. */
+store Theme {
+  get name {
+    "Theme"
+  }
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { name }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 10
+      }
+    },
+    "uri": "file://#{root_path}/store.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/connect_variable_state
+++ b/spec/language_server/definition/location/connect_variable_state
@@ -1,0 +1,60 @@
+/* Comment for Theme store. */
+store Theme {
+  state darkMode = false
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { darkMode }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 16
+      }
+    },
+    "uri": "file://#{root_path}/store.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/enum_destructuring_name
+++ b/spec/language_server/definition/location/enum_destructuring_name
@@ -1,0 +1,62 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+------------------------------------------------------------------file status.mint
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Error => "Error"
+      Status::Ok => "Ok"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 6
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 5
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    },
+    "uri": "file://#{root_path}/status.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/enum_destructuring_option
+++ b/spec/language_server/definition/location/enum_destructuring_option
@@ -1,0 +1,62 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+------------------------------------------------------------------file status.mint
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Error => "Error"
+      Status::Ok => "Ok"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 14
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 7
+      }
+    },
+    "uri": "file://#{root_path}/status.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/enum_id_name
+++ b/spec/language_server/definition/location/enum_id_name
@@ -1,0 +1,61 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+component Test {
+  state status : Status = Status::Ok
+
+  fun render : Html {
+    <div />
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 26
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 5
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    },
+    "uri": "file://#{root_path}/status.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/enum_id_option
+++ b/spec/language_server/definition/location/enum_id_option
@@ -1,0 +1,60 @@
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+component Test {
+  state status : Status = Status::Ok
+
+  fun render : Html {
+    <div />
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 35
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 4
+      }
+    },
+    "uri": "file://#{root_path}/status.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/type_enum
+++ b/spec/language_server/definition/location/type_enum
@@ -1,0 +1,58 @@
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+module Test {
+  fun success : Status {
+    Status::Ok
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 17
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 5
+      },
+      "end": {
+        "line": 0,
+        "character": 11
+      }
+    },
+    "uri": "file://#{root_path}/status.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/type_record
+++ b/spec/language_server/definition/location/type_record
@@ -1,0 +1,63 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+---------------------------------------------------------------file article.mint
+module Test {
+  fun test : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: "Mint"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 14
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 7
+      },
+      "end": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "uri": "file://#{root_path}/article.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect
+++ b/spec/language_server/definition/location_link/connect
@@ -1,0 +1,80 @@
+/* Comment for Theme store. */
+store Theme {
+  state darkMode = false
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { darkMode }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 10
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 10
+      },
+      "end": {
+        "line": 1,
+        "character": 15
+      }
+    },
+    "targetUri": "file://#{root_path}/store.mint",
+    "targetRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 3,
+        "character": 1
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_constant
+++ b/spec/language_server/definition/location_link/connect_variable_constant
@@ -1,0 +1,80 @@
+/* Comment for Theme store. */
+store Theme {
+  const CONSTANT = true
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { CONSTANT }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 35
+      }
+    },
+    "targetUri": "file://#{root_path}/store.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 23
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 16
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_function
+++ b/spec/language_server/definition/location_link/connect_variable_function
@@ -1,0 +1,82 @@
+/* Comment for Theme store. */
+store Theme {
+  fun name {
+    "Theme"
+  }
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { name }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 31
+      }
+    },
+    "targetUri": "file://#{root_path}/store.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 4,
+        "character": 3
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 10
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_get
+++ b/spec/language_server/definition/location_link/connect_variable_get
@@ -1,0 +1,82 @@
+/* Comment for Theme store. */
+store Theme {
+  get name {
+    "Theme"
+  }
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { name }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 31
+      }
+    },
+    "targetUri": "file://#{root_path}/store.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 5,
+        "character": 0
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 10
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_state
+++ b/spec/language_server/definition/location_link/connect_variable_state
@@ -1,0 +1,80 @@
+/* Comment for Theme store. */
+store Theme {
+  state darkMode = false
+}
+-----------------------------------------------------------------file store.mint
+component Test {
+  connect Theme exposing { darkMode }
+
+  fun render : Html {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 27
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 35
+      }
+    },
+    "targetUri": "file://#{root_path}/store.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 24
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 16
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_destructuring_name
+++ b/spec/language_server/definition/location_link/enum_destructuring_name
@@ -1,0 +1,82 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Error => "Error"
+      Status::Ok => "Ok"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 6
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 3,
+        "character": 6
+      },
+      "end": {
+        "line": 3,
+        "character": 12
+      }
+    },
+    "targetUri": "file://#{root_path}/status.mint",
+    "targetRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 4,
+        "character": 1
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 5
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_destructuring_option
+++ b/spec/language_server/definition/location_link/enum_destructuring_option
@@ -1,0 +1,82 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Error => "Error"
+      Status::Ok => "Ok"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 14
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 3,
+        "character": 14
+      },
+      "end": {
+        "line": 3,
+        "character": 19
+      }
+    },
+    "targetUri": "file://#{root_path}/status.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 3,
+        "character": 2
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 7
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_id_name
+++ b/spec/language_server/definition/location_link/enum_id_name
@@ -1,0 +1,81 @@
+/* Comment for Status enum. */
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+component Test {
+  state status : Status = Status::Ok
+
+  fun render : Html {
+    <div />
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 26
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 26
+      },
+      "end": {
+        "line": 1,
+        "character": 32
+      }
+    },
+    "targetUri": "file://#{root_path}/status.mint",
+    "targetRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 4,
+        "character": 1
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 5
+      },
+      "end": {
+        "line": 1,
+        "character": 11
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_id_option
+++ b/spec/language_server/definition/location_link/enum_id_option
@@ -1,0 +1,80 @@
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+component Test {
+  state status : Status = Status::Ok
+
+  fun render : Html {
+    <div />
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 35
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 34
+      },
+      "end": {
+        "line": 1,
+        "character": 36
+      }
+    },
+    "targetUri": "file://#{root_path}/status.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 3,
+        "character": 0
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 4
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/type_enum
+++ b/spec/language_server/definition/location_link/type_enum
@@ -1,0 +1,78 @@
+enum Status {
+  Error
+  Ok
+}
+----------------------------------------------------------------file status.mint
+module Test {
+  fun success : Status {
+    Status::Ok
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 17
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 16
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    },
+    "targetUri": "file://#{root_path}/status.mint",
+    "targetRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 3,
+        "character": 1
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 0,
+        "character": 5
+      },
+      "end": {
+        "line": 0,
+        "character": 11
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/type_record
+++ b/spec/language_server/definition/location_link/type_record
@@ -1,0 +1,83 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+---------------------------------------------------------------file article.mint
+module Test {
+  fun test : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: "Mint"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 1,
+      "character": 14
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 13
+      },
+      "end": {
+        "line": 1,
+        "character": 20
+      }
+    },
+    "targetUri": "file://#{root_path}/article.mint",
+    "targetRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 4,
+        "character": 1
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 0,
+        "character": 7
+      },
+      "end": {
+        "line": 0,
+        "character": 14
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/src/ls/definition/connect.cr
+++ b/src/ls/definition/connect.cr
@@ -1,0 +1,14 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::Connect, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        return unless cursor_intersects?(node.store)
+
+        return unless store =
+                        workspace.ast.stores.find(&.name.value.==(node.store.value))
+
+        location_link server, node.store, store.name, store
+      end
+    end
+  end
+end

--- a/src/ls/definition/connect_variable.cr
+++ b/src/ls/definition/connect_variable.cr
@@ -1,0 +1,24 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::ConnectVariable, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        return unless cursor_intersects?(node.variable)
+
+        return unless connect = stack[1]?.as?(Ast::Connect)
+
+        return unless store =
+                        workspace.ast.stores.find(&.name.value.==(connect.store.value))
+
+        return unless target = store.functions.find(&.name.value.==(node.variable.value)) ||
+                               store.constants.find(&.name.value.==(node.variable.value)) ||
+                               store.states.find(&.name.value.==(node.variable.value)) ||
+                               store.gets.find(&.name.value.==(node.variable.value))
+
+        case target
+        when Ast::Function, Ast::State, Ast::Get, Ast::Constant
+          location_link server, node.variable, target.name, target
+        end
+      end
+    end
+  end
+end

--- a/src/ls/definition/enum_destructuring.cr
+++ b/src/ls/definition/enum_destructuring.cr
@@ -1,0 +1,23 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::EnumDestructuring, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        return unless name = node.name
+        return unless enum_node =
+                        workspace.ast.enums.find(&.name.value.==(name.value))
+
+        return if Core.ast.enums.includes?(enum_node)
+
+        case
+        when cursor_intersects?(name)
+          location_link server, name, enum_node.name, enum_node
+        when cursor_intersects?(node.option)
+          return unless option =
+                          enum_node.try &.options.find(&.value.value.==(node.option.value))
+
+          location_link server, node.option, option.value, option
+        end
+      end
+    end
+  end
+end

--- a/src/ls/definition/enum_id.cr
+++ b/src/ls/definition/enum_id.cr
@@ -1,0 +1,23 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::EnumId, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        return unless name = node.name
+        return unless enum_node =
+                        workspace.ast.enums.find(&.name.value.==(name.value))
+
+        return if Core.ast.enums.includes?(enum_node)
+
+        case
+        when cursor_intersects?(name)
+          location_link server, name, enum_node.name, enum_node
+        when cursor_intersects?(node.option)
+          return unless option =
+                          enum_node.try &.options.find(&.value.value.==(node.option.value))
+
+          location_link server, node.option, option.value, option
+        end
+      end
+    end
+  end
+end

--- a/src/ls/definition/type.cr
+++ b/src/ls/definition/type.cr
@@ -1,0 +1,25 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::Type, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        return unless cursor_intersects?(node.name)
+
+        enum_node =
+          workspace.ast.enums.find(&.name.value.==(node.name.value))
+
+        if enum_node
+          return if Core.ast.enums.includes?(enum_node)
+
+          location_link server, node.name, enum_node.name, enum_node
+        else
+          return unless record =
+                          workspace.ast.records.find(&.name.value.==(node.name.value))
+
+          return if Core.ast.records.includes?(record)
+
+          location_link server, node.name, record.name, record
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds "Go to Definition" support to some more of the easier nodes as shown in the videos below.

For `Ast::ConnectVariable`:

https://github.com/mint-lang/mint/assets/1927518/64ab6659-c07a-442b-b70b-adec9698ada6

For `Ast::EnumDestructuring`:

https://github.com/mint-lang/mint/assets/1927518/2b372165-a1be-446a-ae77-44809c5fd6a8

For `Ast::EnumId`:

https://github.com/mint-lang/mint/assets/1927518/2278adaf-8013-4cbd-9f0f-92746926a727

For `Ast::Type`:

https://github.com/mint-lang/mint/assets/1927518/4b181727-c4e0-4165-9fa5-d2576fa17066

There's still some testing I need to do, especially when referencing any of the "core" files (they are not on the filesystem so you cannot link to them :cry: )  but otherwise should be good for review.