### PR TITLE
Implement @highlight-file directive.

### DIFF
--- a/spec/compilers/directives/highlight-file
+++ b/spec/compilers/directives/highlight-file
@@ -1,0 +1,29 @@
+component Main {
+  fun render : Html {
+    @highlight-file(../../fixtures/Test.mint)
+  }
+}
+--------------------------------------------------------------------------------
+class A extends _C {
+  render() {
+    return _h(React.Fragment, {}, [_h('span', { className: 'keyword' }, [`component`]),
+    ` `,
+    _h('span', { className: 'type' }, [`Main`]),
+    ` {
+  `,
+    _h('span', { className: 'keyword' }, [`fun`]),
+    ` render : `,
+    _h('span', { className: 'type' }, [`Html`]),
+    ` {
+    <`,
+    _h('span', { className: 'namespace' }, [`div`]),
+    `></`,
+    _h('span', { className: 'namespace' }, [`div`]),
+    `>
+  }
+}
+`]);
+  }
+};
+
+A.displayName = "Main";

--- a/spec/examples/directives/highlight_file
+++ b/spec/examples/directives/highlight_file
@@ -1,0 +1,30 @@
+--------------------------highlight_file_directive_expected_opening_parenthesis
+component Main {
+  fun render : String {
+    @highlight-file
+-----------------------------------------highlight_file_directive_expected_path
+component Main {
+  fun render : String {
+    @highlight-file(
+--------------------------highlight_file_directive_expected_closing_parenthesis
+component Main {
+  fun render : String {
+    @highlight-file(path
+-----------------------------------------highlight_file_directive_expected_file
+component Main {
+  fun render : Html {
+    @highlight-file(File.mint)
+  }
+}
+-----------------------------------------highlight_file_directive_expected_mint
+component Main {
+  fun render : Html {
+    @highlight-file(../../fixtures/icon-not-svg)
+  }
+}
+-------------------------------------------------------------------------------
+component Main {
+  fun render : Html {
+    @highlight-file(../../../core/source/Array.mint)
+  }
+}

--- a/spec/fixtures/Test.mint
+++ b/spec/fixtures/Test.mint
@@ -1,0 +1,5 @@
+component Main {
+  fun render : Html {
+    <div></div>
+  }
+}

--- a/spec/formatters/directives/highlight-file
+++ b/spec/formatters/directives/highlight-file
@@ -1,0 +1,11 @@
+component Main {
+  fun render : Html {
+    @highlight-file(../../fixtures/Test.mint)
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun render : Html {
+    @highlight-file(../../fixtures/Test.mint)
+  }
+}

--- a/src/ast/directives/file_based.cr
+++ b/src/ast/directives/file_based.cr
@@ -49,6 +49,9 @@ module Mint
 
       class Svg < FileBased
       end
+
+      class HighlightFile < FileBased
+      end
     end
   end
 end

--- a/src/compilers/directives/highlight_file.cr
+++ b/src/compilers/directives/highlight_file.cr
@@ -1,0 +1,26 @@
+module Mint
+  class Compiler
+    def _compile(node : Ast::Directives::HighlightFile) : String
+      contents =
+        File.read(node.real_path)
+
+      parser = Parser.new(contents, node.real_path.to_s)
+      parser.parse
+
+      parts =
+        SemanticTokenizer.tokenize(parser.ast)
+
+      mapped =
+        parts.map do |item|
+          case item
+          in String
+            "`#{skip { escape_for_javascript(item) }}`"
+          in Tuple(SemanticTokenizer::TokenType, String)
+            "_h('span', { className: '#{item[0].to_s.underscore}' }, [`#{skip { escape_for_javascript(item[1]) }}`])"
+          end
+        end
+
+      "_h(React.Fragment, {}, [#{mapped.join(",\n")}])"
+    end
+  end
+end

--- a/src/formatters/directives/highlight_file.cr
+++ b/src/formatters/directives/highlight_file.cr
@@ -1,0 +1,7 @@
+module Mint
+  class Formatter
+    def format(node : Ast::Directives::HighlightFile)
+      "@highlight-file(#{node.path})"
+    end
+  end
+end

--- a/src/parsers/base_expression.cr
+++ b/src/parsers/base_expression.cr
@@ -30,7 +30,8 @@ module Mint
         when '`'
           js
         when '@'
-          documentation_directive ||
+          highlight_file_directive ||
+            documentation_directive ||
             highlight_directive ||
             format_directive ||
             inline_directive ||

--- a/src/parsers/directives/highlight_file.cr
+++ b/src/parsers/directives/highlight_file.cr
@@ -1,0 +1,33 @@
+module Mint
+  class Parser
+    def highlight_file_directive : Ast::Directives::HighlightFile?
+      parse do |start_position|
+        next unless word! "@highlight-file"
+        whitespace
+
+        next error :highlight_file_directive_expected_opening_parenthesis do
+          expected "the opening parenthesis of an highlight file directive", word
+          snippet self
+        end unless char! '('
+        whitespace
+
+        next error :highlight_file_directive_expected_path do
+          expected "the path (to the file) of an highlight file directive", word
+          snippet self
+        end unless path = gather { chars { char != ')' } }.presence.try(&.strip)
+        whitespace
+
+        next error :highlight_file_directive_expected_closing_parenthesis do
+          expected "the closing parenthesis of an highlight file directive", word
+          snippet self
+        end unless char! ')'
+
+        Ast::Directives::HighlightFile.new(
+          from: start_position,
+          to: position,
+          file: file,
+          path: path)
+      end
+    end
+  end
+end

--- a/src/scope.cr
+++ b/src/scope.cr
@@ -216,6 +216,7 @@ module Mint
 
       case node
       when Ast::Directives::Documentation,
+           Ast::Directives::HighlightFile,
            Ast::Directives::Highlight,
            Ast::Directives::Inline,
            Ast::Directives::Asset,

--- a/src/type_checkers/directives/highlight_file.cr
+++ b/src/type_checkers/directives/highlight_file.cr
@@ -1,0 +1,37 @@
+module Mint
+  class TypeChecker
+    def check(node : Ast::Directives::HighlightFile) : Checkable
+      error! :highlight_file_directive_expected_file do
+        block "The path specified for an highlight file directive does not exist: "
+
+        if ENV["SPEC"]?
+          snippet node.path.to_s
+        else
+          snippet node.real_path.to_s
+        end
+
+        snippet "The highlight file directive in question is here:", node
+      end unless node.exists?
+
+      contents =
+        File.read(node.real_path)
+
+      parser = Parser.new(contents, node.real_path.to_s)
+      parser.parse
+      parser.eof!
+
+      error! :highlight_file_directive_expected_mint do
+        block "I was expecting a Mint file for a highlight file directive " \
+              "but I could not parse it."
+
+        snippet(
+          "These are the first few lines of the file:",
+          contents.lines[0..4].join("\n"))
+
+        snippet "The highlight file directive in question is here:", node
+      end unless parser.errors.empty?
+
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `@highlight-file` directive, which is a different version of the `@highlight` directive.

The issue with the `@highlight` directive is that it can only highlight expressions and cannot highlight top level elements. For the new website, I needed to highlight top level elements for the landing page, so this is the solution for that.