### PR TITLE
LSP: Add Go To Definition support for `Ast::Access`

### DIFF
--- a/spec/language_server/definition/location/access_array
+++ b/spec/language_server/definition/location/access_array
@@ -1,0 +1,57 @@
+record Header {
+  titles : Array(String)
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun getFirstTitle (header : Header) : Maybe(String) {
+    header.titles[0]
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 8
+      }
+    },
+    "uri": "file://#{root_path}/record.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/access_call
+++ b/spec/language_server/definition/location/access_call
@@ -1,0 +1,57 @@
+record Header {
+  hide : Function(Void)
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun hideHeader (header : Header) : Void {
+    header.hide()
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 6
+      }
+    },
+    "uri": "file://#{root_path}/record.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/access_record_multiple
+++ b/spec/language_server/definition/location/access_record_multiple
@@ -1,0 +1,65 @@
+record Nested3 {
+  field3 : String
+}
+---------------------------------------------------------------file nested3.mint
+record Nested2 {
+  field2 : Nested3
+}
+---------------------------------------------------------------file nested2.mint
+record Nested {
+  field1 : Nested2
+}
+---------------------------------------------------------------file nested1.mint
+module Test {
+  fun getNestedField (nested : Nested) : String {
+    nested.field1.field2.field3
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 18
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 8
+      }
+    },
+    "uri": "file://#{root_path}/nested2.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location/access_record_single
+++ b/spec/language_server/definition/location/access_record_single
@@ -1,0 +1,57 @@
+record Header {
+  title : String
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun getTitle (header : Header) : String {
+    header.title
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": false
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 2
+      },
+      "end": {
+        "line": 1,
+        "character": 7
+      }
+    },
+    "uri": "file://#{root_path}/record.mint"
+  },
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/access_array
+++ b/spec/language_server/definition/location_link/access_array
@@ -1,0 +1,79 @@
+record Header {
+  titles : Array(String)
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun getFirstTitle (header : Header) : Maybe(String) {
+    header.titles[0]
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 11
+        },
+        "end": {
+          "line": 2,
+          "character": 17
+        }
+      },
+      "targetUri": "file://#{root_path}/record.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 24
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 8
+        }
+      }
+    }
+  ],
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/access_call
+++ b/spec/language_server/definition/location_link/access_call
@@ -1,0 +1,79 @@
+record Header {
+  hide : Function(Void)
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun hideHeader (header : Header) : Void {
+    header.hide()
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 11
+        },
+        "end": {
+          "line": 2,
+          "character": 15
+        }
+      },
+      "targetUri": "file://#{root_path}/record.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 23
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 6
+        }
+      }
+    }
+  ],
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/access_record_multiple
+++ b/spec/language_server/definition/location_link/access_record_multiple
@@ -1,0 +1,87 @@
+record Nested3 {
+  field3 : String
+}
+---------------------------------------------------------------file nested3.mint
+record Nested2 {
+  field2 : Nested3
+}
+---------------------------------------------------------------file nested2.mint
+record Nested {
+  field1 : Nested2
+}
+---------------------------------------------------------------file nested1.mint
+module Test {
+  fun getNestedField (nested : Nested) : String {
+    nested.field1.field2.field3
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 18
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 18
+        },
+        "end": {
+          "line": 2,
+          "character": 24
+        }
+      },
+      "targetUri": "file://#{root_path}/nested2.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 18
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 8
+        }
+      }
+    }
+  ],
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/spec/language_server/definition/location_link/access_record_single
+++ b/spec/language_server/definition/location_link/access_record_single
@@ -1,0 +1,79 @@
+record Header {
+  title : String
+}
+----------------------------------------------------------------file record.mint
+module Test {
+  fun getTitle (header : Header) : String {
+    header.title
+  }
+}
+------------------------------------------------------------------file test.mint
+{
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "capabilities": {
+      "textDocument": {
+        "definition": {
+          "linkSupport": true
+        }
+      }
+    }
+  }
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "params": {
+    "textDocument": {
+      "uri": "file://#{root_path}/test.mint"
+    },
+    "position": {
+      "line": 2,
+      "character": 11
+    }
+  },
+  "method": "textDocument/definition"
+}
+-------------------------------------------------------------------------request
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "originSelectionRange": {
+        "start": {
+          "line": 2,
+          "character": 11
+        },
+        "end": {
+          "line": 2,
+          "character": 16
+        }
+      },
+      "targetUri": "file://#{root_path}/record.mint",
+      "targetRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 16
+        }
+      },
+      "targetSelectionRange": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 7
+        }
+      }
+    }
+  ],
+  "id": 1
+}
+------------------------------------------------------------------------response

--- a/src/ls/definition/access.cr
+++ b/src/ls/definition/access.cr
@@ -1,0 +1,28 @@
+module Mint
+  module LS
+    class Definition < LSP::RequestMessage
+      def definition(node : Ast::Access, workspace : Workspace, stack : Array(Ast::Node))
+        lhs = workspace
+          .type_checker
+          .cache[node.lhs]?
+
+        case lhs
+        when TypeChecker::Record
+          return unless record =
+                          workspace
+                            .ast
+                            .records
+                            .find(&.name.value.==(lhs.name))
+
+          return if Core.ast.records.includes?(record)
+
+          return unless record_definition_field = record
+                          .fields
+                          .find(&.key.value.==(node.field.value))
+
+          location_link node.field, record_definition_field.key, record_definition_field
+        end
+      end
+    end
+  end
+end

--- a/src/parsers/access.cr
+++ b/src/parsers/access.cr
@@ -6,7 +6,7 @@ module Mint
       start do |start_position|
         next unless char! '.'
 
-        field = variable! AccessExpectedVariable
+        field = variable! AccessExpectedVariable, track: false
 
         node = self << Ast::Access.new(
           from: start_position,


### PR DESCRIPTION
This PR adds support for `Ast::Access`, which I think might be one of the last things needed for Go To Definition. (unless I'm missing some other language features!)


https://github.com/mint-lang/mint/assets/1927518/094fc63d-f102-42a4-a029-2797f86b6631

Fairly straightforward implementation as the type checker is doing the heavy lifting. I did change the parser for `Ast:Access` so it no longer tracks the variable it uses so `.nodes_at_cursor` finds the access first.  (didn't seem to be used by hover or other LS features)