### PR TITLE
Fix comment being included in `case_enum_not_covered` message

### DIFF
--- a/src/type_checkers/case.cr
+++ b/src/type_checkers/case.cr
@@ -79,7 +79,7 @@ module Mint
 
           options =
             not_matched.map do |option|
-              "#{format parent.name}::#{formatter.replace_skipped(format(option))}"
+              "#{format parent.name}::#{formatter.replace_skipped(format(option.value))}"
             end
 
           raise CaseEnumNotCovered, {


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/mint-lang/mint/pull/597#issuecomment-1544562561). Although opening as a draft to see if everyone is happy with this method of testing messages.

As most of the exceptions covered by the messages already have test cases (see `spec/parsers` and `spec/type_checking`), it should be possible to generate these tests with not too much effort - although not this one specifically, as the original test didn't have a comment!

Only thing is that it would be a lot of files :sweat_smile: 