### PR TITLE
Improve Development Server

### DIFF
--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -18,7 +18,6 @@ module Mint
 
     @sockets = [] of HTTP::WebSocket
 
-    getter ast : Ast = Ast.new
     getter script : String?
 
     def self.start(host : String, port : Int32, auto_format : Bool, live_reload : Bool)
@@ -30,85 +29,39 @@ module Mint
 
       workspace = Workspace.current
       workspace.format = auto_format
-
-      init(workspace)
+      workspace.check_everything = false
 
       workspace.on "change" do |result|
-        update result
-        notify
+        case result
+        when Ast
+          # Compile.
+          @script = Compiler.compile workspace.type_checker.artifacts, {
+            css_prefix:     workspace.json.application.css_prefix,
+            web_components: workspace.json.web_components,
+            relative:       false,
+            optimize:       false,
+            build:          false,
+          }
+
+          @artifacts = workspace.type_checker.artifacts
+          @error = nil
+        when Error
+          @error = result.to_html
+          @artifacts = nil
+          @script = nil
+        end
+
+        # Notifies all connected sockets to reload the page.
+        @sockets.each(&.send("reload"))
       end
 
+      # Do the initial parsing and type checking.
+      workspace.update_cache
       workspace.watch
 
-      watch_for_changes
       setup_kemal
 
       Server.run "Development", @host, @port
-    end
-
-    def init(workspace)
-      prefix = "#{COG} Parsing files"
-      line = ""
-
-      elapsed = Time.measure do
-        workspace.initialize_cache do |_, index, size|
-          counter =
-            "#{index} / #{size}".colorize.mode(:bold)
-
-          line =
-            "#{prefix}: #{counter}".ljust(line.size)
-
-          terminal.io.print("#{line}\r")
-          terminal.io.flush
-        end
-      end
-
-      elapsed = TimeFormat.auto(elapsed).colorize.mode(:bold)
-      terminal.io.puts "#{prefix}... #{elapsed}".ljust(line.size)
-
-      @ast = workspace.ast
-      compile_script
-    rescue error : Error
-      @error = error.to_html
-    end
-
-    def update(result)
-      case result
-      when Ast
-        @ast = result
-        @error = nil
-        compile_script
-      when Error
-        @error = result.to_html
-      end
-    end
-
-    def compile_script
-      # Fetch options from the applications
-      json =
-        MintJson.parse_current
-
-      # Create a brand new TypeChecker.
-      type_checker =
-        TypeChecker.new(ast, web_components: json.web_components.keys)
-
-      # Type check.
-      type_checker.check
-
-      # Compile.
-      @script = Compiler.compile type_checker.artifacts, {
-        css_prefix:     json.application.css_prefix,
-        web_components: json.web_components,
-        relative:       false,
-        optimize:       false,
-        build:          false,
-      }
-      @artifacts = type_checker.artifacts
-      @error = nil
-    rescue error : Error
-      @error = error.to_html
-      @artifacts = nil
-      @script = nil
     end
 
     def live_reload
@@ -227,28 +180,6 @@ module Mint
 
         socket.on_close do
           @sockets.delete(socket)
-        end
-      end
-    end
-
-    # Notifies all connected sockets to reload the page.
-    def notify
-      @sockets.each(&.send("reload"))
-    end
-
-    # Sets up watchers to detect changes
-    def watch_for_changes
-      Env.env.try do |file|
-        spawn do
-          Watcher.watch([file]) do
-            Env.load do
-              terminal.measure "#{COG} Environment variables changed, recompiling..." do
-                compile_script
-              end
-
-              notify
-            end
-          end
         end
       end
     end

--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -29,6 +29,7 @@ module Mint
 
       workspace = Workspace.current
       workspace.format = auto_format
+      workspace.check_env = true
       workspace.check_everything = false
 
       workspace.on "change" do |result|

--- a/src/type_checker.cr
+++ b/src/type_checker.cr
@@ -50,6 +50,7 @@ module Mint
     ] of Checkable
 
     getter records, artifacts, formatter, web_components
+    getter? check_everything
 
     property? checking = true
 
@@ -71,7 +72,7 @@ module Mint
 
     @stack = [] of Ast::Node
 
-    def initialize(ast : Ast, @check_env = true, @web_components = [] of String)
+    def initialize(ast : Ast, @check_env = true, @web_components = [] of String, @check_everything = true)
       ast.normalize
 
       @languages = ast.unified_locales.map(&.language)

--- a/src/type_checkers/top_level.cr
+++ b/src/type_checkers/top_level.cr
@@ -50,12 +50,14 @@ module Mint
       # this will not be compiled.
       self.checking = false
 
-      check_all node.components
-      check_all node.unified_modules
+      if check_everything?
+        check_all node.components
+        check_all node.unified_modules
 
-      resolve node.providers
-      resolve node.stores
-      resolve node.type_definitions
+        resolve node.providers
+        resolve node.stores
+        resolve node.type_definitions
+      end
 
       VOID
     end

--- a/src/workspace.cr
+++ b/src/workspace.cr
@@ -170,11 +170,11 @@ module Mint
       end
 
       spawn do
-        @env_watcher.try(&.watch do
+        @env_watcher.try &.watch do
           Env.load do
             update_cache
           end
-        end)
+        end
       end
     end
 

--- a/src/workspace.cr
+++ b/src/workspace.cr
@@ -59,6 +59,7 @@ module Mint
     getter root : String
 
     property? check_everything : Bool = true
+    property? check_env : Bool = false
     property? format : Bool = false
 
     def initialize(@root : String)
@@ -254,8 +255,12 @@ module Mint
     end
 
     private def check!
-      @type_checker = Mint::TypeChecker.new(ast, check_env: false, check_everything: check_everything?)
-      @type_checker.check
+      @type_checker =
+        Mint::TypeChecker.new(
+          check_everything: check_everything?,
+          check_env: check_env?,
+          ast: ast
+        ).tap(&.check)
     end
 
     private def call(event, arg)


### PR DESCRIPTION
This PR improves the development server (`mint start`) in two ways:

1. Previously, it type-checked the whole application twice on every change :cold_sweat:

	- https://github.com/mint-lang/mint/blob/master/src/reactor.cr#L93
	- https://github.com/mint-lang/mint/blob/master/src/workspace.cr#L242

	Now it just uses the `Workspace` for the type-checking like everything else.

2. It just type-checks the hot path, not all entities. This speeds up type checking in cases like icons (https://github.com/mint-lang/mint-tabler-icons/blob/master/source/Icons.mint ~60K LOC) where only the icons which are used are type-checked.

After merging this, the roundtrip on every change should be twice as fast as before :tada: 