### PR TITLE
Fix `Ast::Variable` being tracked even when node is skipped

### DIFF
--- a/src/parsers/record_update.cr
+++ b/src/parsers/record_update.cr
@@ -9,14 +9,14 @@ module Mint
           next unless char! '{'
 
           whitespace
-          value = variable || self.expression
+          value = variable(track: false) || self.expression
           whitespace
 
           next unless value
           next if keyword_ahead?("|>") # Skip if tuple with a pipe `{ x |> Number.toString }`
           next unless char! '|'
 
-          value
+          self << value
         end
 
         next unless expression


### PR DESCRIPTION
Working on adding "Go to Definition" support for `Ast::Variable` (should be ready to PR soon!) and noticed this bug. Thought it might be worth a PR of its own.

There is a small bug when parsing records where an `Ast::Variable` can be tracked twice. As an example, if you were to hover over the key `title` in the record

```mint
record Article {
  title : String
}

module Test {
  fun makeArticle (title : String) : Article {
    { title: title }
  }
}

```

The stack would end up looking something like this:

```
Mint::Ast::Variable
 ↳ Mint::Ast::Variable
  ↳ Mint::Ast::RecordField
   ↳ Mint::Ast::Record
    ↳ Mint::Ast::Statement
     ↳ Mint::Ast::Block
      ↳ Mint::Ast::Function
       ↳ Mint::Ast::Module
```

The duplicate `Ast::Variable` is due to mint trying to parse an `Ast::RecordUpdate` first, before giving up and parsing the `Ast::Record`, tracking the variable in both cases.

As the default when using the `variable` method is to track, this bug could in theory happen elsewhere (for example when parsing [record fields](https://github.com/mint-lang/mint/blob/master/src/parsers/record_field.cr#LL7C11-L7C11)), but I'm not sure there's any other valid Mint program that could trigger it. 

Happy to make the same change to wherever the `variable` method is being used, but otherwise this PR will fix the issue for my specific case!