### PR TITLE
Removed deprecated 'with' from project init scaffold and small bug fix

### DIFF
--- a/src/app_init/app/tests/Main.mint
+++ b/src/app_init/app/tests/Main.mint
@@ -1,9 +1,7 @@
 suite "Main" {
   test "Greets Mint" {
-    with Test.Html {
-      <Main/>
-      |> start()
-      |> assertTextOf("a", "Learn Mint")
-    }
+    <Main/>
+    |> Test.Html.start()
+    |> Test.Html.assertTextOf("a", "Learn Mint")
   }
 }

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -14,11 +14,13 @@ module Mint
     BROWSER_PATHS = {
       firefox: {
         "firefox",
+        "firefox-bin",
         "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
       },
       chrome: {
         "chromium-browser",
         "chromium",
+        "chromium-bin",
         "google-chrome",
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       },

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -20,7 +20,6 @@ module Mint
       chrome: {
         "chromium-browser",
         "chromium",
-        "chromium-bin",
         "google-chrome",
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       },


### PR DESCRIPTION
1. Removed deprecated `with` from project init scaffold that throws errors in Mint 0.17.0 and above.
2. Added 'firefox-bin' to `BROWSER_PATHS`. This is because in Gentoo the binary distributions of Firefox are called '[firefox-bin](https://packages.gentoo.org/packages/www-client/firefox-bin)' to differentiate it from the compiled '[firefox](https://packages.gentoo.org/packages/www-client/firefox)'.