### PR TITLE
Separate nightly CI runs into a separate workflow.

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,12 +1,8 @@
-name: CI
+name: CI Nightly
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  release:
-    types: [published]
+  schedule:
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -16,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crystal: latest
+        crystal: nightly
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -12,14 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crystal: nightly
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{ matrix.crystal }}
+          crystal: nightly
 
       - name: Download source
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crystal: latest
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{ matrix.crystal }}
+          crystal: latest
 
       - name: Download source
         uses: actions/checkout@v3


### PR DESCRIPTION
For a few months now, the CI task was/is broken because the builds fail on the nightly builds. Mostly because of ameba and Crystal and it doesn't seem to be getting better (I was hoping for 1.9 to fix this but it just got broken again).

This causes some issues:
- the badge in the README is red, signaling that the project is neglected
- perfectly fine pull requests appear to be broken
- it takes time to track down the issue and get it fixed for a Crystal version that is not released yet 
- I get emails for all failures

So this PR separates the Crystal nightly builds into it's on workflow, which runs on every Monday.