### PR TITLE
Fix keywords and operators being kept when parsing a parent node fails

### DIFF
--- a/spec/language_server/semantic_tokens/component
+++ b/spec/language_server/semantic_tokens/component
@@ -1,0 +1,106 @@
+component Test {
+  property nextTitle : String = "World"
+
+  /*
+  Comment that spans
+  multiple lines
+  */
+  fun title : String {
+    nextTitle
+  }
+
+  fun render {
+    <div/>
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "semanticTokens": {
+          "dynamicRegistration": false,
+          "tokenTypes": ["property"]
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    }
+  },
+  "method": "textDocument/semanticTokens/full"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "data": [
+      0,
+      0,
+      9,
+      4,
+      0,
+      0,
+      10,
+      4,
+      1,
+      0,
+      1,
+      2,
+      8,
+      4,
+      0,
+      0,
+      21,
+      6,
+      1,
+      0,
+      0,
+      9,
+      7,
+      8,
+      0,
+      2,
+      2,
+      48,
+      5,
+      0,
+      4,
+      2,
+      3,
+      4,
+      0,
+      0,
+      12,
+      6,
+      1,
+      0,
+      1,
+      4,
+      9,
+      6,
+      0,
+      3,
+      2,
+      3,
+      4,
+      0,
+      1,
+      5,
+      3,
+      2,
+      0
+    ]
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -22,16 +22,27 @@ module Mint
 
     def start(&)
       start_position = position
-      node_size = ast.nodes.size
+
+      nodes_size = ast.nodes.size
+      keywords_size = ast.keywords.size
+      operators_size = ast.operators.size
 
       begin
         node = yield position
         @position = start_position unless node
-        ast.nodes.delete_at(node_size...) unless node
+
+        ast.nodes.delete_at(nodes_size...) unless node
+        ast.keywords.delete_at(keywords_size...) unless node
+        ast.operators.delete_at(operators_size...) unless node
+
         node
       rescue error : Error
         @position = start_position
-        ast.nodes.delete_at(node_size...)
+
+        ast.nodes.delete_at(nodes_size...)
+        ast.keywords.delete_at(keywords_size...)
+        ast.operators.delete_at(operators_size...)
+
         raise error
       end
     end

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -31,9 +31,11 @@ module Mint
         node = yield position
         @position = start_position unless node
 
-        ast.nodes.delete_at(nodes_size...) unless node
-        ast.keywords.delete_at(keywords_size...) unless node
-        ast.operators.delete_at(operators_size...) unless node
+        unless node
+          ast.nodes.delete_at(nodes_size...)
+          ast.keywords.delete_at(keywords_size...)
+          ast.operators.delete_at(operators_size...)
+        end
 
         node
       rescue error : Error


### PR DESCRIPTION
Working on refactoring how `Workspace`'s work within the language server which will require updating [mint-lang/mint-vscode](https://github.com/mint-lang/mint-vscode). 

Thought while I was there I would test out [semantic tokens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens) and noticed a couple of bugs. The below is being highlighted using the tokens from language server only: 

![Screenshot from 2023-08-20 22-17-15](https://github.com/mint-lang/mint/assets/1927518/667d72da-9d07-4bb3-b5ca-b78341772ac3)

The issues are: 

* Multiple line comments aren't highlighted correctly. This is because VSCode doesn't support the `multilineTokenSupport` feature (other editors can probably handle it fine!)
* The `next` part of `nextTitle` is being highlighted as if it was a keyword.

This PR fixes the latter. The issue is very similar to the one that was fixed as part of the initial PR https://github.com/mint-lang/mint/pull/615 however this one involves keywords and operators instead of nodes!

I solved it in a very dumb way, just copying and pasting the existing logic. :sweat_smile: Only `keyword`'s cause this specific bug, but I believe it may also be possible for `operator`'s to cause similar bugs so I included that too. 

Here's how it looks after the fix:

![Screenshot from 2023-08-20 22-36-42](https://github.com/mint-lang/mint/assets/1927518/ac560de3-7fe3-4f89-a97b-e7574d33e849)

