### PR TITLE
Test runner improvements.

### DIFF
--- a/src/commands/test.cr
+++ b/src/commands/test.cr
@@ -48,14 +48,30 @@ module Mint
         description: "Will use supplied runtime path instead of the default distribution",
         required: false
 
-      define_argument test : String
+      define_flag watch : Bool,
+        description: "Watch files for changes and rerun tests",
+        required: false
+
+      define_argument test : String,
+        description: "The path to the test file to run"
 
       def run
-        succeeded = nil
-        execute "Running Tests" do
-          succeeded = TestRunner.new(flags, arguments).run
+        MintJson.parse_current.check_dependencies!
+
+        runner =
+          TestRunner.new(flags, arguments)
+
+        if flags.watch
+          runner.watch
+        else
+          succeeded = nil
+
+          execute "Running Tests" do
+            succeeded = runner.run
+          end
+
+          exit(1) unless succeeded
         end
-        exit(1) unless succeeded
       end
     end
   end

--- a/src/render/terminal.cr
+++ b/src/render/terminal.cr
@@ -247,6 +247,10 @@ module Mint
         print contents.to_s
       end
 
+      def reset
+        print "\ec"
+      end
+
       def puts(contents = nil)
         print contents if contents
         print "\n"

--- a/src/test_runner.ecr
+++ b/src/test_runner.ecr
@@ -8,6 +8,8 @@
     <script src="/external-javascripts.js"></script>
     <script src="/runtime.js"></script>
     <script>
+      window.TEST_ID = "<%= @test_id %>";
+
       class TestRunner {
         constructor () {
           this.socket = new WebSocket("<%= ws_url %>")
@@ -66,6 +68,7 @@
             message = message.toString()
           }
           this.socket.send(JSON.stringify({
+            id: window.TEST_ID,
             type: type,
             suite: suite,
             name: name,

--- a/src/test_runner/documentation_reporter.cr
+++ b/src/test_runner/documentation_reporter.cr
@@ -23,6 +23,9 @@ module Mint
       def done
       end
 
+      def reset
+      end
+
       def crashed(message)
         puts "❗ An internal error occurred while executing a test: #{message}".colorize(:red)
       end

--- a/src/test_runner/dot_reporter.cr
+++ b/src/test_runner/dot_reporter.cr
@@ -44,6 +44,10 @@ module Mint
         puts
       end
 
+      def reset
+        @count = 0
+      end
+
       def crashed(message)
         puts
         puts "❗ An internal error occurred while executing a test: #{message}".colorize(:red)

--- a/src/test_runner/reporter.cr
+++ b/src/test_runner/reporter.cr
@@ -6,6 +6,7 @@ module Mint
       abstract def errored(name, error)
       abstract def suite(name)
       abstract def done
+      abstract def reset
       abstract def crashed(message)
     end
   end

--- a/src/utils/server.cr
+++ b/src/utils/server.cr
@@ -12,14 +12,14 @@ module Mint
       true
     end
 
-    def run(name, host = "127.0.0.1", port = 3000)
+    def run(name, host = "127.0.0.1", port = 3000, verbose = true)
       config = Kemal.config
       config.logging = false
       config.setup
 
       if port_open?(host, port)
         server = HTTP::Server.new(config.handlers)
-        terminal.puts "#{COG} #{name} server started on http://#{host}:#{port}/"
+        terminal.puts "#{COG} #{name} server started on http://#{host}:#{port}/" if verbose
       elsif STDIN.tty?
         new_port = config.port + 1
         until port_open?(host, new_port)


### PR DESCRIPTION
This PR adds some improvements to the `test` command and the test runner:

- The tests are compiled on the request instead of being cached, so when running in the browser and clicking refresh will load the latest tests instead of serving the cached tests. This allows for quicker iteration on tests.
- Added `--watch` for running tests when files change.

Fixes #644