### PR TITLE
LSP: Fix `LSP::LocationLink`'s not being returned within an array 

### DIFF
--- a/spec/language_server/definition/location_link/connect
+++ b/spec/language_server/definition/location_link/connect
@@ -42,39 +42,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 10
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 10
+        },
+        "end": {
+          "line": 1,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_constant
+++ b/spec/language_server/definition/location_link/connect_variable_constant
@@ -42,39 +42,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 27
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 27
+        },
+        "end": {
+          "line": 1,
+          "character": 35
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 35
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 23
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 8
-      },
-      "end": {
-        "line": 2,
-        "character": 16
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 8
+        },
+        "end": {
+          "line": 2,
+          "character": 16
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_function
+++ b/spec/language_server/definition/location_link/connect_variable_function
@@ -44,39 +44,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 27
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 27
+        },
+        "end": {
+          "line": 1,
+          "character": 31
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 31
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 4,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 6
-      },
-      "end": {
-        "line": 2,
-        "character": 10
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 6
+        },
+        "end": {
+          "line": 2,
+          "character": 10
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_get
+++ b/spec/language_server/definition/location_link/connect_variable_get
@@ -44,39 +44,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 27
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 27
+        },
+        "end": {
+          "line": 1,
+          "character": 31
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 31
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 0
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 0
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 6
-      },
-      "end": {
-        "line": 2,
-        "character": 10
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 6
+        },
+        "end": {
+          "line": 2,
+          "character": 10
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/connect_variable_state
+++ b/spec/language_server/definition/location_link/connect_variable_state
@@ -42,39 +42,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 27
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 27
+        },
+        "end": {
+          "line": 1,
+          "character": 35
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 35
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 24
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 24
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 8
-      },
-      "end": {
-        "line": 2,
-        "character": 16
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 8
+        },
+        "end": {
+          "line": 2,
+          "character": 16
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_destructuring_name
+++ b/spec/language_server/definition/location_link/enum_destructuring_name
@@ -44,39 +44,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 6
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 6
+        },
+        "end": {
+          "line": 3,
+          "character": 12
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 12
-      }
-    },
-    "targetUri": "file://#{root_path}/status.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/status.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 5
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 5
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_destructuring_option
+++ b/spec/language_server/definition/location_link/enum_destructuring_option
@@ -44,39 +44,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 14
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 14
+        },
+        "end": {
+          "line": 3,
+          "character": 19
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 19
-      }
-    },
-    "targetUri": "file://#{root_path}/status.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/status.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 2
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 2
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 2
-      },
-      "end": {
-        "line": 2,
-        "character": 7
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 7
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_id_name
+++ b/spec/language_server/definition/location_link/enum_id_name
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 26
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 26
+        },
+        "end": {
+          "line": 1,
+          "character": 32
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 32
-      }
-    },
-    "targetUri": "file://#{root_path}/status.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/status.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 5
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 5
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/enum_id_option
+++ b/spec/language_server/definition/location_link/enum_id_option
@@ -42,39 +42,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 34
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 34
+        },
+        "end": {
+          "line": 1,
+          "character": 36
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 36
-      }
-    },
-    "targetUri": "file://#{root_path}/status.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/status.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 0
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 0
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 2
-      },
-      "end": {
-        "line": 2,
-        "character": 4
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 4
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/html_attribute
+++ b/spec/language_server/definition/location_link/html_attribute
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 12
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 12
+        },
+        "end": {
+          "line": 2,
+          "character": 16
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 16
-      }
-    },
-    "targetUri": "file://#{root_path}/button.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/button.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 34
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 34
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 11
-      },
-      "end": {
-        "line": 1,
-        "character": 15
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 15
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/html_component
+++ b/spec/language_server/definition/location_link/html_component
@@ -42,39 +42,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 5
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 5
+        },
+        "end": {
+          "line": 2,
+          "character": 11
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 11
-      }
-    },
-    "targetUri": "file://#{root_path}/button.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/button.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 5,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 10
-      },
-      "end": {
-        "line": 1,
-        "character": 16
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 10
+        },
+        "end": {
+          "line": 1,
+          "character": 16
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/html_style
+++ b/spec/language_server/definition/location_link/html_style
@@ -39,39 +39,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 6,
-        "character": 10
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 6,
+          "character": 10
+        },
+        "end": {
+          "line": 6,
+          "character": 14
+        }
       },
