### PR TITLE
When no hash, jump to start of document

### DIFF
--- a/core/source/Window.mint
+++ b/core/source/Window.mint
@@ -333,6 +333,8 @@ module Window {
     `requestAnimationFrame(() => {
       if (window.location.hash) {
         window.location.href = window.location.hash
+      } else {
+        window.scrollTo(0, 0)
       }
     })
     `


### PR DESCRIPTION
When the user calls `Window.triggerHashJump()`, and there is no hash part in the URL, jump to the start of the document.