### PR TITLE
Highlight Mint code in Markdown content.

### DIFF
--- a/src/parser/top_level.cr
+++ b/src/parser/top_level.cr
@@ -12,6 +12,43 @@ module Mint
       parser.ast
     end
 
+    def parse_any : Nil
+      many do
+        oneof do
+          module_definition ||
+            type_definition ||
+            html_attribute ||
+            interpolation ||
+            css_font_face ||
+            css_keyframes ||
+            component ||
+            constant ||
+            property ||
+            operator ||
+            provider ||
+            css_node ||
+            function ||
+            comment ||
+            connect ||
+            locale ||
+            routes ||
+            route ||
+            state ||
+            store ||
+            style ||
+            suite ||
+            test ||
+            type ||
+            get ||
+            use ||
+            statement ||
+            case_branch ||
+            destructuring ||
+            expression
+        end
+      end
+    end
+
     def parse : Nil
       # Comment needs to be last since other comments are parsed with the
       # entities.

--- a/src/semantic_tokenizer.cr
+++ b/src/semantic_tokenizer.cr
@@ -43,10 +43,13 @@ module Mint
     getter tokens = [] of Token
 
     def self.tokenize(ast : Ast)
+      parts = [] of String | Tuple(SemanticTokenizer::TokenType, String)
+
+      return parts if ast.nodes.empty?
+
       tokenizer = self.new
       tokenizer.tokenize(ast)
 
-      parts = [] of String | Tuple(SemanticTokenizer::TokenType, String)
       contents = ast.nodes.first.file.contents
       position = 0
 

--- a/src/utils/markd_vdom_renderer.cr
+++ b/src/utils/markd_vdom_renderer.cr
@@ -69,7 +69,30 @@ module Mint
 
       tag("pre")
       tag("code", code_attributes)
-      @io << '`' << node.text.gsub('`', "\\`").strip << '`'
+
+      if language == "mint"
+        parser = Parser.new(node.text, "source.mint")
+        parser.parse_any
+
+        parts =
+          SemanticTokenizer.tokenize(parser.ast)
+
+        parts.map_with_index do |item, index|
+          case item
+          in String
+            @io << '`' << item.gsub('`', "\\`") << '`'
+          in Tuple(SemanticTokenizer::TokenType, String)
+            tag("span", {"className" => item[0].to_s.underscore})
+            @io << '`' << item[1].gsub('`', "\\`") << '`'
+            tag_end
+          end
+
+          @io << ','
+        end
+      else
+        @io << '`' << node.text.gsub('`', "\\`").strip << '`'
+      end
+
       tag_end
       tag_end(node)
     end

--- a/src/utils/markd_vdom_renderer.cr
+++ b/src/utils/markd_vdom_renderer.cr
@@ -77,7 +77,7 @@ module Mint
         parts =
           SemanticTokenizer.tokenize(parser.ast)
 
-        parts.each_with_index do |item, index|
+        parts.each do |item|
           case item
           in String
             @io << '`' << item.gsub('`', "\\`") << '`'

--- a/src/utils/markd_vdom_renderer.cr
+++ b/src/utils/markd_vdom_renderer.cr
@@ -77,7 +77,7 @@ module Mint
         parts =
           SemanticTokenizer.tokenize(parser.ast)
 
-        parts.map_with_index do |item, index|
+        parts.each_with_index do |item, index|
           case item
           in String
             @io << '`' << item.gsub('`', "\\`") << '`'


### PR DESCRIPTION
This PR implements highlighting for Mint language blocks in Markdown content in here documents.