-      "end": {
-        "line": 6,
-        "character": 14
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_component_constant
+++ b/spec/language_server/definition/location_link/module_access_component_constant
@@ -45,39 +45,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/header.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/header.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_component_function
+++ b/spec/language_server/definition/location_link/module_access_component_function
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 22
-      }
-    },
-    "targetUri": "file://#{root_path}/header.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/header.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_component_gets
+++ b/spec/language_server/definition/location_link/module_access_component_gets
@@ -47,39 +47,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/header.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/header.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 2
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 2
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_component_name
+++ b/spec/language_server/definition/location_link/module_access_component_name
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 9
+        },
+        "end": {
+          "line": 3,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/header.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/header.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 17
-      },
-      "end": {
-        "line": 0,
-        "character": 23
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 17
+        },
+        "end": {
+          "line": 0,
+          "character": 23
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_component_state
+++ b/spec/language_server/definition/location_link/module_access_component_state
@@ -45,39 +45,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/header.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/header.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_module_constant
+++ b/spec/language_server/definition/location_link/module_access_module_constant
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/module.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/module.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_module_function
+++ b/spec/language_server/definition/location_link/module_access_module_function
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/module.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/module.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_module_name
+++ b/spec/language_server/definition/location_link/module_access_module_name
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 9
+        },
+        "end": {
+          "line": 3,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/module.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/module.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 7
-      },
-      "end": {
-        "line": 0,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 7
+        },
+        "end": {
+          "line": 0,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_module_name_shared
+++ b/spec/language_server/definition/location_link/module_access_module_name_shared
@@ -50,39 +50,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 6
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 6
+        },
+        "end": {
+          "line": 3,
+          "character": 12
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 12
-      }
-    },
-    "targetUri": "file://#{root_path}/module.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/module.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 7
-      },
-      "end": {
-        "line": 0,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 7
+        },
+        "end": {
+          "line": 0,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_store_constant
+++ b/spec/language_server/definition/location_link/module_access_store_constant
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_store_function
+++ b/spec/language_server/definition/location_link/module_access_store_function
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_store_gets
+++ b/spec/language_server/definition/location_link/module_access_store_gets
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 4,
+          "character": 0
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 0
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_store_name
+++ b/spec/language_server/definition/location_link/module_access_store_name
@@ -43,39 +43,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 9
+        },
+        "end": {
+          "line": 3,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 6
-      },
-      "end": {
-        "line": 0,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 6
+        },
+        "end": {
+          "line": 0,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/module_access_store_state
+++ b/spec/language_server/definition/location_link/module_access_store_state
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/store.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/store.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/type_enum
+++ b/spec/language_server/definition/location_link/type_enum
@@ -40,39 +40,41 @@ module Status {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 16
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 16
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 22
-      }
-    },
-    "targetUri": "file://#{root_path}/status.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/status.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 5
-      },
-      "end": {
-        "line": 0,
-        "character": 11
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 5
+        },
+        "end": {
+          "line": 0,
+          "character": 11
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/type_record
+++ b/spec/language_server/definition/location_link/type_record
@@ -45,39 +45,41 @@ module Article {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 13
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 13
+        },
+        "end": {
+          "line": 1,
+          "character": 20
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 20
-      }
-    },
-    "targetUri": "file://#{root_path}/article.mint",
-    "targetRange": {
-      "start": {
-        "line": 0,
-        "character": 0
+      "targetUri": "file://#{root_path}/article.mint",
+      "targetRange": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 1
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 1
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 0,
-        "character": 7
-      },
-      "end": {
-        "line": 0,
-        "character": 14
+      "targetSelectionRange": {
+        "start": {
+          "line": 0,
+          "character": 7
+        },
+        "end": {
+          "line": 0,
+          "character": 14
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_block_statement_target
+++ b/spec/language_server/definition/location_link/variable_block_statement_target
@@ -37,39 +37,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 23
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 23
+        },
+        "end": {
+          "line": 5,
+          "character": 27
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 27
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 4
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 4
+        },
+        "end": {
+          "line": 3,
+          "character": 12
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 12
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 8
-      },
-      "end": {
-        "line": 2,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 8
+        },
+        "end": {
+          "line": 2,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_casebranch_enumdestructuring
+++ b/spec/language_server/definition/location_link/variable_casebranch_enumdestructuring
@@ -43,39 +43,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 8,
-        "character": 26
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 8,
+          "character": 26
+        },
+        "end": {
+          "line": 8,
+          "character": 30
+        }
       },
-      "end": {
-        "line": 8,
-        "character": 30
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 8,
-        "character": 6
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 8,
+          "character": 6
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 8,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 8,
-        "character": 17
-      },
-      "end": {
-        "line": 8,
-        "character": 21
+      "targetSelectionRange": {
+        "start": {
+          "line": 8,
+          "character": 17
+        },
+        "end": {
+          "line": 8,
+          "character": 21
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_connect
+++ b/spec/language_server/definition/location_link/variable_component_connect
@@ -42,39 +42,41 @@ store Theme {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 16
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 16
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 36
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 36
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 27
-      },
-      "end": {
-        "line": 1,
-        "character": 34
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 27
+        },
+        "end": {
+          "line": 1,
+          "character": 34
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_connect_as
+++ b/spec/language_server/definition/location_link/variable_component_connect_as
@@ -42,39 +42,41 @@ store Theme {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 21
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 52
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 52
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 38
-      },
-      "end": {
-        "line": 1,
-        "character": 50
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 38
+        },
+        "end": {
+          "line": 1,
+          "character": 50
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_constant
+++ b/spec/language_server/definition/location_link/variable_component_constant
@@ -39,39 +39,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 13
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 21
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 21
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_function
+++ b/spec/language_server/definition/location_link/variable_component_function
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 7,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 7,
+          "character": 9
+        },
+        "end": {
+          "line": 7,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 7,
-        "character": 13
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 10
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 10
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_get
+++ b/spec/language_server/definition/location_link/variable_component_get
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 7,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 7,
+          "character": 9
+        },
+        "end": {
+          "line": 7,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 7,
-        "character": 13
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 2
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 2
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 10
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 10
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_property
+++ b/spec/language_server/definition/location_link/variable_component_property
@@ -39,39 +39,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 13
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 33
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 33
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 11
-      },
-      "end": {
-        "line": 1,
-        "character": 15
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 11
+        },
+        "end": {
+          "line": 1,
+          "character": 15
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_component_state
+++ b/spec/language_server/definition/location_link/variable_component_state
@@ -39,39 +39,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 9
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 9
+        },
+        "end": {
+          "line": 5,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 13
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 30
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 30
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_for
+++ b/spec/language_server/definition/location_link/variable_for
@@ -37,39 +37,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 3,
-        "character": 25
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 3,
+          "character": 25
+        },
+        "end": {
+          "line": 3,
+          "character": 30
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 30
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 4
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 2
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 2
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 8
-      },
-      "end": {
-        "line": 2,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 8
+        },
+        "end": {
+          "line": 2,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_for_subject
+++ b/spec/language_server/definition/location_link/variable_for_subject
@@ -37,39 +37,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 30
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 30
+        },
+        "end": {
+          "line": 2,
+          "character": 35
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 35
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 17
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 17
+        },
+        "end": {
+          "line": 1,
+          "character": 31
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 31
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 17
-      },
-      "end": {
-        "line": 1,
-        "character": 22
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 17
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_function_argument
+++ b/spec/language_server/definition/location_link/variable_function_argument
@@ -35,39 +35,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 4
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 4
+        },
+        "end": {
+          "line": 2,
+          "character": 10
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 10
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 16
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 16
+        },
+        "end": {
+          "line": 1,
+          "character": 31
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 31
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 16
-      },
-      "end": {
-        "line": 1,
-        "character": 22
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 16
+        },
+        "end": {
+          "line": 1,
+          "character": 22
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_module_constant
+++ b/spec/language_server/definition/location_link/variable_module_constant
@@ -37,39 +37,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 4
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 9
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 9
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 23
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_component
+++ b/spec/language_server/definition/location_link/variable_nextcall_component
@@ -41,39 +41,41 @@ component Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 11
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 26
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 26
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_record
+++ b/spec/language_server/definition/location_link/variable_nextcall_record
@@ -56,39 +56,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 20,
-        "character": 12
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 20,
+          "character": 12
+        },
+        "end": {
+          "line": 20,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 20,
-        "character": 23
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 2,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 22
+        }
       },
-      "end": {
-        "line": 2,
-        "character": 22
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 2,
-        "character": 2
-      },
-      "end": {
-        "line": 2,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_store
+++ b/spec/language_server/definition/location_link/variable_nextcall_store
@@ -37,39 +37,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 11
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 4,
+          "character": 15
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 15
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 26
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 26
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 12
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 12
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_nextcall_value
+++ b/spec/language_server/definition/location_link/variable_nextcall_value
@@ -40,39 +40,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 7,
-        "character": 17
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 7,
+          "character": 17
+        },
+        "end": {
+          "line": 7,
+          "character": 24
+        }
       },
-      "end": {
-        "line": 7,
-        "character": 24
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 4,
-        "character": 4
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 12
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 12
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 8
-      },
-      "end": {
-        "line": 4,
-        "character": 15
+      "targetSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 8
+        },
+        "end": {
+          "line": 4,
+          "character": 15
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_provider_constant
+++ b/spec/language_server/definition/location_link/variable_provider_constant
@@ -41,39 +41,41 @@ provider Provider : Subscription {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 8,
-        "character": 4
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 8,
+          "character": 4
+        },
+        "end": {
+          "line": 8,
+          "character": 9
+        }
       },
-      "end": {
-        "line": 8,
-        "character": 9
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 5,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 5,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 23
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 8
-      },
-      "end": {
-        "line": 5,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 8
+        },
+        "end": {
+          "line": 5,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_recordfield_key
+++ b/spec/language_server/definition/location_link/variable_recordfield_key
@@ -45,39 +45,41 @@ module Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 9,
-        "character": 6
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 9,
+          "character": 6
+        },
+        "end": {
+          "line": 9,
+          "character": 8
+        }
       },
-      "end": {
-        "line": 9,
-        "character": 8
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 13
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 2
-      },
-      "end": {
-        "line": 1,
-        "character": 4
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 4
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_recordfield_value
+++ b/spec/language_server/definition/location_link/variable_recordfield_value
@@ -45,39 +45,41 @@ module Test {
 ------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 5,
-        "character": 13
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 5,
+          "character": 13
+        },
+        "end": {
+          "line": 5,
+          "character": 18
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 18
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 19
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 19
+        },
+        "end": {
+          "line": 1,
+          "character": 33
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 33
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 19
-      },
-      "end": {
-        "line": 1,
-        "character": 24
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 19
+        },
+        "end": {
+          "line": 1,
+          "character": 24
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_constant
+++ b/spec/language_server/definition/location_link/variable_store_constant
@@ -37,39 +37,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 4
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 9
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 9
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 23
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_function
+++ b/spec/language_server/definition/location_link/variable_store_function
@@ -39,39 +39,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 6,
-        "character": 10
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 6,
+          "character": 10
+        },
+        "end": {
+          "line": 6,
+          "character": 14
+        }
       },
-      "end": {
-        "line": 6,
-        "character": 14
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
       },
-      "end": {
-        "line": 3,
-        "character": 3
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 10
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 10
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_get
+++ b/spec/language_server/definition/location_link/variable_store_get
@@ -43,39 +43,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 10,
-        "character": 15
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 10,
+          "character": 15
+        },
+        "end": {
+          "line": 10,
+          "character": 26
+        }
       },
-      "end": {
-        "line": 10,
-        "character": 26
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 2
+        }
       },
-      "end": {
-        "line": 5,
-        "character": 2
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 6
-      },
-      "end": {
-        "line": 1,
-        "character": 17
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 17
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_store_state
+++ b/spec/language_server/definition/location_link/variable_store_state
@@ -41,39 +41,41 @@ store Test {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 8,
-        "character": 15
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 8,
+          "character": 15
+        },
+        "end": {
+          "line": 8,
+          "character": 20
+        }
       },
-      "end": {
-        "line": 8,
-        "character": 20
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 32
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 32
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/variable_suite_constant
+++ b/spec/language_server/definition/location_link/variable_suite_constant
@@ -37,39 +37,41 @@ suite "Test" {
 -------------------------------------------------------------------------request
 {
   "jsonrpc": "2.0",
-  "result": {
-    "originSelectionRange": {
-      "start": {
-        "line": 4,
-        "character": 4
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 9
+        }
       },
-      "end": {
-        "line": 4,
-        "character": 9
-      }
-    },
-    "targetUri": "file://#{root_path}/test.mint",
-    "targetRange": {
-      "start": {
-        "line": 1,
-        "character": 2
+      "targetUri": "file://#{root_path}/test.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
       },
-      "end": {
-        "line": 1,
-        "character": 23
-      }
-    },
-    "targetSelectionRange": {
-      "start": {
-        "line": 1,
-        "character": 8
-      },
-      "end": {
-        "line": 1,
-        "character": 13
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 8
+        },
+        "end": {
+          "line": 1,
+          "character": 13
+        }
       }
     }
-  },
+  ],
   "id": 1
 }
 ------------------------------------------------------------------------response

