### PR TITLE
Improve `format` command.

### DIFF
--- a/src/mint_json.cr
+++ b/src/mint_json.cr
@@ -75,6 +75,12 @@ module Mint
       from_file(Path[Dir.current, "mint.json"].to_s)
     end
 
+    def self.parse_current? : MintJson?
+      parse_current
+    rescue
+      nil
+    end
+
     # Calculating nodes for the snippet in errors.
     # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Improvements:

- Doesn't error out if there is no `mint.json` file
- Pattern has precedence over `mint.json` fields
- Error case is now not necessary probably

Fixes #640