### PR TITLE
Fix constants/gets not working within a Provider

### DIFF
--- a/spec/compilers/provider_with_items
+++ b/spec/compilers/provider_with_items
@@ -1,0 +1,102 @@
+record Subscription {
+  a : Bool,
+  b : Bool
+}
+
+provider Provider : Subscription {
+  const NAME = "hello"
+
+  state a : String = ""
+
+  get b : String {
+    a
+  }
+
+  fun name : String {
+    NAME
+  }
+}
+
+component Main {
+  use Provider {
+    a: true,
+    b: false
+  }
+
+  fun render {
+    <div/>
+  }
+}
+--------------------------------------------------------------------------------
+const A = _R({
+  a: [
+    "a",
+    Decoder.boolean
+  ],
+  b: [
+    "b",
+    Decoder.boolean
+  ]
+});
+
+const B = new(class extends _P {
+  constructor() {
+    super();
+
+    this.state = {
+      c: ``
+    };
+
+    this._d({
+      b: () => {
+        return `hello`
+      }
+    });
+  }
+
+  get c() {
+    return this.state.c;
+  }
+
+  get d() {
+    return this.c
+  }
+
+  a() {
+    return this.b;
+  }
+});
+
+class C extends _C {
+  componentWillUnmount() {
+    B._unsubscribe(this);
+  }
+
+  componentDidUpdate() {
+    if (true) {
+      B._subscribe(this, new A({
+        a: true,
+        b: false
+      }))
+    } else {
+      B._unsubscribe(this)
+    };
+  }
+
+  componentDidMount() {
+    if (true) {
+      B._subscribe(this, new A({
+        a: true,
+        b: false
+      }))
+    } else {
+      B._unsubscribe(this)
+    };
+  }
+
+  render() {
+    return _h("div", {});
+  }
+};
+
+C.displayName = "Main";

--- a/spec/formatters/constant_provider
+++ b/spec/formatters/constant_provider
@@ -1,0 +1,24 @@
+record Subscription {
+  a : Bool
+}
+
+provider Provider:Subscription {
+  /* Comment */constNAME="hello"
+
+  fun name:String {
+    NAME
+  }
+}
+--------------------------------------------------------------------------------
+record Subscription {
+  a : Bool
+}
+
+provider Provider : Subscription {
+  /* Comment */
+  const NAME = "hello"
+
+  fun name : String {
+    NAME
+  }
+}

--- a/spec/formatters/provider_with_items
+++ b/spec/formatters/provider_with_items
@@ -1,0 +1,34 @@
+record Subscription {
+    a : Bool
+}
+  
+provider Provider:Subscription {
+/* Comment */constNAME="hello"
+
+  state a :String = ""
+  getb:String {
+  a
+  }
+  fun name:String {
+    NAME
+  }
+}
+--------------------------------------------------------------------------------
+record Subscription {
+  a : Bool
+}
+
+provider Provider : Subscription {
+  /* Comment */
+  const NAME = "hello"
+
+  state a : String = ""
+
+  get b : String {
+    a
+  }
+
+  fun name : String {
+    NAME
+  }
+}

--- a/spec/type_checking/provider_const
+++ b/spec/type_checking/provider_const
@@ -1,0 +1,24 @@
+record Subscription {
+    a : Bool
+}
+  
+provider Provider : Subscription {
+  const ONE_PLUS_ONE = 1 + 1
+  const TWO = 2
+
+  fun test : Bool {
+    ONE_PLUS_ONE == TWO
+  }
+}
+-----------------------------------------------------------------VariableMissing
+record Subscription {
+  a : Bool
+}
+  
+provider Provider : Subscription {
+  const TWO = 2
+
+  fun test : Bool {
+    1 + TWO == THREE
+  }
+}

--- a/src/formatters/provider.cr
+++ b/src/formatters/provider.cr
@@ -8,7 +8,7 @@ module Mint
         node.subscription
 
       body =
-        list node.functions + node.comments + node.states + node.gets
+        list node.functions + node.comments + node.states + node.gets + node.constants
 
       comment =
         node.comment.try { |item| "#{format(item)}\n" }

--- a/src/parsers/provider.cr
+++ b/src/parsers/provider.cr
@@ -26,7 +26,7 @@ module Mint
           opening_bracket: ProviderExpectedOpeningBracket,
           closing_bracket: ProviderExpectedClosingBracket
         ) do
-          items = many { function || state || constant || self.comment }
+          items = many { function || state || get || constant || self.comment }
 
           raise ProviderExpectedBody if items.none?(Ast::Function)
 

--- a/src/type_checker/scope.cr
+++ b/src/type_checker/scope.cr
@@ -156,7 +156,7 @@ module Mint
           node.functions.find(&.name.value.==(variable)) ||
             node.states.find(&.name.value.==(variable)) ||
             node.gets.find(&.name.value.==(variable)) ||
-            node.constants.find(&.name.==(variable))
+            node.constants.find(&.name.value.==(variable))
         end
       end
 


### PR DESCRIPTION
As mentioned within https://github.com/mint-lang/mint/pull/619#discussion_r1270890982, this PR fixes a couple of issues with both constants and gets when using them with a Provider:

* Constants were being removed when formatting
* Constants weren't being type checked correctly (you would receive a `VariableMissing` error)
* Gets were not being parsed 

I've done a quick test in browser and the above seems to be working there too :smile: Unfortunately none of the existing providers use these features yet - perhaps some `.mint` tests purely for testing language features rather than the standard library might be useful? 

I'll update the other PR to support Providers once this is merged :+1: 