--- a/src/ls/definition/connect.cr
+++ b/src/ls/definition/connect.cr
@@ -1,13 +1,13 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::Connect, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::Connect, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.store)
 
         return unless store =
                         workspace.ast.stores.find(&.name.value.==(node.store.value))
 
-        location_link server, node.store, store.name, store
+        location_link node.store, store.name, store
       end
     end
   end

--- a/src/ls/definition/connect_variable.cr
+++ b/src/ls/definition/connect_variable.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::ConnectVariable, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::ConnectVariable, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.variable)
 
         return unless connect = stack[1]?.as?(Ast::Connect)
@@ -16,7 +16,7 @@ module Mint
 
         case target
         when Ast::Function, Ast::State, Ast::Get, Ast::Constant
-          location_link server, node.variable, target.name, target
+          location_link node.variable, target.name, target
         end
       end
     end

--- a/src/ls/definition/enum_destructuring.cr
+++ b/src/ls/definition/enum_destructuring.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::EnumDestructuring, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::EnumDestructuring, workspace : Workspace, stack : Array(Ast::Node))
         return unless name = node.name
         return unless enum_node =
                         workspace.ast.enums.find(&.name.value.==(name.value))
@@ -10,12 +10,12 @@ module Mint
 
         case
         when cursor_intersects?(name)
