### PR TITLE
LSP: Add Go to Definition support for `Ast::Variable`

### DIFF
--- a/spec/language_server/definition/location/variable_block_statement_target
+++ b/spec/language_server/definition/location/variable_block_statement_target
@@ -1,0 +1,55 @@
+module Test {
+  fun upperCaseMint : String {
+    let test =
+      "Mint"
+
+    String.toUpperCase(test)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 23
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 12
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_casebranch_enumdestructuring
+++ b/spec/language_server/definition/location/variable_casebranch_enumdestructuring
@@ -1,0 +1,61 @@
+enum Status {
+  Error
+  Ok(text : String)
+}
+
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Ok(text) => text
+      Status::Error => "error"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 26
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 8,
+        "character": 17
+      },
+      "end": {
+        "line": 8,
+        "character": 21
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_connect
+++ b/spec/language_server/definition/location/variable_component_connect
@@ -1,0 +1,60 @@
+component Test {
+  connect Theme exposing { primary }
+
+  fun render : Html {
+    <div>
+      <{ primary }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+store Theme {
+  state primary : String = "#00a0e8"
+}
+-----------------------------------------------------------------file store.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 34
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_connect_as
+++ b/spec/language_server/definition/location/variable_component_connect_as
@@ -1,0 +1,60 @@
+component Test {
+  connect Theme exposing { primary as primaryColor }
+
+  fun render : Html {
+    <div>
+      <{ primaryColor }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+store Theme {
+  state primary : String = "#00a0e8"
+}
+-----------------------------------------------------------------file store.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 38
+      },
+      "end": {
+        "line": 1,
+        "character": 50
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_constant
+++ b/spec/language_server/definition/location/variable_component_constant
@@ -1,0 +1,57 @@
+component Test {
+  const TEXT = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ TEXT }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_function
+++ b/spec/language_server/definition/location/variable_component_function
@@ -1,0 +1,59 @@
+component Test {
+  fun text : String {
+    "Mint"
+  }
+
+  fun render : Html {
+    <div>
+      <{ text() }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_get
+++ b/spec/language_server/definition/location/variable_component_get
@@ -1,0 +1,59 @@
+component Test {
+  get text : String {
+    "Mint"
+  }
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_property
+++ b/spec/language_server/definition/location/variable_component_property
@@ -1,0 +1,57 @@
+component Test {
+  property text : String = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 11
+      },
+      "end": {
+        "line": 1,
+        "character": 15
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_component_state
+++ b/spec/language_server/definition/location/variable_component_state
@@ -1,0 +1,57 @@
+component Test {
+  state text : String = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_for
+++ b/spec/language_server/definition/location/variable_for
@@ -1,0 +1,55 @@
+module Test {
+  fun uppercase (values : Array(String)) : Array(String) {
+    for value of values {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 25
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_for_argument_stop
+++ b/spec/language_server/definition/location/variable_for_argument_stop
@@ -1,0 +1,43 @@
+module Test {
+  fun uppercase (value : String) : Array(String) {
+    for value of String.split(value, ",") {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 8
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_for_subject
+++ b/spec/language_server/definition/location/variable_for_subject
@@ -1,0 +1,55 @@
+module Test {
+  fun uppercase (value : String) : Array(String) {
+    for value of String.split(value, ",") {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 30
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 17
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_function_argument
+++ b/spec/language_server/definition/location/variable_function_argument
@@ -1,0 +1,53 @@
+module Test {
+  fun toString (status : String) : String {
+    status
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 16
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_function_argument_stop
+++ b/spec/language_server/definition/location/variable_function_argument_stop
@@ -1,0 +1,29 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 12
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 0
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_module_constant
+++ b/spec/language_server/definition/location/variable_module_constant
@@ -1,0 +1,55 @@
+module Test {
+  const TITLE = "title"
+
+  fun title : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_nextcall_component
+++ b/spec/language_server/definition/location/variable_nextcall_component
@@ -1,0 +1,59 @@
+component Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+
+  fun render {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_nextcall_record
+++ b/spec/language_server/definition/location/variable_nextcall_record
@@ -1,0 +1,74 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+
+store Test {
+  state article : Article =
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: "Mint"
+    }
+
+  fun load : Promise(Void) {
+    next
+      {
+        article:
+          {
+            id: 1,
+            description: "Mint Lang",
+            title: "Mint"
+          }
+      }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 20,
+      "character": 12
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_nextcall_store
+++ b/spec/language_server/definition/location/variable_nextcall_store
@@ -1,0 +1,55 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_nextcall_value
+++ b/spec/language_server/definition/location/variable_nextcall_value
@@ -1,0 +1,58 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    let newText =
+      "Mint"
+
+    next { text: newText }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 17
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 8
+      },
+      "end": {
+        "line": 4,
+        "character": 15
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_provider_constant
+++ b/spec/language_server/definition/location/variable_provider_constant
@@ -1,0 +1,59 @@
+record Subscription {
+  a : Bool
+}
+
+provider Provider : Subscription {
+  const TITLE = "title"
+
+  fun title : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 8
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_recordfield_key
+++ b/spec/language_server/definition/location/variable_recordfield_key
@@ -1,0 +1,63 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+
+module Test {
+  fun makeArticle (title : String) : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: title
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 9,
+      "character": 6
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 4
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_recordfield_value
+++ b/spec/language_server/definition/location/variable_recordfield_value
@@ -1,0 +1,63 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+---------------------------------------------------------------file article.mint
+module Test {
+  fun makeArticle (title : String) : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: title
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 13
+    }
+  },
+  "method": "textDocument/definition"
+}
+------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 19
+      },
+      "end": {
+        "line": 1,
+        "character": 24
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_store_constant
+++ b/spec/language_server/definition/location/variable_store_constant
@@ -1,0 +1,55 @@
+store Test {
+  const TITLE = "title"
+
+  fun getTitle : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_store_function
+++ b/spec/language_server/definition/location/variable_store_function
@@ -1,0 +1,57 @@
+store Test {
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load("Mint")
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 6,
+      "character": 10
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_store_get
+++ b/spec/language_server/definition/location/variable_store_get
@@ -1,0 +1,61 @@
+store Test {
+  get description : String {
+    "description"
+  }
+
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load(description)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 10,
+      "character": 15
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 17
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_store_state
+++ b/spec/language_server/definition/location/variable_store_state
@@ -1,0 +1,59 @@
+store Test {
+  state title : String = "title"
+
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load(title)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 15
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/variable_suite_constant
+++ b/spec/language_server/definition/location/variable_suite_constant
@@ -1,0 +1,55 @@
+suite "Test" {
+  const TITLE = "title"
+
+  test "it has a constant" {
+    TITLE == "title"
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    },
+    "uri": "file://#{root_path}/test.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_block_statement_target
+++ b/spec/language_server/definition/location_link/variable_block_statement_target
@@ -1,0 +1,75 @@
+module Test {
+  fun upperCaseMint : String {
+    let test =
+      "Mint"
+
+    String.toUpperCase(test)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 23
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 23
+      },
+      "end": {
+        "line": 5,
+        "character": 27
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 4
+      },
+      "end": {
+        "line": 3,
+        "character": 12
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 12
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_casebranch_enumdestructuring
+++ b/spec/language_server/definition/location_link/variable_casebranch_enumdestructuring
@@ -1,0 +1,81 @@
+enum Status {
+  Error
+  Ok(text : String)
+}
+
+module Test {
+  fun toString (status : Status) : String {
+    case status {
+      Status::Ok(text) => text
+      Status::Error => "error"
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 26
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 8,
+        "character": 26
+      },
+      "end": {
+        "line": 8,
+        "character": 30
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 8,
+        "character": 6
+      },
+      "end": {
+        "line": 8,
+        "character": 22
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 8,
+        "character": 17
+      },
+      "end": {
+        "line": 8,
+        "character": 21
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_connect
+++ b/spec/language_server/definition/location_link/variable_component_connect
@@ -1,0 +1,80 @@
+component Test {
+  connect Theme exposing { primary }
+
+  fun render : Html {
+    <div>
+      <{ primary }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+store Theme {
+  state primary : String = "#00a0e8"
+}
+-----------------------------------------------------------------file store.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 9
+      },
+      "end": {
+        "line": 5,
+        "character": 16
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 36
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 27
+      },
+      "end": {
+        "line": 1,
+        "character": 34
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_connect_as
+++ b/spec/language_server/definition/location_link/variable_component_connect_as
@@ -1,0 +1,80 @@
+component Test {
+  connect Theme exposing { primary as primaryColor }
+
+  fun render : Html {
+    <div>
+      <{ primaryColor }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+store Theme {
+  state primary : String = "#00a0e8"
+}
+-----------------------------------------------------------------file store.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 9
+      },
+      "end": {
+        "line": 5,
+        "character": 21
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 52
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 38
+      },
+      "end": {
+        "line": 1,
+        "character": 50
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_constant
+++ b/spec/language_server/definition/location_link/variable_component_constant
@@ -1,0 +1,77 @@
+component Test {
+  const TEXT = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ TEXT }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 9
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 21
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_function
+++ b/spec/language_server/definition/location_link/variable_component_function
@@ -1,0 +1,79 @@
+component Test {
+  fun text : String {
+    "Mint"
+  }
+
+  fun render : Html {
+    <div>
+      <{ text() }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 7,
+        "character": 9
+      },
+      "end": {
+        "line": 7,
+        "character": 13
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 3,
+        "character": 3
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_get
+++ b/spec/language_server/definition/location_link/variable_component_get
@@ -1,0 +1,79 @@
+component Test {
+  get text : String {
+    "Mint"
+  }
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 7,
+        "character": 9
+      },
+      "end": {
+        "line": 7,
+        "character": 13
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 5,
+        "character": 2
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_property
+++ b/spec/language_server/definition/location_link/variable_component_property
@@ -1,0 +1,77 @@
+component Test {
+  property text : String = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 9
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 33
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 11
+      },
+      "end": {
+        "line": 1,
+        "character": 15
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_state
+++ b/spec/language_server/definition/location_link/variable_component_state
@@ -1,0 +1,77 @@
+component Test {
+  state text : String = "Mint"
+
+  fun render : Html {
+    <div>
+      <{ text }>
+    </div>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 9
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 9
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 30
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_for
+++ b/spec/language_server/definition/location_link/variable_for
@@ -1,0 +1,75 @@
+module Test {
+  fun uppercase (values : Array(String)) : Array(String) {
+    for value of values {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 25
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 3,
+        "character": 25
+      },
+      "end": {
+        "line": 3,
+        "character": 30
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 4
+      },
+      "end": {
+        "line": 5,
+        "character": 2
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 8
+      },
+      "end": {
+        "line": 2,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_for_argument_stop
+++ b/spec/language_server/definition/location_link/variable_for_argument_stop
@@ -1,0 +1,43 @@
+module Test {
+  fun uppercase (value : String) : Array(String) {
+    for value of String.split(value, ",") {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 8
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_for_subject
+++ b/spec/language_server/definition/location_link/variable_for_subject
@@ -1,0 +1,75 @@
+module Test {
+  fun uppercase (value : String) : Array(String) {
+    for value of String.split(value, ",") {
+      String.toUpperCase(value)
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 30
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 30
+      },
+      "end": {
+        "line": 2,
+        "character": 35
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 17
+      },
+      "end": {
+        "line": 1,
+        "character": 31
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 17
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_function_argument
+++ b/spec/language_server/definition/location_link/variable_function_argument
@@ -1,0 +1,73 @@
+module Test {
+  fun toString (status : String) : String {
+    status
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 4
+      },
+      "end": {
+        "line": 2,
+        "character": 10
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 16
+      },
+      "end": {
+        "line": 1,
+        "character": 31
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 16
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_function_argument_stop
+++ b/spec/language_server/definition/location_link/variable_function_argument_stop
@@ -1,0 +1,29 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 3,
+      "character": 12
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": null,
+  "id": 0
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_module_constant
+++ b/spec/language_server/definition/location_link/variable_module_constant
@@ -1,0 +1,75 @@
+module Test {
+  const TITLE = "title"
+
+  fun title : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 4,
+        "character": 9
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 23
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_component
+++ b/spec/language_server/definition/location_link/variable_nextcall_component
@@ -1,0 +1,79 @@
+component Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+
+  fun render {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 11
+      },
+      "end": {
+        "line": 4,
+        "character": 15
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 26
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_record
+++ b/spec/language_server/definition/location_link/variable_nextcall_record
@@ -1,0 +1,94 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+
+store Test {
+  state article : Article =
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: "Mint"
+    }
+
+  fun load : Promise(Void) {
+    next
+      {
+        article:
+          {
+            id: 1,
+            description: "Mint Lang",
+            title: "Mint"
+          }
+      }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 20,
+      "character": 12
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 20,
+        "character": 12
+      },
+      "end": {
+        "line": 20,
+        "character": 23
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 22
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 2,
+        "character": 2
+      },
+      "end": {
+        "line": 2,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_store
+++ b/spec/language_server/definition/location_link/variable_nextcall_store
@@ -1,0 +1,75 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    next { text: text }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 11
+      },
+      "end": {
+        "line": 4,
+        "character": 15
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 26
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_value
+++ b/spec/language_server/definition/location_link/variable_nextcall_value
@@ -1,0 +1,78 @@
+store Test {
+  state text : String = ""
+
+  fun load (text : String) : Promise(Void) {
+    let newText =
+      "Mint"
+
+    next { text: newText }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 7,
+      "character": 17
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 7,
+        "character": 17
+      },
+      "end": {
+        "line": 7,
+        "character": 24
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 5,
+        "character": 12
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 8
+      },
+      "end": {
+        "line": 4,
+        "character": 15
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_provider_constant
+++ b/spec/language_server/definition/location_link/variable_provider_constant
@@ -1,0 +1,79 @@
+record Subscription {
+  a : Bool
+}
+
+provider Provider : Subscription {
+  const TITLE = "title"
+
+  fun title : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 8,
+        "character": 4
+      },
+      "end": {
+        "line": 8,
+        "character": 9
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 5,
+        "character": 2
+      },
+      "end": {
+        "line": 5,
+        "character": 23
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 8
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_recordfield_key
+++ b/spec/language_server/definition/location_link/variable_recordfield_key
@@ -1,0 +1,83 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+
+module Test {
+  fun makeArticle (title : String) : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: title
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 9,
+      "character": 6
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 9,
+        "character": 6
+      },
+      "end": {
+        "line": 9,
+        "character": 8
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 4
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_recordfield_value
+++ b/spec/language_server/definition/location_link/variable_recordfield_value
@@ -1,0 +1,83 @@
+record Article {
+  id : Number,
+  description : String,
+  title : String
+}
+---------------------------------------------------------------file article.mint
+module Test {
+  fun makeArticle (title : String) : Article {
+    {
+      id: 1,
+      description: "Mint Lang",
+      title: title
+    }
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 5,
+      "character": 13
+    }
+  },
+  "method": "textDocument/definition"
+}
+------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 5,
+        "character": 13
+      },
+      "end": {
+        "line": 5,
+        "character": 18
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 19
+      },
+      "end": {
+        "line": 1,
+        "character": 33
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 19
+      },
+      "end": {
+        "line": 1,
+        "character": 24
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_constant
+++ b/spec/language_server/definition/location_link/variable_store_constant
@@ -1,0 +1,75 @@
+store Test {
+  const TITLE = "title"
+
+  fun getTitle : String {
+    TITLE
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 4,
+        "character": 9
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 23
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_function
+++ b/spec/language_server/definition/location_link/variable_store_function
@@ -1,0 +1,77 @@
+store Test {
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load("Mint")
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 6,
+      "character": 10
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 6,
+        "character": 10
+      },
+      "end": {
+        "line": 6,
+        "character": 14
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 3,
+        "character": 3
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 10
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_get
+++ b/spec/language_server/definition/location_link/variable_store_get
@@ -1,0 +1,81 @@
+store Test {
+  get description : String {
+    "description"
+  }
+
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load(description)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 10,
+      "character": 15
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 10,
+        "character": 15
+      },
+      "end": {
+        "line": 10,
+        "character": 26
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 5,
+        "character": 2
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 6
+      },
+      "end": {
+        "line": 1,
+        "character": 17
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_state
+++ b/spec/language_server/definition/location_link/variable_store_state
@@ -1,0 +1,79 @@
+store Test {
+  state title : String = "title"
+
+  fun load (text : String) : Promise(Void) {
+    Promise.never()
+  }
+
+  fun dashboard : Promise(Void) {
+    await load(title)
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 8,
+      "character": 15
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 8,
+        "character": 15
+      },
+      "end": {
+        "line": 8,
+        "character": 20
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 32
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_suite_constant
+++ b/spec/language_server/definition/location_link/variable_suite_constant
@@ -1,0 +1,75 @@
+suite "Test" {
+  const TITLE = "title"
+
+  test "it has a constant" {
+    TITLE == "title"
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 4,
+      "character": 4
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "originSelectionRange": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 4,
+        "character": 9
+      }
+    },
+    "targetUri": "file://#{root_path}/test.mint",
+    "targetRange": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 23
+      }
+    },
+    "targetSelectionRange": {
+      "start": {
+        "line": 1,
+        "character": 8
+      },
+      "end": {
+        "line": 1,
+        "character": 13
+      }
+    }
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/src/ls/definition/enum_id.cr
+++ b/src/ls/definition/enum_id.cr
@@ -8,7 +8,11 @@ module Mint
         if name.nil?
           stack.each do |parent|
             case parent
-            when Ast::Component, Ast::Store
+            when Ast::Component,
+                 Ast::Store,
+                 Ast::Suite,
+                 Ast::Module,
+                 Ast::Provider
               parent.constants.each do |constant|
                 if node.option.value == constant.name.value
                   return location_link server, node.option, constant.name, constant

--- a/src/ls/definition/enum_id.cr
+++ b/src/ls/definition/enum_id.cr
@@ -2,20 +2,35 @@ module Mint
   module LS
     class Definition < LSP::RequestMessage
       def definition(node : Ast::EnumId, server : Server, workspace : Workspace, stack : Array(Ast::Node))
-        return unless name = node.name
-        return unless enum_node =
-                        workspace.ast.enums.find(&.name.value.==(name.value))
+        name = node.name
 
-        return if Core.ast.enums.includes?(enum_node)
+        # When `.name` is nil the node is used as a CONSTANT
+        if name.nil?
+          stack.each do |parent|
+            case parent
+            when Ast::Component, Ast::Store
+              parent.constants.each do |constant|
+                if node.option.value == constant.name.value
+                  return location_link server, node.option, constant.name, constant
+                end
+              end
+            end
+          end
+        else
+          return unless enum_node =
+                          workspace.ast.enums.find(&.name.value.==(name.value))
 
-        case
-        when cursor_intersects?(name)
-          location_link server, name, enum_node.name, enum_node
-        when cursor_intersects?(node.option)
-          return unless option =
-                          enum_node.try &.options.find(&.value.value.==(node.option.value))
+          return if Core.ast.enums.includes?(enum_node)
 
-          location_link server, node.option, option.value, option
+          case
+          when cursor_intersects?(name)
+            location_link server, name, enum_node.name, enum_node
+          when cursor_intersects?(node.option)
+            return unless option =
+                            enum_node.try &.options.find(&.value.value.==(node.option.value))
+
+            location_link server, node.option, option.value, option
+          end
         end
       end
     end

--- a/src/ls/definition/variable.cr
+++ b/src/ls/definition/variable.cr
@@ -1,0 +1,101 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::Variable, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        lookup = workspace.type_checker.variables[node]?
+
+        if lookup
+          variable_lookup_parent(node, lookup[1], server, workspace) ||
+            variable_connect(node, lookup[2], server) ||
+            variable_lookup(node, lookup[0], server)
+        else
+          variable_record_key(node, server, workspace, stack) ||
+            variable_next_key(node, server, workspace, stack)
+        end
+      end
+
+      def variable_connect(node : Ast::Variable, parents : Array(TypeChecker::Scope::Node), server : Server)
+        # Check to see if this variable is defined as an Ast::ConnectVariable
+        # as the `.variables` cache links directly to the stores state/function etc
+        return unless component = parents.select(Ast::Component).first?
+
+        component.connects.each do |connect|
+          connect.keys.each do |key|
+            variable = key.name || key.variable
+
+            if variable.value == node.value
+              return location_link server, node, variable, connect
+            end
+          end
+        end
+      end
+
+      def variable_lookup_parent(node : Ast::Variable, target : TypeChecker::Scope::Node, server : Server, workspace : Workspace)
+        case target
+        when Tuple(String, TypeChecker::Checkable, Ast::Node)
+          case variable = target[2]
+          when Ast::Variable
+            # For some variables in the .variables` cache, we only have access to the
+            # target Ast::Variable and not its containing node, so we must search for it
+            return unless parent = workspace
+                            .ast
+                            .nodes
+                            .select { |other| other.is_a?(Ast::EnumDestructuring) || other.is_a?(Ast::Statement) || other.is_a?(Ast::For) }
+                            .select(&.input.file.==(variable.input.file))
+                            .find { |other| other.from < variable.from && other.to > variable.to }
+
+            location_link server, node, variable, parent
+          end
+        end
+      end
+
+      def variable_lookup(node : Ast::Variable, target : Ast::Node | TypeChecker::Checkable, server : Server)
+        case item = target
+        when Ast::Node
+          name = case item
+                 when Ast::Property,
+                      Ast::Constant,
+                      Ast::Function,
+                      Ast::State,
+                      Ast::Get,
+                      Ast::Argument
+                   item.name
+                 else
+                   item
+                 end
+
+          location_link server, node, name, item
+        end
+      end
+
+      def variable_record_key(node : Ast::Variable, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        case field = stack[1]?
+        when Ast::RecordField
+          return unless record_name = workspace.type_checker.record_field_lookup[field]?
+
+          return unless record_definition_field = workspace
+                          .ast
+                          .records
+                          .find(&.name.value.==(record_name))
+                          .try(&.fields.find(&.key.value.==(node.value)))
+
+          location_link server, node, record_definition_field.key, record_definition_field
+        end
+      end
+
+      def variable_next_key(node : Ast::Variable, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+        case next_call = stack[3]?
+        when Ast::NextCall
+          return unless parent = workspace.type_checker.lookups[next_call]
+
+          return unless state = case parent
+                                when Ast::Provider, Ast::Component, Ast::Store
+                                  parent.states.find(&.name.value.==(node.value))
+                                end
+
+          location_link server, node, state.name, state
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Been through a couple of iterations of this and still not terribly happy with the code (could do with another pass or two :sweat_smile:), but this PR adds "Go to Definition" support for the majority of `Ast::Variable`'s.

Here's a quick example of it in action:

https://github.com/mint-lang/mint/assets/1927518/421bb271-328d-43ab-874b-3e2709eec1fd

Will keep testing as I'm sure there's a bunch of weird and wonderful ways of using Mint that I haven't accounted for, but it's pretty handy as is!

_Note_: There are a couple of tests that will fail until the fix from https://github.com/mint-lang/mint/pull/615 has been merged 



