### PR TITLE
LSP: Fix enum destructuring/id linking to other types with the same name

### DIFF
--- a/spec/language_server/definition/location_link/enum_destructuring_option
+++ b/spec/language_server/definition/location_link/enum_destructuring_option
@@ -1,3 +1,9 @@
+component Error {
+  fun render {
+    <div/>
+  }
+}
+-------------------------------------------------------------file component.mint
 /* Comment for Status enum. */
 enum Status {
   Error

--- a/spec/language_server/definition/location_link/enum_id_option
+++ b/spec/language_server/definition/location_link/enum_id_option
@@ -1,3 +1,9 @@
+component Ok {
+  fun render {
+    <div/>
+  }
+}
+-------------------------------------------------------------file component.mint
 enum Status {
   Error
   Ok

--- a/src/parsers/enum_destructuring.cr
+++ b/src/parsers/enum_destructuring.cr
@@ -6,11 +6,11 @@ module Mint
 
     def enum_destructuring
       start do |start_position|
-        next unless option = type_id
+        next unless option = type_id track: false
 
         if keyword "::"
           name = option
-          option = type_id! EnumDestructuringExpectedOption
+          option = type_id! EnumDestructuringExpectedOption, track: false
         end
 
         parameters = [] of Ast::Node

--- a/src/parsers/enum_id.cr
+++ b/src/parsers/enum_id.cr
@@ -30,11 +30,11 @@ module Mint
 
     def enum_id
       start do |start_position|
-        next unless option = type_id
+        next unless option = type_id track: false
 
         if keyword "::"
           name = option
-          option = type_id! EnumIdExpectedOption
+          option = type_id! EnumIdExpectedOption, track: false
         end
 
         self << Ast::EnumId.new(


### PR DESCRIPTION
Noticed a bug when working on a fix for the [issue mentioned in my last PR](https://github.com/mint-lang/mint/pull/623#discussion_r1285119505).

When doing "Go to Definition" on an `Ast::EnumId` or `Ast::EnumDestructuring` node, if their `.option` field matched the name of an existing component, store etc, then it would link to that instead.

Here's an example of the issue in video form:

https://github.com/mint-lang/mint/assets/1927518/25c6b32c-c312-43b9-82da-8d5799af3db8

The fix here was to stop tracking `Ast::TypeId` within these two nodes, as hover/definition etc use the higher level nodes to provide their features anyway.