-          location_link server, name, enum_node.name, enum_node
+          location_link name, enum_node.name, enum_node
         when cursor_intersects?(node.option)
           return unless option =
                           enum_node.try &.options.find(&.value.value.==(node.option.value))
 
-          location_link server, node.option, option.value, option
+          location_link node.option, option.value, option
         end
       end
     end

--- a/src/ls/definition/enum_id.cr
+++ b/src/ls/definition/enum_id.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::EnumId, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::EnumId, workspace : Workspace, stack : Array(Ast::Node))
         name = node.name
 
         # When `.name` is nil the node is used as a CONSTANT
@@ -15,7 +15,7 @@ module Mint
                  Ast::Provider
               parent.constants.each do |constant|
                 if node.option.value == constant.name.value
-                  return location_link server, node.option, constant.name, constant
+                  return location_link node.option, constant.name, constant
                 end
               end
             end
@@ -28,12 +28,12 @@ module Mint
 
           case
           when cursor_intersects?(name)
-            location_link server, name, enum_node.name, enum_node
+            location_link name, enum_node.name, enum_node
           when cursor_intersects?(node.option)
             return unless option =
                             enum_node.try &.options.find(&.value.value.==(node.option.value))
 
-            location_link server, node.option, option.value, option
+            location_link node.option, option.value, option
           end
         end
       end

