### PR TITLE
Prompt installing for dependencies instead of exiting.

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -8,6 +8,10 @@ shards:
     git: https://github.com/crystal-ameba/ameba.git
     version: 1.5.0
 
+  ansi-escapes:
+    git: https://github.com/gtramontina/ansi-escapes.cr.git
+    version: 1.0.0
+
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
     version: 1.2.2

--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,9 @@ dependencies:
   markd:
     github: icyleaf/markd
     version: ~> 0.5.0
+  ansi-escapes:
+    github: gtramontina/ansi-escapes.cr
+    version: ~> 1.0.0
 
 development_dependencies:
   ameba:

--- a/src/all.cr
+++ b/src/all.cr
@@ -1,5 +1,5 @@
 require "baked_file_system"
-require "ecr"
+require "ansi-escapes"
 require "file_utils"
 require "colorize"
 require "markd"
@@ -7,6 +7,7 @@ require "kemal"
 require "uuid"
 require "html"
 require "json"
+require "ecr"
 require "xml"
 
 MINT_ENV = {} of String => String

--- a/src/builder.cr
+++ b/src/builder.cr
@@ -8,9 +8,7 @@ module Mint
         skip_icons = true
       end
 
-      terminal.measure "#{COG} Ensuring dependencies..." do
-        json.check_dependencies!
-      end
+      json.check_dependencies!
 
       terminal.measure "#{COG} Clearing the \"#{DIST_DIR}\" directory..." do
         FileUtils.rm_rf DIST_DIR

--- a/src/mint_json.cr
+++ b/src/mint_json.cr
@@ -1173,28 +1173,26 @@ module Mint
     def check_dependencies!
       dependencies.each do |dependency|
         next if dependency_exists?(dependency.name)
-        error! :mint_json_dependency_not_installed do
-          block do
-            text "Not all"
-            bold "dependencies"
-            text "in your mint.json file are installed."
-          end
 
-          block do
-            text "The dependency"
-            bold dependency.name
-            text "was expected to be in the"
-            bold ".mint/packages/#{name}"
-            text "directory."
-          end
+        terminal.puts "#{COG} Ensuring dependencies..."
+        terminal.puts " ↳ Not all dependencies in your mint.json file are installed."
+        terminal.puts "   Would you like to install them now? (Y/n)"
 
-          block do
-            text "Usually you can fix this by running the"
-            bold "mint install"
-            text "command."
-          end
+        answer = gets.to_s.downcase
+        terminal.puts AnsiEscapes::Erase.lines(2)
+
+        if answer == "y"
+          Installer.new
+          break
+        else
+          terminal.puts "#{WARNING} Missing packages, exiting..."
+          exit(1)
         end
       end
+    end
+
+    def terminal
+      Render::Terminal::STDOUT
     end
 
     def dependency_exists?(name : String)

--- a/src/mint_json.cr
+++ b/src/mint_json.cr
@@ -1185,8 +1185,8 @@ module Mint
           Installer.new
           break
         else
-          terminal.puts "#{WARNING} Missing packages, exiting..."
-          exit(1)
+          terminal.print "#{WARNING} Missing dependencies..."
+          raise CliException.new
         end
       end
     end

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -26,9 +26,7 @@ module Mint
     end
 
     def initialize(@host, @port, @auto_format, @live_reload)
-      terminal.measure "#{COG} Ensuring dependencies..." do
-        MintJson.parse_current.check_dependencies!
-      end
+      MintJson.parse_current.check_dependencies!
 
       workspace = Workspace.current
       workspace.format = auto_format

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -47,9 +47,7 @@ module Mint
     end
 
     def run : Bool
-      terminal.measure "#{COG} Ensuring dependencies..." do
-        MintJson.parse_current.check_dependencies!
-      end
+      MintJson.parse_current.check_dependencies!
 
       ast = terminal.measure "#{COG} Compiling tests..." do
         compile_ast.tap do |a|


### PR DESCRIPTION
This PR adds a prompt to install dependencies instead of displaying an error and exiting when dependencies are missing (`mint build`, `mint test`, `mint start`).

This is how the installing looks like:

```
Mint - Running the development server
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
⚙ Ensuring dependencies...
 ↳ Not all dependencies in your mint.json file are installed.
   Would you like to install them now? (Y/n)

⚙ Constructing dependency tree...
  ✔ Updated mint-color (https://github.com/mint-lang/mint-color.git)
  ✔ Updated mint-tabler-icons (https://github.com/mint-lang/mint-tabler-icons.git)

⚙ Resolving dependency tree...
  ◈ mint-color ➔ 0.7.0
  ◈ mint-tabler-icons ➔ 1.0.0

⚙ Copying packages...
⚙ Parsing files... 579.817ms
⚙ Development server started on http://127.0.0.1:3000/
```

This is how the not installing looks like:

```
Mint - Running the development server
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
⚙ Ensuring dependencies...
 ↳ Not all dependencies in your mint.json file are installed.
   Would you like to install them now? (Y/n)

⚠ Missing dependencies...
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
There was an error, exiting...
```

Fixes #664 