### PR TITLE
Extra build mode flags: `--skip-manifest`, `--inline`, and `--watch`

### DIFF
--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -10,6 +10,10 @@ module Mint
         default: false,
         short: "r"
 
+      define_flag skip_manifest : Bool,
+        description: "If specified the web manifest will not be generated",
+        default: false
+
       define_flag skip_service_worker : Bool,
         description: "If specified the service worker functionality will be disabled",
         default: false
@@ -23,19 +27,36 @@ module Mint
         default: true,
         short: "m"
 
+      define_flag inline : Bool,
+        description: "If specified the JavaScript and CSS will be inlined with the html",
+        default: false,
+        short: "i"
+
       define_flag runtime : String,
         description: "Will use supplied runtime path instead of the default distribution",
         required: false
+
+      define_flag watch : Bool,
+        description: "Enables watch mode for build",
+        default: false,
+        short: "w"
 
       def run
         execute "Building for production" do
           Builder.new(
             flags.relative,
+            flags.skip_manifest,
             flags.skip_service_worker,
             flags.skip_icons,
             flags.minify,
-            flags.runtime
+            flags.inline,
+            flags.runtime,
+            flags.watch
           )
+
+          if flags.watch
+            sleep
+          end
         end
       end
     end

--- a/src/utils/index_html.cr
+++ b/src/utils/index_html.cr
@@ -2,18 +2,21 @@ module Mint
   # Renders the main HTML file based on a mint.json file and an environment.
   class IndexHtml
     @relative : Bool
+    @no_manifest : Bool
     @no_service_worker : Bool
     @no_icons : Bool
+    @inline : Bool
+    @index_js : String
     @live_reload : Bool
 
     getter env : Environment
     getter json : MintJson
 
-    def self.render(env : Environment, relative = false, no_service_worker = false, no_icons = false, live_reload = true) : String
-      new(env, relative, no_service_worker, no_icons, live_reload).to_s
+    def self.render(env : Environment, relative = false, no_manifest = false, no_service_worker = false, no_icons = false, inline = false, index_js = "", live_reload = true) : String
+      new(env, relative, no_manifest, no_service_worker, no_icons, inline, index_js, live_reload).to_s
     end
 
-    def initialize(@env : Environment, @relative, @no_service_worker, @no_icons, @live_reload)
+    def initialize(@env : Environment, @relative, @no_manifest, @no_service_worker, @no_icons, @inline, @index_js, @live_reload)
       @json = MintJson.parse_current
     end
 

--- a/src/utils/index_html.ecr
+++ b/src/utils/index_html.ecr
@@ -3,7 +3,9 @@
   <head>
     <meta charset="<%= application.meta["charset"]? || "utf-8" %>">
     <title><%= application.title %></title>
-    <link rel="manifest" href="<%= path_for("manifest.webmanifest") %>">
+    <% unless @no_manifest %>
+      <link rel="manifest" href="<%= path_for("manifest.webmanifest") %>">
+    <% end %>
     <% application.meta.each do |name, content| %>
       <% next if name == "charset" %>
       <meta name="<%= name %>" content="<%= content %>">
@@ -21,7 +23,13 @@
     <% end %>
 
     <% if SourceFiles.external_stylesheets? %>
-      <link rel="stylesheet" href="<%= path_for("external-stylesheets.css") %>">
+      <% if @inline %>
+        <style>
+          <%= SourceFiles.external_stylesheets %>
+        </style>
+      <% else %>
+        <link rel="stylesheet" href="<%= path_for("external-stylesheets.css") %>">
+      <% end %>
     <% end %>
   </head>
   <body>
@@ -45,10 +53,23 @@
     <% end %>
 
     <% if SourceFiles.external_javascripts? %>
-      <script src="<%= path_for("external-javascripts.js") %>"></script>
+      <% if @inline %>
+        <script>
+          <%= SourceFiles.external_javascripts %>
+        </style>
+      <% else %>
+        <script src="<%= path_for("external-javascripts.js") %>"></script>
+      <% end %>
+    <% end %>
+    
+    <% if @inline %>
+      <script>
+        <%= @index_js %>
+      </script>
+    <% else %>
+      <script src="<%= path_for("index.js") %>"></script>
     <% end %>
 
-    <script src="<%= path_for("index.js") %>"></script>
     <noscript>
       This application requires JavaScript.
     </noscript>


### PR DESCRIPTION
Adds three flags to `mint build` command:

`--skip-manifest` which will skip generating the web manifest file and reference in html.
`--inline` which will inline the JS and CSS into html, resulting in one single file for entire SPA.
`--watch` mode which will write files on changes.