--- a/src/ls/definition/html_attribute.cr
+++ b/src/ls/definition/html_attribute.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::HtmlAttribute, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::HtmlAttribute, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.name)
 
         return unless html_component = stack.find(&.is_a?(Ast::HtmlComponent)).as?(Ast::HtmlComponent)
@@ -12,7 +12,7 @@ module Mint
         return unless component_property =
                         component.properties.find(&.name.value.== node.name.value)
 
-        location_link server, node.name, component_property.name, component_property
+        location_link node.name, component_property.name, component_property
       end
     end
   end

--- a/src/ls/definition/html_component.cr
+++ b/src/ls/definition/html_component.cr
@@ -1,13 +1,13 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::HtmlComponent, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::HtmlComponent, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.component)
 
         return unless component =
                         find_component(workspace, node.component.value)
 
-        location_link server, node.component, component.name, component
+        location_link node.component, component.name, component
       end
     end
   end

--- a/src/ls/definition/html_element.cr
+++ b/src/ls/definition/html_element.cr
@@ -1,11 +1,11 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::HtmlElement, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::HtmlElement, workspace : Workspace, stack : Array(Ast::Node))
         node.styles.each do |style|
           next unless cursor_intersects?(style)
 
-          return definition(style, server, workspace, stack)
+          return definition(style, workspace, stack)
         end
       end
     end

