### PR TITLE
Allow `else` branch to be omitted in certain cases.

### DIFF
--- a/spec/compilers/if_without_else_array
+++ b/spec/compilers/if_without_else_array
@@ -1,0 +1,15 @@
+component Main {
+  fun render : Array(String) {
+    if ("asd" == "asd2") {
+      ["ARRAY"]
+    }
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return (_compare(`asd`, `asd2`) ? [`ARRAY`] : []);
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/if_without_else_promise
+++ b/spec/compilers/if_without_else_promise
@@ -1,0 +1,18 @@
+component Main {
+  fun render : String {
+    if ("asd" == "asd2") {
+      next {}
+    }
+
+    ""
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    (_compare(`asd`, `asd2`) ? null : null);
+    return ``;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/if_without_else_string
+++ b/spec/compilers/if_without_else_string
@@ -1,0 +1,15 @@
+component Main {
+  fun render : String {
+    if ("asd" == "asd2") {
+      "TRUE"
+    }
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return (_compare(`asd`, `asd2`) ? `TRUE` : "");
+  }
+};
+
+A.displayName = "Main";

--- a/spec/compilers/next_call_empty
+++ b/spec/compilers/next_call_empty
@@ -1,0 +1,15 @@
+component Main {
+  fun render : String {
+    next {}
+    ""
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    null;
+    return ``;
+  }
+};
+
+A.displayName = "Main";

--- a/spec/parsers/if_spec.cr
+++ b/spec/parsers/if_spec.cr
@@ -17,8 +17,6 @@ describe "If Expression" do
   expect_error "if (a) { ", Mint::Parser::IfExpectedTruthyExpression
   expect_error "if (a) { a", Mint::Parser::IfExpectedTruthyClosingBracket
   expect_error "if (a) { a ", Mint::Parser::IfExpectedTruthyClosingBracket
-  expect_error "if (a) { a }", Mint::Parser::IfExpectedElse
-  expect_error "if (a) { a } ", Mint::Parser::IfExpectedElse
   expect_error "if (a) { a } else", Mint::Parser::IfExpectedFalsyOpeningBracket
   expect_error "if (a) { a } else ", Mint::Parser::IfExpectedFalsyOpeningBracket
   expect_error "if (a) { a } else {", Mint::Parser::IfExpectedFalsyExpression
@@ -26,6 +24,8 @@ describe "If Expression" do
   expect_error "if (a) { a } else { a", Mint::Parser::IfExpectedFalsyClosingBracket
   expect_error "if (a) { a } else { a ", Mint::Parser::IfExpectedFalsyClosingBracket
 
+  expect_ok "if (a) { a }"
+  expect_ok "if (a) { a } "
   expect_ok "if (a) { b } else { c }"
   expect_ok "if ( a ) { b } else { c }"
   expect_ok "if (a) { b } else if (x) { y } else { z }"

--- a/src/compilers/if.cr
+++ b/src/compilers/if.cr
@@ -44,8 +44,19 @@ module Mint
         when Ast::Node
           compile item
         else
-          "null"
-        end
+          if truthy_item.is_a?(Ast::Node)
+            type = cache[truthy_item]
+
+            case type.name
+            when "Array"
+              "[]"
+            when "String"
+              "\"\""
+            when "Maybe"
+              "new #{nothing}"
+            end
+          end
+        end || "null"
 
       case statement = node.condition
       when Ast::Statement

--- a/src/compilers/next_call.cr
+++ b/src/compilers/next_call.cr
@@ -4,30 +4,34 @@ module Mint
       entity =
         lookups[node]?
 
-      state =
-        node.data.fields.each_with_object({} of String => String) do |item, memo|
-          field =
-            case entity
-            when Ast::Provider
-              entity
-                .states
-                .find(&.name.value.==(item.key.value))
-            when Ast::Component, Ast::Store
-              entity
-                .states
-                .find(&.name.value.==(item.key.value))
+      if node.data.fields.empty?
+        "null"
+      else
+        state =
+          node.data.fields.each_with_object({} of String => String) do |item, memo|
+            field =
+              case entity
+              when Ast::Provider
+                entity
+                  .states
+                  .find(&.name.value.==(item.key.value))
+              when Ast::Component, Ast::Store
+                entity
+                  .states
+                  .find(&.name.value.==(item.key.value))
+              end
+
+            if field
+              memo[js.variable_of(field)] = compile item.value
+            else
+              memo
             end
-
-          if field
-            memo[js.variable_of(field)] = compile item.value
-          else
-            memo
           end
-        end
 
-      js.promise do
-        js.arrow_function(%w[_resolve]) do
-          "this.setState(_u(this.state, new Record(#{js.object(state)})), _resolve)\n"
+        js.promise do
+          js.arrow_function(%w[_resolve]) do
+            "this.setState(_u(this.state, new Record(#{js.object(state)})), _resolve)\n"
+          end
         end
       end
     end

--- a/src/messages/if_expected_else.cr
+++ b/src/messages/if_expected_else.cr
@@ -1,14 +1,19 @@
 message IfExpectedElse do
-  title "Syntax Error"
+  title "Type Error"
 
   block do
-    text "An"
+    text "This"
     bold "if expression"
     text "must have an"
     bold "else branch."
   end
 
-  was_looking_for "else branch", got
+  block do
+    text "The elese branch can be omitted if the truthy branch returns one of:"
+    type_list expected
+    text "but it returns"
+    type got
+  end
 
   snippet node
 end

--- a/src/parsers/html_body.cr
+++ b/src/parsers/html_body.cr
@@ -9,7 +9,7 @@ module Mint
         html_fragment ||
         string_literal ||
         array ||
-        if_expression(for_html: true) ||
+        if_expression ||
         for_expression ||
         case_expression ||
         comment

--- a/src/parsers/if.cr
+++ b/src/parsers/if.cr
@@ -8,9 +8,8 @@ module Mint
     syntax_error IfExpectedTruthyExpression
     syntax_error IfExpectedFalsyExpression
     syntax_error IfExpectedCondition
-    syntax_error IfExpectedElse
 
-    def if_expression(for_css = false, for_html = false) : Ast::If?
+    def if_expression(for_css = false) : Ast::If?
       start do |start_position|
         next unless keyword "if"
 
@@ -41,11 +40,10 @@ module Mint
         falsy = nil
         whitespace
 
-        if (!for_css && !for_html) || keyword_ahead? "else"
-          keyword! "else", IfExpectedElse
+        if keyword "else"
           whitespace
 
-          unless falsy = if_expression(for_css: for_css, for_html: for_html)
+          unless falsy = if_expression(for_css: for_css)
             falsy =
               if for_css
                 block(

--- a/src/type_checker.cr
+++ b/src/type_checker.cr
@@ -10,7 +10,6 @@ module Mint
     NUMBER         = Type.new("Number")
     VOID           = Type.new("Void")
     TIME           = Type.new("Time")
-    NEVER          = Type.new("Never")
     HTML           = Type.new("Html")
     EVENT          = Type.new("Html.Event")
     OBJECT         = Type.new("Object")
@@ -27,6 +26,16 @@ module Mint
     VOID_FUNCTION  = Type.new("Function", [Variable.new("a")] of Checkable)
     TEST_CONTEXT   = Type.new("Test.Context", [Variable.new("a")] of Checkable)
     STYLE_MAP      = Type.new("Map", [STRING, STRING] of Checkable)
+    VOID_PROMISE   = Type.new("Promise", [VOID] of Checkable)
+
+    VALID_IF_TYPES = [
+      VOID_PROMISE,
+      STRING,
+      ARRAY,
+      MAYBE,
+      VOID,
+      HTML,
+    ] of Checkable
 
     getter records, scope, artifacts, formatter, web_components
 
@@ -240,7 +249,7 @@ module Mint
           if @stack.includes?(node)
             case node
             when Ast::Component
-              NEVER
+              VOID
             when Ast::Function, Ast::InlineFunction
               static_type_signature(node)
             when Ast::Statement

--- a/src/type_checkers/case_branch.cr
+++ b/src/type_checkers/case_branch.cr
@@ -12,7 +12,7 @@ module Mint
         end || resolve(node.expression)
 
       if node.expression.is_a?(Array(Ast::CssDefinition))
-        NEVER
+        VOID
       else
         type.as(Checkable)
       end

--- a/src/type_checkers/comment.cr
+++ b/src/type_checkers/comment.cr
@@ -1,7 +1,7 @@
 module Mint
   class TypeChecker
     def check(node : Ast::Comment) : Checkable
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/component.cr
+++ b/src/type_checkers/component.cr
@@ -55,7 +55,7 @@ module Mint
         resolve node.functions
       end
 
-      NEVER
+      VOID
     end
 
     def check(node : Ast::Component) : Checkable
@@ -207,7 +207,7 @@ module Mint
         end
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/connect.cr
+++ b/src/type_checkers/connect.cr
@@ -32,7 +32,7 @@ module Mint
         lookups[key] = found
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/css_definition.cr
+++ b/src/type_checkers/css_definition.cr
@@ -32,7 +32,7 @@ module Mint
         } unless Comparer.matches_any?(type, [STRING, NUMBER])
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/css_font_face.cr
+++ b/src/type_checkers/css_font_face.cr
@@ -17,7 +17,7 @@ module Mint
           } if interpolation
         end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/css_keyframes.cr
+++ b/src/type_checkers/css_keyframes.cr
@@ -3,7 +3,7 @@ module Mint
     def check(node : Ast::CssKeyframes) : Checkable
       resolve node.selectors
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/css_nested_at.cr
+++ b/src/type_checkers/css_nested_at.cr
@@ -3,7 +3,7 @@ module Mint
     def check(node : Ast::CssNestedAt) : Checkable
       resolve node.body
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/css_selector.cr
+++ b/src/type_checkers/css_selector.cr
@@ -3,7 +3,7 @@ module Mint
     def check(node : Ast::CssSelector) : Checkable
       resolve node.body
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/destructuring.cr
+++ b/src/type_checkers/destructuring.cr
@@ -198,7 +198,7 @@ module Mint
               when Ast::TypeVariable
                 unified.parameters[parent.parameters.index! { |enum_item| enum_item.value == item.value }]
               else
-                NEVER # Can't happen
+                VOID # Can't happen
               end
 
             destructure(param, sub_type, variables)

--- a/src/type_checkers/html_content.cr
+++ b/src/type_checkers/html_content.cr
@@ -18,7 +18,7 @@ module Mint
         end
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/html_style.cr
+++ b/src/type_checkers/html_style.cr
@@ -44,7 +44,7 @@ module Mint
 
       lookups[node] = style
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/if.cr
+++ b/src/type_checkers/if.cr
@@ -2,6 +2,7 @@ module Mint
   class TypeChecker
     type_error IfConditionTypeMismatch
     type_error IfElseTypeMismatch
+    type_error IfExpectedElse
 
     def check(node : Ast::If) : Checkable
       condition =
@@ -39,6 +40,12 @@ module Mint
             "expected" => truthy,
             "got"      => falsy,
           } unless Comparer.compare(truthy, falsy)
+        else
+          raise IfExpectedElse, {
+            "expected" => VALID_IF_TYPES,
+            "got"      => truthy,
+            "node"     => node,
+          } unless Comparer.matches_any?(truthy, VALID_IF_TYPES)
         end
 
         truthy
@@ -49,7 +56,7 @@ module Mint
 
         falsy_item.try { |data| resolve data }
 
-        NEVER
+        VOID
       end
     end
   end

--- a/src/type_checkers/module.cr
+++ b/src/type_checkers/module.cr
@@ -9,14 +9,14 @@ module Mint
         resolve node.functions
       end
 
-      NEVER
+      VOID
     end
 
     def check(node : Ast::Module) : Checkable
       check_names node.functions, ModuleEntityNameConflict
       check_global_names node.name.value, node
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/provider.cr
+++ b/src/type_checkers/provider.cr
@@ -32,7 +32,7 @@ module Mint
         resolve node.gets
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/routes.cr
+++ b/src/type_checkers/routes.cr
@@ -3,7 +3,7 @@ module Mint
     def check(node : Ast::Routes) : Checkable
       resolve node.routes
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/store.cr
+++ b/src/type_checkers/store.cr
@@ -22,7 +22,7 @@ module Mint
         resolve node.gets
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/style.cr
+++ b/src/type_checkers/style.cr
@@ -6,7 +6,7 @@ module Mint
         resolve node.body
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/suite.cr
+++ b/src/type_checkers/suite.cr
@@ -6,7 +6,7 @@ module Mint
         resolve node.tests
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/test.cr
+++ b/src/type_checkers/test.cr
@@ -17,7 +17,7 @@ module Mint
         }
       end
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/top_level.cr
+++ b/src/type_checkers/top_level.cr
@@ -59,7 +59,7 @@ module Mint
       resolve node.stores
       resolve node.enums
 
-      NEVER
+      VOID
     end
   end
 end

--- a/src/type_checkers/variable.cr
+++ b/src/type_checkers/variable.cr
@@ -59,7 +59,7 @@ module Mint
         when Checkable
           value
         else
-          NEVER
+          VOID
         end
       end
     end


### PR DESCRIPTION
This PR contains three separate changes (sorry about that):

1. Allow omitting the `else` branch when the return type and value can be inferred. The reason for this is there are cases when the else branch is unnecessary like when working with `Html` (which could be omitted before) or `next { }` branches. The inferred return values for omitted else branches are:
	- `String` returns empty string `""`
	- `Array(a)` returns empty array
	- `Promise(Void)` returns `null` (maybe it will need to return an actual promise we will see)
	- `Maybe(a)` returns `Maybe::Nothing`
	- `Void` returns `null`
	- `Html` returns `null`
2. `next { }` now compiles to `null`. Previously it would compile to something like this ( which essentially does nothing):
   ```
   new Promise((resolve) => { this.setState(new Record({})) })
   ```
3. Remove `NEVER` from the type checker and replace it with `VOID`  
  