--- a/src/ls/definition/html_style.cr
+++ b/src/ls/definition/html_style.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::HtmlStyle, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::HtmlStyle, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.name)
 
         return unless component = stack.find(&.is_a?(Ast::Component)).as?(Ast::Component)
@@ -9,7 +9,7 @@ module Mint
         return unless component_style =
                         component.styles.find(&.name.value.== node.name.value)
 
-        location_link server, node.name, component_style.name, component_style
+        location_link node.name, component_style.name, component_style
       end
     end
   end

--- a/src/ls/definition/module_access.cr
+++ b/src/ls/definition/module_access.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::ModuleAccess, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::ModuleAccess, workspace : Workspace, stack : Array(Ast::Node))
         lookup = workspace.type_checker.lookups[node.variable]?
 
         if lookup
@@ -11,7 +11,7 @@ module Mint
                Ast::Function,
                Ast::State,
                Ast::Get
-            location_link server, node.variable, lookup.name, lookup
+            location_link node.variable, lookup.name, lookup
           end
         end
       end

--- a/src/ls/definition/type.cr
+++ b/src/ls/definition/type.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::Type, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::Type, workspace : Workspace, stack : Array(Ast::Node))
         return unless cursor_intersects?(node.name)
 
         enum_node =
@@ -10,14 +10,14 @@ module Mint
         if enum_node
           return if Core.ast.enums.includes?(enum_node)
 
-          location_link server, node.name, enum_node.name, enum_node
+          location_link node.name, enum_node.name, enum_node
         else
           return unless record =
                           workspace.ast.records.find(&.name.value.==(node.name.value))
 
           return if Core.ast.records.includes?(record)
 
-          location_link server, node.name, record.name, record
+          location_link node.name, record.name, record
         end
       end
     end

--- a/src/ls/definition/type_id.cr
+++ b/src/ls/definition/type_id.cr
@@ -9,10 +9,9 @@ module Mint
             .reject(&.in?(Core.ast.nodes))
             .sort_by!(&.input.file)
             .map do |mod|
-              location_link server, node, mod.name, mod
+              location_link node, mod.name, mod
             end
 
-          return links.first if links.size == 1
           return links unless links.empty?
         end
 

--- a/src/ls/definition/type_id.cr
+++ b/src/ls/definition/type_id.cr
@@ -1,7 +1,7 @@
 module Mint
   module LS
     class Definition < LSP::RequestMessage
-      def definition(node : Ast::TypeId, server : Server, workspace : Workspace, stack : Array(Ast::Node))
+      def definition(node : Ast::TypeId, workspace : Workspace, stack : Array(Ast::Node))
         case stack[1]?
         when Ast::ModuleAccess
           links = workspace.ast.modules
@@ -23,14 +23,14 @@ module Mint
             find_component(workspace, node.value)
 
         if found.nil? && (next_node = stack[1])
-          return definition(next_node, server, workspace, stack)
+          return definition(next_node, workspace, stack)
         end
 
         return if Core.ast.nodes.includes?(found)
 
         case found
         when Ast::Store, Ast::Enum, Ast::Component, Ast::RecordDefinition
-          location_link server, node, found.name, found
+          location_link node, found.name, found
         end
       end
     end


### PR DESCRIPTION
This PR fixes the issue [discussed in a previous PR](https://github.com/mint-lang/mint/pull/623#discussion_r1285119505). 

Previously it was possible for the Mint's LS to return a single instance of `LSP::LocationLink` whereas [the specification ](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition) only allows these to be returned within an array (the result must be one of `Location | Location[] | LocationLink[] | null`)

VSCode and similar clients don't seem to mind this, but it would be nice to be within spec! :sweat_smile: 

--- 

I have also refactored the definition methods slightly so they are only dealing with `LSP::LocationLink`'s. If these are not supported by the client, mapping to `LSP::Location`'s is done in the main definition method. 

This allowed me to remove `server : Server` as one of the parameters that had to be passed to each of these methods.

I haven't simplified the type signature of the main method as also mentioned in the previous PR. However it does now at least match the specification.