### PR TITLE
Allow generating source maps.

### DIFF
--- a/spec/compilers/block_with_early_return
+++ b/spec/compilers/block_with_early_return
@@ -13,18 +13,18 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  destructure as E,
-  newVariant as F,
-  pattern as G,
-  variant as B
+  patternVariable as E,
+  destructure as B,
+  newVariant as C,
+  pattern as D,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  D = () => {
-    const a = E(F(A)(`Some string...`), G(A, [H]));
+  F = A(1),
+  G = A(1),
+  H = () => {
+    const a = B(C(F)(`Some string...`), D(F, [E]));
     if (a === false) {
       return `RETURN`
     };

--- a/spec/compilers/block_with_early_return_await
+++ b/spec/compilers/block_with_early_return_await
@@ -17,19 +17,19 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  destructure as E,
-  newVariant as F,
-  pattern as G,
-  variant as B
+  patternVariable as E,
+  destructure as B,
+  newVariant as C,
+  pattern as D,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  D = () => {
+  F = A(1),
+  G = A(1),
+  H = () => {
     (async () => {
-      const a = E(await F(A)(`Some string...`), G(A, [H]));
+      const a = B(await C(F)(`Some string...`), D(F, [E]));
       if (a === false) {
         return `RETURN`
       };

--- a/spec/compilers/bracket_access
+++ b/spec/compilers/bracket_access
@@ -20,24 +20,24 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  bracketAccess as E,
-  mapAccess as F,
-  variant as B
+  bracketAccess as B,
+  mapAccess as C,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(0),
-  C = B(1),
-  D = () => {
-    E([
+  D = A(0),
+  E = A(1),
+  F = () => {
+    B([
       `Hello`,
       `Blah`,
       `Joe`
-    ], 1, C, A);
-    E([], 1, C, A);
-    F([[
+    ], 1, E, D);
+    B([], 1, E, D);
+    C([[
       `key`,
       `value`
-    ]], `key`, C, A);
+    ]], `key`, E, D);
     return ``
   };

--- a/spec/compilers/builtin
+++ b/spec/compilers/builtin
@@ -7,11 +7,11 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as C,
-  decodeBoolean as B
+  createElement as B,
+  decodeBoolean as A
 } from "./runtime.js";
 
-export const A = () => {
-  (B);
-  return C(`div`, {})
+export const C = () => {
+  (A);
+  return B(`div`, {})
 };

--- a/spec/compilers/bundling
+++ b/spec/compilers/bundling
@@ -57,14 +57,14 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as I,
-  createElement as G,
-  useEffect as E,
-  useSignal as D,
-  fragment as H,
-  variant as K,
-  load as F,
-  lazy as B
+  lazyComponent as G,
+  createElement as E,
+  useEffect as C,
+  useSignal as B,
+  fragment as F,
+  variant as H,
+  load as D,
+  lazy as A
 } from "./runtime.js";
 
 export const
@@ -72,31 +72,31 @@ export const
   b = (c) => {
     return `Hello ${c}!`
   },
-  A = B(`./2.js`),
-  C = () => {
-    const d = D(``);
-    E(() => {
+  I = A(`./2.js`),
+  J = () => {
+    const d = B(``);
+    C(() => {
       (async () => {
-        const e = await F(a);
+        const e = await D(a);
         return (() => {
           d.value = e
         })()
       })()
     }, []);
-    return G(H, {}, [
-      G(I, {
+    return E(F, {}, [
+      E(G, {
         c: [],
         key: `Greeter`,
         p: {
           a: `World`
         },
-        x: A
+        x: I
       }),
       b(`Me`)
     ])
   },
-  J = K(0),
-  L = K(0);
+  K = H(0),
+  L = H(0);
 
 ---=== /__mint__/1.js ===---
 export const a = `Hello, I was loaded later...`;

--- a/spec/compilers/case
+++ b/spec/compilers/case
@@ -10,10 +10,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { match as B } from "./runtime.js";
+import { match as A } from "./runtime.js";
 
-export const A = () => {
-  B(`Hello`, [
+export const B = () => {
+  A(`Hello`, [
     [
       `test`,
       () => {

--- a/spec/compilers/case_await
+++ b/spec/compilers/case_await
@@ -12,11 +12,11 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { match as B } from "./runtime.js";
+import { match as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   (async () => {
-    return B(await `Hello`, [
+    return A(await `Hello`, [
       [
         `test`,
         () => {

--- a/spec/compilers/case_empty
+++ b/spec/compilers/case_empty
@@ -6,10 +6,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { match as B } from "./runtime.js";
+import { match as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`Hello`, [[
+export const B = () => {
+  return A(`Hello`, [[
     null,
     () => {
       return `false`

--- a/spec/compilers/case_with_array_destructuring
+++ b/spec/compilers/case_with_array_destructuring
@@ -11,13 +11,13 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as C,
-  patternSpread as D,
-  match as B
+  patternVariable as B,
+  patternSpread as C,
+  match as A
 } from "./runtime.js";
 
-export const A = () => {
-  return B([], [
+export const D = () => {
+  return A([], [
     [
       [],
       () => {
@@ -31,15 +31,15 @@ export const A = () => {
       }
     ],
     [
-      [C],
+      [B],
       (a) => {
         return [a]
       }
     ],
     [
       [
-        C,
-        C
+        B,
+        B
       ],
       (b, c) => {
         return [
@@ -50,9 +50,9 @@ export const A = () => {
     ],
     [
       [
-        C,
-        C,
-        D
+        B,
+        B,
+        C
       ],
       (d, e, f) => {
         return f

--- a/spec/compilers/case_with_nested_tuple_destructuring
+++ b/spec/compilers/case_with_nested_tuple_destructuring
@@ -14,12 +14,12 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as C,
-  match as B
+  patternVariable as B,
+  match as A
 } from "./runtime.js";
 
-export const A = () => {
-  return B([
+export const C = () => {
+  return A([
     `A`,
     [
       `B`,
@@ -52,10 +52,10 @@ export const A = () => {
     ],
     [
       [
-        C,
+        B,
         [
-          C,
-          C
+          B,
+          B
         ]
       ],
       (a, b, c) => {

--- a/spec/compilers/case_with_tuple_destructuring
+++ b/spec/compilers/case_with_tuple_destructuring
@@ -14,12 +14,12 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as C,
-  match as B
+  patternVariable as B,
+  match as A
 } from "./runtime.js";
 
-export const A = () => {
-  return B([
+export const C = () => {
+  return A([
     `A`,
     0,
     true
@@ -46,9 +46,9 @@ export const A = () => {
     ],
     [
       [
-        C,
-        C,
-        C
+        B,
+        B,
+        B
       ],
       (a, b, c) => {
         return a

--- a/spec/compilers/case_with_tuple_destructuring_bool
+++ b/spec/compilers/case_with_tuple_destructuring_bool
@@ -12,10 +12,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { match as B } from "./runtime.js";
+import { match as A } from "./runtime.js";
 
-export const A = () => {
-  return B([
+export const B = () => {
+  return A([
     false,
     true
   ], [

--- a/spec/compilers/case_with_type_destructuring
+++ b/spec/compilers/case_with_type_destructuring
@@ -23,30 +23,30 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as I,
-  newVariant as G,
-  pattern as H,
-  variant as B,
-  match as F
+  patternVariable as E,
+  newVariant as C,
+  pattern as D,
+  variant as A,
+  match as B
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = B(1),
-  E = () => {
-    F(G(A)(G(D)(``)), [
+  F = A(1),
+  G = A(0),
+  H = A(1),
+  I = () => {
+    B(C(F)(C(H)(``)), [
       [
-        H(C, []),
+        D(G, []),
         () => {
           return ``
         }
       ],
       [
-        H(A, [I]),
+        D(F, [E]),
         (a) => {
-          return F(a, [[
-            H(D, [I]),
+          return B(a, [[
+            D(H, [E]),
             (b) => {
               return b
             }

--- a/spec/compilers/component_async
+++ b/spec/compilers/component_async
@@ -36,9 +36,9 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as E,
-  createElement as D,
-  lazy as B
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
@@ -48,34 +48,34 @@ export const
   b = () => {
     return `I'm in both!`
   },
-  A = B(`./1.js`),
-  C = () => {
-    return D(`div`, {}, [
+  D = A(`./1.js`),
+  E = () => {
+    return B(`div`, {}, [
       a(),
       b(),
-      D(E, {
+      B(C, {
         c: [],
         key: `Test`,
         p: {},
-        x: A
+        x: D
       })
     ])
   };
 
 ---=== /__mint__/1.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-import { b as c } from "./index.js";
+import { b as a } from "./index.js";
 
 export const
-  a = (b) => {
-    return `I'm ${b}!`
+  b = (c) => {
+    return `I'm ${c}!`
   },
-  A = () => {
-    return B(`div`, {}, [
-      a(`async`),
-      c()
+  B = () => {
+    return A(`div`, {}, [
+      b(`async`),
+      a()
     ])
   };
 
-export default A;
+export default B;

--- a/spec/compilers/component_async_2
+++ b/spec/compilers/component_async_2
@@ -26,59 +26,59 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as F,
-  createElement as E,
-  lazy as B
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
-  A = B(`./1.js`),
-  C = B(`./2.js`),
-  D = () => {
-    return E(`div`, {}, [
-      E(F, {
+  D = A(`./1.js`),
+  E = A(`./2.js`),
+  F = () => {
+    return B(`div`, {}, [
+      B(C, {
         c: [],
         key: `First`,
         p: {},
-        x: A
+        x: D
       }),
-      E(F, {
+      B(C, {
         c: [],
         key: `Second`,
         p: {},
-        x: C
+        x: E
       })
     ])
   };
 
 ---=== /__mint__/1.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {}, [`First`])
+export const B = () => {
+  return A(`div`, {}, [`First`])
 };
 
-export default A;
+export default B;
 
 ---=== /__mint__/2.js ===---
 import {
-  lazyComponent as E,
-  createElement as D,
-  lazy as B
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
-  A = B(`./1.js`),
-  C = () => {
-    return D(`div`, {}, [
-      D(E, {
+  D = A(`./1.js`),
+  E = () => {
+    return B(`div`, {}, [
+      B(C, {
         c: [],
         key: `First`,
         p: {},
-        x: A
+        x: D
       }),
       `Second`
     ])
   };
 
-export default C;
+export default E;

--- a/spec/compilers/component_async_3
+++ b/spec/compilers/component_async_3
@@ -38,9 +38,9 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as F,
-  createElement as E,
-  lazy as B
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
@@ -50,50 +50,50 @@ export const
   b = () => {
     return a()
   },
-  A = B(`./1.js`),
-  C = B(`./2.js`),
-  D = () => {
-    return E(`div`, {}, [
-      E(F, {
+  D = A(`./1.js`),
+  E = A(`./2.js`),
+  F = () => {
+    return B(`div`, {}, [
+      B(C, {
         c: [],
         key: `First`,
         p: {},
-        x: A
+        x: D
       }),
-      E(F, {
+      B(C, {
         c: [],
         key: `Second`,
         p: {},
-        x: C
+        x: E
       }),
       b()
     ])
   };
 
 ---=== /__mint__/1.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 import { b as a } from "./index.js";
 
-export const A = () => {
-  return B(`div`, {}, [
+export const B = () => {
+  return A(`div`, {}, [
     `First`,
     a()
   ])
 };
 
-export default A;
+export default B;
 
 ---=== /__mint__/2.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 import { b as a } from "./index.js";
 
-export const A = () => {
-  return B(`div`, {}, [
+export const B = () => {
+  return A(`div`, {}, [
     `Second`,
     a()
   ])
 };
 
-export default A;
+export default B;

--- a/spec/compilers/component_async_4
+++ b/spec/compilers/component_async_4
@@ -40,34 +40,34 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as G,
-  createElement as B,
-  lazy as E
+  lazyComponent as C,
+  createElement as A,
+  lazy as B
 } from "./runtime.js";
 
 export const
-  A = ({
+  D = ({
     a = ``
   }) => {
-    return B(`div`, {}, [a])
+    return A(`div`, {}, [a])
   },
-  C = ({
+  E = ({
     b = 18
   }) => {
-    return B(`div`, {}, [`${b}px`])
+    return A(`div`, {}, [`${b}px`])
   },
-  D = E(`./1.js`),
-  F = () => {
-    return B(`div`, {}, [
-      B(A, {
+  F = B(`./1.js`),
+  G = () => {
+    return A(`div`, {}, [
+      A(D, {
         a: `blah`
       }),
-      B(C, {}),
-      B(G, {
+      A(E, {}),
+      A(C, {
         c: [],
         key: `Test`,
         p: {},
-        x: D
+        x: F
       })
     ])
   };
@@ -75,16 +75,16 @@ export const
 ---=== /__mint__/1.js ===---
 import { createElement as B } from "./runtime.js";
 
-import { C } from "./index.js";
+import { E as A } from "./index.js";
 
-export const A = ({
+export const C = ({
   a = ``,
   b = ``,
   c = ``
 }) => {
-  return B(C, {
+  return B(A, {
     b: 16
   })
 };
 
-export default A;
+export default C;

--- a/spec/compilers/component_async_5
+++ b/spec/compilers/component_async_5
@@ -25,30 +25,30 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as F,
-  createElement as E,
-  lazy as C
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
-  A = ({
+  D = ({
     a = ``
   }) => {
     return a
   },
-  B = C(`./1.js`),
-  D = () => {
-    return E(`div`, {}, [
-      E(A, {
+  E = A(`./1.js`),
+  F = () => {
+    return B(`div`, {}, [
+      B(D, {
         a: `Blah`
       }),
-      E(F, {
+      B(C, {
         c: [],
         key: `Lesson`,
         p: {
           a: `Hello`
         },
-        x: B
+        x: E
       })
     ])
   };

--- a/spec/compilers/component_children
+++ b/spec/compilers/component_children
@@ -13,16 +13,16 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as C,
-  toArray as D
+  createElement as A,
+  toArray as B
 } from "./runtime.js";
 
 export const
-  A = ({
+  C = ({
     children: a = []
   }) => {
     return a
   },
-  B = () => {
-    return C(A, {}, D(``))
+  D = () => {
+    return A(C, {}, B(``))
   };

--- a/spec/compilers/component_global
+++ b/spec/compilers/component_global
@@ -25,21 +25,21 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  signal as D
+  createElement as A,
+  signal as B
 } from "./runtime.js";
 
 export const
-  A = () => {
-    return B(`div`, {}, [a()])
+  C = () => {
+    return A(`div`, {}, [a()])
   },
   b = (c) => {
     return c
   },
-  C = () => {
-    return B(`div`, {}, [b(`Hello`)])
+  D = () => {
+    return A(`div`, {}, [b(`Hello`)])
   },
-  d = D(``),
+  d = B(``),
   a = () => {
     return d.value
   };

--- a/spec/compilers/component_instance_access
+++ b/spec/compilers/component_instance_access
@@ -29,55 +29,55 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as K,
-  createElement as F,
-  pattern as J,
-  useMemo as E,
-  variant as B,
-  setRef as L,
-  useRef as H,
-  match as I
+  patternVariable as G,
+  createElement as C,
+  pattern as F,
+  useMemo as B,
+  variant as A,
+  setRef as H,
+  useRef as D,
+  match as E
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = ({
+  I = A(1),
+  J = A(0),
+  K = ({
     _
   }) => {
     const a = () => {
       return `Instance`
     };
-    const b = E(() => {
+    const b = B(() => {
       return {
         a
       }
     }, []);
     (_ ? _(b) : null);
-    return F(`div`, {})
+    return C(`div`, {})
   },
-  G = () => {
+  L = () => {
     const
-      c = H(new C()),
+      c = D(new J()),
       d = () => {
-        return I(c.current, [
+        return E(c.current, [
           [
-            J(A, [K]),
+            F(I, [G]),
             (e) => {
               return e.a()
             }
           ],
           [
-            J(C, []),
+            F(J, []),
             () => {
               return ``
             }
           ]
         ])
       };
-    return F(`div`, {
+    return C(`div`, {
       "onClick": d
-    }, [F(D, {
-      _: L(c, A)
+    }, [C(K, {
+      _: H(c, I)
     })])
   };

--- a/spec/compilers/component_instance_access_2
+++ b/spec/compilers/component_instance_access_2
@@ -16,21 +16,21 @@ global component Global {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as E,
-  createRef as F,
-  variant as B,
-  setRef as H
+  createElement as B,
+  createRef as C,
+  variant as A,
+  setRef as D
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = () => {
-    return E(`div`, {})
-  },
-  a = F(new C()),
+  E = A(1),
+  F = A(0),
   G = () => {
-    return E(D, {
-      _: H(a, A)
+    return B(`div`, {})
+  },
+  a = C(new F()),
+  H = () => {
+    return B(G, {
+      _: D(a, E)
     })
   };

--- a/spec/compilers/component_instance_access_ref
+++ b/spec/compilers/component_instance_access_ref
@@ -25,55 +25,55 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as L,
-  createElement as G,
-  pattern as K,
-  useMemo as F,
-  variant as B,
-  setRef as H,
-  useRef as E,
-  match as J
+  patternVariable as H,
+  createElement as D,
+  pattern as G,
+  useMemo as C,
+  variant as A,
+  setRef as E,
+  useRef as B,
+  match as F
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = ({
+  I = A(1),
+  J = A(0),
+  K = ({
     _
   }) => {
-    const a = E(new C());
-    const b = F(() => {
+    const a = B(new J());
+    const b = C(() => {
       return {
         a
       }
     }, []);
     (_ ? _(b) : null);
-    return G(`div`, {
-      ref: H(a, A)
+    return D(`div`, {
+      ref: E(a, I)
     })
   },
-  I = () => {
+  L = () => {
     const
-      c = E(new C()),
+      c = B(new J()),
       d = () => {
-        return J(c.current, [
+        return F(c.current, [
           [
-            K(A, [L]),
+            G(I, [H]),
             (e) => {
               return e.a.current
             }
           ],
           [
-            K(C, []),
+            G(J, []),
             () => {
-              return new C()
+              return new J()
             }
           ]
         ])
       };
-    return G(`div`, {
+    return D(`div`, {
       "onClick": d
-    }, [G(D, {
-      _: H(c, A)
+    }, [D(K, {
+      _: E(c, I)
     })])
   };

--- a/spec/compilers/component_namespaced
+++ b/spec/compilers/component_namespaced
@@ -10,12 +10,12 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as C } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = () => {
+  B = () => {
     return `test`
   },
-  B = () => {
-    return C(A, {})
+  C = () => {
+    return A(B, {})
   };

--- a/spec/compilers/component_namespaced_with_style
+++ b/spec/compilers/component_namespaced_with_style
@@ -22,14 +22,14 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = () => {
-    return B(`div`, {
+  B = () => {
+    return A(`div`, {
       className: `Ui·Dropdown_base`
     }, [`test`])
   },
   C = () => {
-    return B(A, {})
+    return A(B, {})
   };

--- a/spec/compilers/component_readonly
+++ b/spec/compilers/component_readonly
@@ -12,16 +12,16 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = ({
+  B = ({
     a = false
   }) => {
-    return B(`div`, {})
+    return A(`div`, {})
   },
   C = () => {
-    return B(A, {
+    return A(B, {
       a: true
     })
   };

--- a/spec/compilers/component_with_provider
+++ b/spec/compilers/component_with_provider
@@ -23,19 +23,19 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createProvider as B,
-  createElement as E,
-  useId as D
+  createProvider as A,
+  createElement as C,
+  useId as B
 } from "./runtime.js";
 
 export const
   a = new Map(),
-  A = B(a, () => {
+  D = A(a, () => {
     return null
   }),
-  C = () => {
-    const b = D();
-    A(b, () => {
+  E = () => {
+    const b = B();
+    D(b, () => {
       return (false ? {
         moves: (c) => {
           return null
@@ -45,6 +45,5 @@ export const
         }
       } : null)
     });
-    return E(`div`, {})
+    return C(`div`, {})
   };
-

--- a/spec/compilers/component_with_provider_and_lifecycle_functions
+++ b/spec/compilers/component_with_provider_and_lifecycle_functions
@@ -35,21 +35,21 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createProvider as B,
-  createElement as G,
-  useDidUpdate as F,
-  useEffect as E,
-  useId as D
+  createProvider as A,
+  createElement as E,
+  useDidUpdate as D,
+  useEffect as C,
+  useId as B
 } from "./runtime.js";
 
 export const
   a = new Map(),
-  A = B(a, () => {
+  F = A(a, () => {
     return null
   }),
-  C = () => {
-    const b = D();
-    E(() => {
+  G = () => {
+    const b = B();
+    C(() => {
       (() => {
         return null
       })();
@@ -57,10 +57,10 @@ export const
         return null
       }
     }, []);
-    F(() => {
+    D(() => {
       return null
     });
-    A(b, () => {
+    F(b, () => {
       return (false ? {
         moves: (c) => {
           return null
@@ -70,5 +70,5 @@ export const
         }
       } : null)
     });
-    return G(`div`, {})
+    return E(`div`, {})
   };

--- a/spec/compilers/component_with_provider_and_store
+++ b/spec/compilers/component_with_provider_and_store
@@ -33,10 +33,10 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createProvider as C,
-  createElement as F,
+  createProvider as B,
+  createElement as D,
   signal as A,
-  useId as E
+  useId as C
 } from "./runtime.js";
 
 export const
@@ -45,12 +45,12 @@ export const
   },
   b = A(``),
   c = new Map(),
-  B = C(c, () => {
+  E = B(c, () => {
     return null
   }),
-  D = () => {
-    const d = E();
-    B(d, () => {
+  F = () => {
+    const d = C();
+    E(d, () => {
       return (false ? {
         moves: (e) => {
           return null
@@ -60,5 +60,5 @@ export const
         }
       } : null)
     });
-    return F(`div`, {})
+    return D(`div`, {})
   };

--- a/spec/compilers/constant_component
+++ b/spec/compilers/constant_component
@@ -6,9 +6,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { useSignal as B } from "./runtime.js";
+import { useSignal as A } from "./runtime.js";
 
-export const A = () => {
-  const a = B(`ASD`);
+export const B = () => {
+  const a = A(`ASD`);
   return a.value
 };

--- a/spec/compilers/constant_global_component
+++ b/spec/compilers/constant_global_component
@@ -14,13 +14,13 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as C } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = () => {
+  B = () => {
     return a
   },
   a = `ASD`,
-  B = () => {
-    return C(`div`, {}, [a])
+  C = () => {
+    return A(`div`, {}, [a])
   };

--- a/spec/compilers/constant_module
+++ b/spec/compilers/constant_module
@@ -10,11 +10,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
   a = `ASD`,
-  A = () => {
-    return B(`div`, {}, [a])
+  B = () => {
+    return A(`div`, {}, [a])
   };
-

--- a/spec/compilers/constant_store
+++ b/spec/compilers/constant_store
@@ -10,11 +10,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
   a = `ASD`,
-  A = () => {
-    return B(`div`, {}, [a])
+  B = () => {
+    return A(`div`, {}, [a])
   };
-

--- a/spec/compilers/constant_store_exposed
+++ b/spec/compilers/constant_store_exposed
@@ -12,10 +12,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
   a = `ASD`,
-  A = () => {
-    return B(`div`, {}, [a])
+  B = () => {
+    return A(`div`, {}, [a])
   };

--- a/spec/compilers/css_definition
+++ b/spec/compilers/css_definition
@@ -19,11 +19,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
     a = () => {
       return 10
@@ -34,8 +34,8 @@ export const A = () => {
       };
       return _
     };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([b()])
+    style: B([b()])
   })
 };

--- a/spec/compilers/css_font_face
+++ b/spec/compilers/css_font_face
@@ -30,10 +30,10 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `Main_test`
   })
 };

--- a/spec/compilers/css_font_face_with_quotes
+++ b/spec/compilers/css_font_face_with_quotes
@@ -24,10 +24,10 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `Main_test`
   })
 };

--- a/spec/compilers/css_keyframes
+++ b/spec/compilers/css_keyframes
@@ -51,22 +51,22 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(1),
+    a = A(1),
     b = () => {
       const _ = {
         [`--a-a`]: a.value
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([b()])
+    style: C([b()])
   })
 };

--- a/spec/compilers/css_media
+++ b/spec/compilers/css_media
@@ -31,11 +31,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
     a = () => {
       return `blue`
@@ -47,8 +47,8 @@ export const A = () => {
       };
       return _
     };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([b()])
+    style: B([b()])
   })
 };

--- a/spec/compilers/css_media_with_if
+++ b/spec/compilers/css_media_with_if
@@ -27,11 +27,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = () => {
     const _ = {};
     (true ? Object.assign(_, {
@@ -39,8 +39,8 @@ export const A = () => {
     }) : null);
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a()])
+    style: B([a()])
   })
 };

--- a/spec/compilers/css_selector
+++ b/spec/compilers/css_selector
@@ -29,11 +29,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
     a = () => {
       return `blue`
@@ -44,8 +44,8 @@ export const A = () => {
       };
       return _
     };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([b()])
+    style: B([b()])
   })
 };

--- a/spec/compilers/css_selector_multiple
+++ b/spec/compilers/css_selector_multiple
@@ -34,11 +34,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
     a = () => {
       return `blue`
@@ -49,8 +49,8 @@ export const A = () => {
       };
       return _
     };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([b()])
+    style: B([b()])
   })
 };

--- a/spec/compilers/css_string
+++ b/spec/compilers/css_string
@@ -21,22 +21,22 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(`Joe`),
+    a = A(`Joe`),
     b = () => {
       const _ = {
         [`--a-a`]: `"Hi"` + ` blah ` + a.value + ` ` + `"Here is some content; Thanks ${a.value}"`
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_unicode`,
-    style: D([b()])
-  }, [C(`span`, {})])
+    style: C([b()])
+  }, [B(`span`, {})])
 };

--- a/spec/compilers/css_supports
+++ b/spec/compilers/css_supports
@@ -21,22 +21,22 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(`blue`),
+    a = A(`blue`),
     b = () => {
       const _ = {
         [`--a-a`]: a.value
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([b()])
+    style: C([b()])
   })
 };

--- a/spec/compilers/css_with_ands
+++ b/spec/compilers/css_with_ands
@@ -32,10 +32,10 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `Main_test`
   })
 };

--- a/spec/compilers/css_with_arguments
+++ b/spec/compilers/css_with_arguments
@@ -15,19 +15,19 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = (b) => {
     const _ = {
       [`--a-a`]: b
     };
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a(`red`)])
+    style: B([a(`red`)])
   })
 };

--- a/spec/compilers/css_with_case
+++ b/spec/compilers/css_with_case
@@ -23,15 +23,15 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  style as D,
-  match as B
+  createElement as B,
+  style as C,
+  match as A
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const a = () => {
     const _ = {};
-    B(`a`, [
+    A(`a`, [
       [
         `a`,
         () => {
@@ -51,8 +51,8 @@ export const A = () => {
     ]);
     return _
   };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([a()])
+    style: C([a()])
   })
 };

--- a/spec/compilers/css_with_else_if
+++ b/spec/compilers/css_with_else_if
@@ -25,23 +25,23 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  compare as B,
-  style as D
+  createElement as B,
+  compare as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const a = (b) => {
     const _ = {};
-    (B(b, `red`) ? Object.assign(_, {
+    (A(b, `red`) ? Object.assign(_, {
       [`--a-a`]: `red`
-    }) : (B(b, `blue`) ? Object.assign(_, {
+    }) : (A(b, `blue`) ? Object.assign(_, {
       [`--a-a`]: `blue`
     }) : null));
     return _
   };
-  return C(`div`, {}, [C(`div`, {
+  return B(`div`, {}, [B(`div`, {
     className: `Main_base`,
-    style: D([a(`blue`)])
+    style: C([a(`blue`)])
   })])
 };

--- a/spec/compilers/css_with_if
+++ b/spec/compilers/css_with_if
@@ -21,11 +21,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = () => {
     const _ = {};
     (true ? Object.assign(_, {
@@ -35,8 +35,8 @@ export const A = () => {
     }));
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a()])
+    style: B([a()])
   })
 };

--- a/spec/compilers/css_with_if_and_case
+++ b/spec/compilers/css_with_if_and_case
@@ -26,15 +26,15 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  style as D,
-  match as B
+  createElement as B,
+  style as C,
+  match as A
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const a = () => {
     const _ = {};
-    B(true, [
+    A(true, [
       [
         true,
         () => {
@@ -59,8 +59,8 @@ export const A = () => {
     }));
     return _
   };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([a()])
+    style: C([a()])
   })
 };

--- a/spec/compilers/css_with_if_same_condition
+++ b/spec/compilers/css_with_if_same_condition
@@ -33,11 +33,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = () => {
     const _ = {};
     (true ? Object.assign(_, {
@@ -52,8 +52,8 @@ export const A = () => {
     }));
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a()])
+    style: B([a()])
   })
 };

--- a/spec/compilers/css_with_if_variables
+++ b/spec/compilers/css_with_if_variables
@@ -28,14 +28,14 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
+  createElement as B,
   signal as A,
-  style as D
+  style as C
 } from "./runtime.js";
 
 export const
   a = A(false),
-  B = () => {
+  D = () => {
     const b = () => {
       const _ = {};
       (a.value ? Object.assign(_, {
@@ -45,8 +45,8 @@ export const
       }));
       return _
     };
-    return C(`div`, {
+    return B(`div`, {
       className: `Main_test`,
-      style: D([b()])
+      style: C([b()])
     })
   };

--- a/spec/compilers/css_with_if_with_interpolation
+++ b/spec/compilers/css_with_if_with_interpolation
@@ -21,11 +21,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = () => {
     const _ = {};
     (true ? Object.assign(_, {
@@ -35,8 +35,8 @@ export const A = () => {
     }));
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a()])
+    style: B([a()])
   })
 };

--- a/spec/compilers/dce_remove_component_computed_property
+++ b/spec/compilers/dce_remove_component_computed_property
@@ -8,8 +8,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {})
+export const B = () => {
+  return A(`div`, {})
 };

--- a/spec/compilers/dce_remove_component_function
+++ b/spec/compilers/dce_remove_component_function
@@ -8,8 +8,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {})
+export const B = () => {
+  return A(`div`, {})
 };

--- a/spec/compilers/dce_style
+++ b/spec/compilers/dce_style
@@ -8,8 +8,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {})
+export const B = () => {
+  return A(`div`, {})
 };

--- a/spec/compilers/decode
+++ b/spec/compilers/decode
@@ -21,21 +21,21 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeString as E,
-  decoder as D,
-  variant as B
+  decodeString as C,
+  decoder as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  a = D({
-    blah: E(C, A)
-  }, C, A),
-  b = D({
-    name: E(C, A),
+  D = A(1),
+  E = A(1),
+  a = B({
+    blah: C(E, D)
+  }, E, D),
+  b = B({
+    name: C(E, D),
     y: a
-  }, C, A),
+  }, E, D),
   F = () => {
     b((null));
     return ``

--- a/spec/compilers/decode_function
+++ b/spec/compilers/decode_function
@@ -21,21 +21,21 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeString as E,
-  decoder as D,
-  variant as B
+  decodeString as C,
+  decoder as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  a = D({
-    blah: E(C, A)
-  }, C, A),
-  b = D({
-    name: E(C, A),
+  D = A(1),
+  E = A(1),
+  a = B({
+    blah: C(E, D)
+  }, E, D),
+  b = B({
+    name: C(E, D),
     y: a
-  }, C, A),
+  }, E, D),
   F = () => {
     (b)((null));
     return ``

--- a/spec/compilers/decode_map
+++ b/spec/compilers/decode_map
@@ -12,15 +12,15 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeNumber as F,
-  decodeMap as E,
-  variant as B
+  decodeNumber as C,
+  decodeMap as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  D = () => {
-    E(F(C, A), C, A)((([])));
+  D = A(1),
+  E = A(1),
+  F = () => {
+    B(C(E, D), E, D)((([])));
     return ``
   };

--- a/spec/compilers/decode_tuple
+++ b/spec/compilers/decode_tuple
@@ -12,20 +12,20 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeNumber as G,
-  decodeString as F,
-  decodeTuple as E,
-  variant as B
+  decodeNumber as D,
+  decodeString as C,
+  decodeTuple as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  D = () => {
-    E([
-      F(C, A),
-      G(C, A),
-      F(C, A)
-    ], C, A)((([])));
+  E = A(1),
+  F = A(1),
+  G = () => {
+    B([
+      C(F, E),
+      D(F, E),
+      C(F, E)
+    ], F, E)((([])));
     return ``
   };

--- a/spec/compilers/decoder
+++ b/spec/compilers/decoder
@@ -30,36 +30,36 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeBoolean as K,
-  decodeString as I,
-  decodeNumber as G,
-  decodeArray as J,
-  decodeMaybe as H,
-  decodeTime as L,
-  decoder as F,
-  variant as B
+  decodeBoolean as G,
+  decodeString as E,
+  decodeNumber as C,
+  decodeArray as F,
+  decodeMaybe as D,
+  decodeTime as H,
+  decoder as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = B(1),
-  E = B(1),
-  a = F({
+  I = A(1),
+  J = A(0),
+  K = A(1),
+  L = A(1),
+  a = B({
     size: [
-      G(E, D),
+      C(L, K),
       "SIIIZEEE"
     ]
-  }, E, D),
-  b = F({
-    maybe: H(I(E, D), E, D, A, C),
-    array: J(I(E, D), E, D),
-    string: I(E, D),
-    number: G(E, D),
-    bool: K(E, D),
-    time: L(E, D),
+  }, L, K),
+  b = B({
+    maybe: D(E(L, K), L, K, I, J),
+    array: F(E(L, K), L, K),
+    string: E(L, K),
+    number: C(L, K),
+    bool: G(L, K),
+    time: H(L, K),
     y: a
-  }, E, D),
+  }, L, K),
   M = () => {
     b(undefined);
     return ``

--- a/spec/compilers/defer
+++ b/spec/compilers/defer
@@ -28,9 +28,9 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  createElement as D,
-  useEffect as B,
-  load as C
+  createElement as C,
+  useEffect as A,
+  load as B
 } from "./runtime.js";
 
 export const
@@ -38,23 +38,23 @@ export const
     return `Blah`
   },
   b = `./1.js`,
-  A = () => {
-    B(() => {
+  D = () => {
+    A(() => {
       (async () => {
-        const c = await C(b);
+        const c = await B(b);
         return c
       })()
     }, []);
-    return D(`div`, {}, [a()])
+    return C(`div`, {}, [a()])
   };
 
 ---=== /__mint__/1.js ===---
-import { a as c } from "./index.js";
+import { a } from "./index.js";
 
 export const
-  a = () => {
+  b = () => {
     return `Hello!`
   },
-  b = a() + c();
+  c = b() + a();
 
-export default b;
+export default c;

--- a/spec/compilers/defer_2
+++ b/spec/compilers/defer_2
@@ -16,27 +16,27 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  patternVariable as E,
-  createElement as F,
-  destructure as C,
-  useEffect as B,
-  load as D
+  patternVariable as D,
+  createElement as E,
+  destructure as B,
+  useEffect as A,
+  load as C
 } from "./runtime.js";
 
 export const
   a = `./1.js`,
-  A = () => {
-    B(() => {
+  F = () => {
+    A(() => {
       (async () => {
-        const b = C(await D(a), [E]);
+        const b = B(await C(a), [D]);
         if (b === false) {
           return ``
         };
         const [c] = b;
-        return await D(c)
+        return await C(c)
       })()
     }, []);
-    return F(`div`, {}, [``])
+    return E(`div`, {}, [``])
   };
 
 ---=== /__mint__/1.js ===---

--- a/spec/compilers/destructuring
+++ b/spec/compilers/destructuring
@@ -22,34 +22,34 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  newVariant as E,
-  pattern as G,
-  variant as B,
-  match as F
+  patternVariable as E,
+  newVariant as B,
+  pattern as D,
+  variant as A,
+  match as C
 } from "./runtime.js";
 
 export const
-  A = B([
+  F = A([
     "matchString",
     "content",
     "key"
   ]),
-  C = B(0),
-  D = () => {
-    const a = E(A)(`MATCHSTRING`, `CONTENT`, `KEY`);
-    return F(a, [
+  G = A(0),
+  H = () => {
+    const a = B(F)(`MATCHSTRING`, `CONTENT`, `KEY`);
+    return C(a, [
       [
-        G(A, [
+        D(F, [
           null,
-          H
+          E
         ]),
         (b) => {
           return b
         }
       ],
       [
-        G(C, []),
+        D(G, []),
         () => {
           return ``
         }

--- a/spec/compilers/destructuring_constant
+++ b/spec/compilers/destructuring_constant
@@ -11,12 +11,12 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { match as B } from "./runtime.js";
+import { match as A } from "./runtime.js";
 
 export const
   a = `Hello`,
-  A = () => {
-    return B(``, [
+  B = () => {
+    return A(``, [
       [
         a,
         () => {

--- a/spec/compilers/destructuring_state
+++ b/spec/compilers/destructuring_state
@@ -13,13 +13,13 @@ component Main {
 --------------------------------------------------------------------------------
 import {
   signal as A,
-  match as C
+  match as B
 } from "./runtime.js";
 
 export const
   a = A(`Hello`),
-  B = () => {
-    return C(``, [
+  C = () => {
+    return B(``, [
       [
         a.value,
         () => {

--- a/spec/compilers/directives/highlight
+++ b/spec/compilers/directives/highlight
@@ -7,16 +7,16 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   return [
     `Test`,
-    B(C, {}, [B("span", {
+    A(B, {}, [A("span", {
       className: "line"
-    }, [B("span", {
+    }, [A("span", {
       className: "string"
     }, [`"Test"`])])])
   ][1]

--- a/spec/compilers/directives/highlight-comments-multiple
+++ b/spec/compilers/directives/highlight-comments-multiple
@@ -9,38 +9,38 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   return [
     ``,
-    B(C, {}, [
-      B("span", {
+    A(B, {}, [
+      A("span", {
         className: "line"
       }, [
-        B("span", {
+        A("span", {
           className: "comment"
         }, [`// Comment1`]),
         `
 `
       ]),
-      B("span", {
+      A("span", {
         className: "line"
       }, [
         ``,
-        B("span", {
+        A("span", {
           className: "comment"
         }, [`// Comment2`]),
         `
 `
       ]),
-      B("span", {
+      A("span", {
         className: "line"
       }, [
         ``,
-        B("span", {
+        A("span", {
           className: "string"
         }, [`""`])
       ])

--- a/spec/compilers/directives/highlight-file
+++ b/spec/compilers/directives/highlight-file
@@ -5,62 +5,62 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B("span", {
+export const C = () => {
+  return A(B, {}, [
+    A("span", {
       className: "line"
     }, [
-      B("span", {
+      A("span", {
         className: "keyword"
       }, [`component`]),
       ` `,
-      B("span", {
+      A("span", {
         className: "type"
       }, [`Main`]),
       ` {
 `
     ]),
-    B("span", {
+    A("span", {
       className: "line"
     }, [
       `  `,
-      B("span", {
+      A("span", {
         className: "keyword"
       }, [`fun`]),
       ` render : `,
-      B("span", {
+      A("span", {
         className: "type"
       }, [`Html`]),
       ` {
 `
     ]),
-    B("span", {
+    A("span", {
       className: "line"
     }, [
       `    <`,
-      B("span", {
+      A("span", {
         className: "namespace"
       }, [`div`]),
       `></`,
-      B("span", {
+      A("span", {
         className: "namespace"
       }, [`div`]),
       `>
 `
     ]),
-    B("span", {
+    A("span", {
       className: "line"
     }, [`  }
 `]),
-    B("span", {
+    A("span", {
       className: "line"
     }, [`}
 `]),
-    B("span", {
+    A("span", {
       className: "line"
     }, [``])
   ])

--- a/spec/compilers/encode_in_async
+++ b/spec/compilers/encode_in_async
@@ -13,19 +13,19 @@ component Main {
 --------------------------------------------------------------------------------
 ---=== /__mint__/index.js ===---
 import {
-  lazyComponent as E,
-  createElement as D,
-  lazy as B
+  lazyComponent as C,
+  createElement as B,
+  lazy as A
 } from "./runtime.js";
 
 export const
-  A = B(`./1.js`),
-  C = () => {
-    return D(E, {
+  D = A(`./1.js`),
+  E = () => {
+    return B(C, {
       c: [],
       key: `X`,
       p: {},
-      x: A
+      x: D
     })
   };
 

--- a/spec/compilers/encoder_and_decoder
+++ b/spec/compilers/encoder_and_decoder
@@ -18,24 +18,24 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  decodeNumber as F,
-  decodeString as E,
-  identity as H,
-  encoder as G,
-  decoder as D,
-  variant as B
+  decodeNumber as D,
+  decodeString as C,
+  identity as F,
+  encoder as E,
+  decoder as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(1),
-  a = D({
-    string: E(C, A),
-    number: F(C, A)
-  }, C, A),
-  b = G({
-    string: H,
-    number: H
+  G = A(1),
+  H = A(1),
+  a = B({
+    string: C(H, G),
+    number: D(H, G)
+  }, H, G),
+  b = E({
+    string: F,
+    number: F
   }),
   I = () => {
     a(undefined);

--- a/spec/compilers/field
+++ b/spec/compilers/field
@@ -14,12 +14,12 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   {
     a: `Hello`,
     b: 0
   };
-  return B(`div`, {})
+  return A(`div`, {})
 };

--- a/spec/compilers/field_access
+++ b/spec/compilers/field_access
@@ -24,13 +24,13 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { access as B } from "./runtime.js";
+import { access as A } from "./runtime.js";
 
 export const
   a = (b, c) => {
     return undefined
   },
-  A = () => {
+  B = () => {
     a([
       {
         name: `Joe`
@@ -38,6 +38,6 @@ export const
       {
         name: `Doe`
       }
-    ], B(`name`));
+    ], A(`name`));
     return `asd`
   };

--- a/spec/compilers/for
+++ b/spec/compilers/for
@@ -8,9 +8,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   return (() => {
     const _0 = [];
     const _1 = [
@@ -20,7 +20,7 @@ export const A = () => {
     let _i = -1;
     for (let a of _1) {
       _i++;
-      _0.push(B(`div`, {}, [a]))
+      _0.push(A(`div`, {}, [a]))
     };
     return _0
   })()

--- a/spec/compilers/for_with_destructuring
+++ b/spec/compilers/for_with_destructuring
@@ -9,12 +9,12 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as C,
-  createElement as D,
-  destructure as B
+  patternVariable as B,
+  createElement as C,
+  destructure as A
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   return (() => {
     const _0 = [];
     const _1 = [[
@@ -27,11 +27,11 @@ export const A = () => {
       const [
         b,
         c
-      ] = B(a, [
-        C,
-        C
+      ] = A(a, [
+        B,
+        B
       ]);
-      _0.push(D(`div`, {}, [`${b},${c}`]))
+      _0.push(C(`div`, {}, [`${b},${c}`]))
     };
     return _0
   })()

--- a/spec/compilers/for_with_index
+++ b/spec/compilers/for_with_index
@@ -11,11 +11,11 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as C,
-  compare as B
+  createElement as B,
+  compare as A
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   return (() => {
     const _0 = [];
     const _1 = [
@@ -26,11 +26,11 @@ export const A = () => {
     for (let a of _1) {
       _i++;
       const b = _i;
-      const _2 = B(b, 10);
+      const _2 = A(b, 10);
       if (!_2) {
         continue
       };
-      _0.push(C(`div`, {}, [a]))
+      _0.push(B(`div`, {}, [a]))
     };
     return _0
   })()

--- a/spec/compilers/for_with_index_2
+++ b/spec/compilers/for_with_index_2
@@ -8,9 +8,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   return (() => {
     const _0 = [];
     const _1 = [
@@ -21,7 +21,7 @@ export const A = () => {
     for (let a of _1) {
       _i++;
       const b = _i;
-      _0.push(B(`div`, {}, [a]))
+      _0.push(A(`div`, {}, [a]))
     };
     return _0
   })()

--- a/spec/compilers/function_call_with_arguments
+++ b/spec/compilers/function_call_with_arguments
@@ -25,4 +25,3 @@ export const A = () => {
   d();
   return ``
 };
-

--- a/spec/compilers/here_doc_markdown
+++ b/spec/compilers/here_doc_markdown
@@ -9,13 +9,13 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B('h2', {}, [`Hello There`]),
-    B('p', {}, [`WTF`])
+export const C = () => {
+  return A(B, {}, [
+    A('h2', {}, [`Hello There`]),
+    A('p', {}, [`WTF`])
   ])
 };

--- a/spec/compilers/here_doc_markdown_escape
+++ b/spec/compilers/here_doc_markdown_escape
@@ -14,61 +14,61 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B('p', {}, [`#{name}`]),
-    B('pre', {}, [B('code', {
+export const C = () => {
+  return A(B, {}, [
+    A('p', {}, [`#{name}`]),
+    A('pre', {}, [A('code', {
       class: "language-mint"
     }, [
-      B('span', {
+      A('span', {
         class: "line"
       }, [`\`Something\`
 `]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [
         ``,
-        B('span', {
+        A('span', {
           class: "string"
         }, [`"#{`]),
-        B('span', {
+        A('span', {
           class: "variable"
         }, [`name`]),
-        B('span', {
+        A('span', {
           class: "string"
         }, [`}"`]),
         `
 `
       ]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [
         ``,
-        B('span', {
+        A('span', {
           class: "string"
         }, [`"First line" \\`]),
         `
 `
       ]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [
         ``,
-        B('span', {
+        A('span', {
           class: "string"
         }, [`"Second line" \\`]),
         `
 `
       ]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [
         ``,
-        B('span', {
+        A('span', {
           class: "string"
         }, [`"Third line"`])
       ])

--- a/spec/compilers/here_doc_markdown_in_markdown
+++ b/spec/compilers/here_doc_markdown_in_markdown
@@ -17,65 +17,65 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [B('pre', {}, [B('code', {
+export const C = () => {
+  return A(B, {}, [A('pre', {}, [A('code', {
     class: "language-mint"
   }, [
-    B('span', {
+    A('span', {
       class: "line"
     }, [
       `<<#MD(`,
-      B('span', {
+      A('span', {
         class: "keyword"
       }, [`highlight`]),
       `)`,
-      B('span', {
+      A('span', {
         class: "string"
       }, [``])
     ]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`This is a paragraph.`])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [``])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`\`\`\`mint`])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`module Mint {`])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`  // This will be syntax highlighted`])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`}`])]),
-    B('span', {
+    A('span', {
       class: "line"
-    }, [B('span', {
+    }, [A('span', {
       class: "string"
     }, [`\`\`\``])]),
-    B('span', {
+    A('span', {
       class: "line"
     }, [
-      B('span', {
+      A('span', {
         class: "string"
       }, [``]),
       `MD`

--- a/spec/compilers/here_doc_markdown_with_code_block
+++ b/spec/compilers/here_doc_markdown_with_code_block
@@ -13,27 +13,27 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B('p', {}, [`Text`]),
-    B('pre', {}, [B('code', {
+export const C = () => {
+  return A(B, {}, [
+    A('p', {}, [`Text`]),
+    A('pre', {}, [A('code', {
       class: "language-mint"
-    }, [B('span', {
+    }, [A('span', {
       class: "line"
     }, [
-      B('span', {
+      A('span', {
         class: "keyword"
       }, [`module`]),
       ` `,
-      B('span', {
+      A('span', {
         class: "type"
       }, [`Time`]),
       ` {}`
     ])])]),
-    B('p', {}, [`Text`])
+    A('p', {}, [`Text`])
   ])
 };

--- a/spec/compilers/here_doc_markdown_with_code_block_interpolation
+++ b/spec/compilers/here_doc_markdown_with_code_block_interpolation
@@ -11,16 +11,16 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = [
     0,
     0
   ];
-  return B(C, {}, [B('pre', {}, [B('code', {
+  return A(B, {}, [A('pre', {}, [A('code', {
     class: "language-mint"
   }, [
     `<div>"`,

--- a/spec/compilers/here_doc_markdown_with_code_block_interpolation_highlight
+++ b/spec/compilers/here_doc_markdown_with_code_block_interpolation_highlight
@@ -11,26 +11,26 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = [
     0,
     0
   ];
-  return B(C, {}, [B('pre', {}, [B('code', {
+  return A(B, {}, [A('pre', {}, [A('code', {
     class: "language-mint"
-  }, [B('span', {
+  }, [A('span', {
     class: "line"
   }, [
     `<`,
-    B('span', {
+    A('span', {
       class: "namespace"
     }, [`div`]),
     `>`,
-    B('span', {
+    A('span', {
       class: "string"
     }, [
       `"`,
@@ -40,7 +40,7 @@ export const A = () => {
       `"`
     ]),
     `</`,
-    B('span', {
+    A('span', {
       class: "namespace"
     }, [`div`]),
     `>`

--- a/spec/compilers/here_doc_markdown_with_code_block_multiline
+++ b/spec/compilers/here_doc_markdown_with_code_block_multiline
@@ -15,51 +15,51 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B('p', {}, [`Text`]),
-    B('pre', {}, [B('code', {
+export const C = () => {
+  return A(B, {}, [
+    A('p', {}, [`Text`]),
+    A('pre', {}, [A('code', {
       class: "language-mint"
     }, [
-      B('span', {
+      A('span', {
         class: "line"
       }, [
-        B('span', {
+        A('span', {
           class: "keyword"
         }, [`module`]),
         ` `,
-        B('span', {
+        A('span', {
           class: "type"
         }, [`Time`]),
         ` {
 `
       ]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [
         `  `,
-        B('span', {
+        A('span', {
           class: "keyword"
         }, [`const`]),
         ` `,
-        B('span', {
+        A('span', {
           class: "type"
         }, [`NOW`]),
         ` = `,
-        B('span', {
+        A('span', {
           class: "string"
         }, [`""`]),
         `
 `
       ]),
-      B('span', {
+      A('span', {
         class: "line"
       }, [`}`])
     ])]),
-    B('p', {}, [`Text`])
+    A('p', {}, [`Text`])
   ])
 };

--- a/spec/compilers/here_doc_markdown_with_html_interpolation
+++ b/spec/compilers/here_doc_markdown_with_html_interpolation
@@ -9,14 +9,14 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as C,
-  useSignal as B,
-  fragment as D
+  createElement as B,
+  useSignal as A,
+  fragment as C
 } from "./runtime.js";
 
-export const A = () => {
-  const a = B(C(`div`, {}));
-  return C(D, {}, [C('p', {}, [
+export const D = () => {
+  const a = A(B(`div`, {}));
+  return B(C, {}, [B('p', {}, [
     ``,
     a.value,
     ` Some text...`

--- a/spec/compilers/here_doc_markdown_with_inline_code
+++ b/spec/compilers/here_doc_markdown_with_inline_code
@@ -7,14 +7,14 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [B('ul', {}, [B('li', {}, [
+export const C = () => {
+  return A(B, {}, [A('ul', {}, [A('li', {}, [
     `When open pressing `,
-    B('code', {}, [`Esc`]),
+    A('code', {}, [`Esc`]),
     ` closes it.`
   ])])])
 };

--- a/spec/compilers/here_doc_markdown_with_interpolation
+++ b/spec/compilers/here_doc_markdown_with_interpolation
@@ -9,16 +9,16 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(C, {}, [
-    B('h2', {}, [`Hello There`]),
-    B('p', {}, [
+export const C = () => {
+  return A(B, {}, [
+    A('h2', {}, [`Hello There`]),
+    A('p', {}, [
       ``,
-      B(`div`, {}, [`Hello`]),
+      A(`div`, {}, [`Hello`]),
       ``,
       `
 `,

--- a/spec/compilers/html_attribute_class
+++ b/spec/compilers/html_attribute_class
@@ -5,10 +5,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `something`
   })
 };

--- a/spec/compilers/html_attribute_class_with_style
+++ b/spec/compilers/html_attribute_class_with_style
@@ -15,10 +15,10 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `something` + ` Main_base`
   })
 };

--- a/spec/compilers/html_attribute_html_fragment
+++ b/spec/compilers/html_attribute_html_fragment
@@ -12,16 +12,16 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = ({
+  B = ({
     a = null
   }) => {
-    return B(`div`, {})
+    return A(`div`, {})
   },
   C = () => {
-    return B(A, {
+    return A(B, {
       a: `x`
     })
   };

--- a/spec/compilers/html_attribute_readonly
+++ b/spec/compilers/html_attribute_readonly
@@ -4,10 +4,11 @@ component Main {
     </div>
   }
 }
---------------------------------------------------------------------------------import { createElement as B } from "./runtime.js";
+--------------------------------------------------------------------------------
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     readOnly: true
   })
 };

--- a/spec/compilers/html_attribute_ref
+++ b/spec/compilers/html_attribute_ref
@@ -11,19 +11,18 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as F,
-  variant as B,
-  setRef as G,
-  useRef as E
+  createElement as C,
+  variant as A,
+  setRef as D,
+  useRef as B
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = () => {
-    const a = E(new C());
-    return F(`div`, {
-      ref: G(a, A)
+  E = A(1),
+  F = A(0),
+  G = () => {
+    const a = B(new F());
+    return C(`div`, {
+      ref: D(a, E)
     })
   };
-

--- a/spec/compilers/html_attribute_simple
+++ b/spec/compilers/html_attribute_simple
@@ -5,10 +5,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     "title": `Hello`
   })
 };

--- a/spec/compilers/html_attribute_with_expression
+++ b/spec/compilers/html_attribute_with_expression
@@ -5,10 +5,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     "title": `Hello ` + `there!`
   })
 };

--- a/spec/compilers/html_component
+++ b/spec/compilers/html_component
@@ -10,12 +10,12 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = () => {
-    return B(`div`, {})
+  B = () => {
+    return A(`div`, {})
   },
   C = () => {
-    return B(A, {})
+    return A(B, {})
   };

--- a/spec/compilers/html_fragment
+++ b/spec/compilers/html_fragment
@@ -10,12 +10,12 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  fragment as C
+  createElement as A,
+  fragment as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {}, [B(C, {}, [
+export const C = () => {
+  return A(`div`, {}, [A(B, {}, [
     `A`,
     `B`
   ])])

--- a/spec/compilers/html_fragment_empty
+++ b/spec/compilers/html_fragment_empty
@@ -7,8 +7,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {}, [null])
+export const B = () => {
+  return A(`div`, {}, [null])
 };

--- a/spec/compilers/html_with_custom_style
+++ b/spec/compilers/html_with_custom_style
@@ -10,15 +10,15 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = () => {
     return undefined
   };
-  return B(`div`, {
-    style: C([a()])
+  return A(`div`, {
+    style: B([a()])
   })
 };

--- a/spec/compilers/html_with_multiple_styles
+++ b/spec/compilers/html_with_multiple_styles
@@ -23,10 +23,10 @@ component Main {
 }
 
 ---=== /__mint__/index.js ===---
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
+export const B = () => {
+  return A(`div`, {
     className: `Main_one Main_two`
   })
 };

--- a/spec/compilers/html_with_multiple_styles_and_parameters
+++ b/spec/compilers/html_with_multiple_styles_and_parameters
@@ -24,19 +24,19 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = (b) => {
     const _ = {
       [`--a-a`]: b
     };
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_one Main_two`,
-    style: C([a(`blue`)])
+    style: B([a(`blue`)])
   })
 };

--- a/spec/compilers/html_with_multiple_styles_and_parameters_2
+++ b/spec/compilers/html_with_multiple_styles_and_parameters_2
@@ -24,11 +24,11 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
     a = (b) => {
       const _ = {
@@ -42,9 +42,9 @@ export const A = () => {
       };
       return _
     };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_one Main_two`,
-    style: C([
+    style: B([
       a(`red`),
       c(`blue`)
     ])

--- a/spec/compilers/html_with_pseudos
+++ b/spec/compilers/html_with_pseudos
@@ -49,15 +49,15 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(`yellow`),
-    b = B(`blue`),
+    a = A(`yellow`),
+    b = A(`blue`),
     c = () => {
       const _ = {
         [`--a-a`]: b.value,
@@ -66,8 +66,8 @@ export const A = () => {
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([c()])
+    style: C([c()])
   })
 };

--- a/spec/compilers/html_with_string_style
+++ b/spec/compilers/html_with_string_style
@@ -5,12 +5,12 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {
-    style: C([`opacity:0;`])
+export const C = () => {
+  return A(`div`, {
+    style: B([`opacity:0;`])
   })
 };

--- a/spec/compilers/html_with_style
+++ b/spec/compilers/html_with_style
@@ -62,15 +62,15 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(`blue`),
-    b = B(`yellow`),
+    a = A(`blue`),
+    b = A(`yellow`),
     c = () => {
       const _ = {
         [`--a-a`]: a.value,
@@ -80,8 +80,8 @@ export const A = () => {
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([c()])
+    style: C([c()])
   })
 };

--- a/spec/compilers/html_with_style_and_custom_style
+++ b/spec/compilers/html_with_style_and_custom_style
@@ -24,14 +24,14 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as C,
-  useSignal as B,
-  style as D
+  createElement as B,
+  useSignal as A,
+  style as C
 } from "./runtime.js";
 
-export const A = () => {
+export const D = () => {
   const
-    a = B(`blue`),
+    a = A(`blue`),
     b = () => {
       return undefined
     },
@@ -41,9 +41,9 @@ export const A = () => {
       };
       return _
     };
-  return C(`div`, {
+  return B(`div`, {
     className: `Main_test`,
-    style: D([
+    style: C([
       c(),
       b()
     ])

--- a/spec/compilers/if
+++ b/spec/compilers/if
@@ -10,9 +10,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  (B(`asd`, `asd2`) ? true : false);
+export const B = () => {
+  (A(`asd`, `asd2`) ? true : false);
   return ``
 };

--- a/spec/compilers/if_let
+++ b/spec/compilers/if_let
@@ -14,20 +14,20 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  newVariant as F,
-  pattern as G,
-  variant as B,
-  match as E
+  patternVariable as E,
+  newVariant as C,
+  pattern as D,
+  variant as A,
+  match as B
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = () => {
-    return E(F(A)(``), [
+  F = A(1),
+  G = A(0),
+  H = () => {
+    return B(C(F)(``), [
       [
-        G(A, [H]),
+        D(F, [E]),
         (a) => {
           return a
         }

--- a/spec/compilers/if_let_await
+++ b/spec/compilers/if_let_await
@@ -18,21 +18,21 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  newVariant as F,
-  pattern as G,
-  variant as B,
-  match as E
+  patternVariable as E,
+  newVariant as C,
+  pattern as D,
+  variant as A,
+  match as B
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = () => {
+  F = A(1),
+  G = A(0),
+  H = () => {
     (async () => {
-      return E(await F(A)(``), [
+      return B(await C(F)(``), [
         [
-          G(A, [H]),
+          D(F, [E]),
           (a) => {
             return a
           }

--- a/spec/compilers/if_without_else_array
+++ b/spec/compilers/if_without_else_array
@@ -6,8 +6,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  return (B(`asd`, `asd2`) ? [`ARRAY`] : [])
+export const B = () => {
+  return (A(`asd`, `asd2`) ? [`ARRAY`] : [])
 };

--- a/spec/compilers/if_without_else_promise
+++ b/spec/compilers/if_without_else_promise
@@ -8,9 +8,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  (B(`asd`, `asd2`) ? null : null);
+export const B = () => {
+  (A(`asd`, `asd2`) ? null : null);
   return ``
 };

--- a/spec/compilers/if_without_else_string
+++ b/spec/compilers/if_without_else_string
@@ -6,8 +6,8 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  return (B(`asd`, `asd2`) ? `TRUE` : "")
+export const B = () => {
+  return (A(`asd`, `asd2`) ? `TRUE` : "")
 };

--- a/spec/compilers/locale_key
+++ b/spec/compilers/locale_key
@@ -9,19 +9,19 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  translations as C,
-  translate as B,
-  locale as D
+  translations as B,
+  translate as A,
+  locale as C
 } from "./runtime.js";
 
-export const A = () => {
-  return B(`test`)
+export const D = () => {
+  return A(`test`)
 };
 
-C.value = {
+B.value = {
   en: {
     'test': `Hello`
   }
 };
 
-D.value = `en`;
+C.value = `en`;

--- a/spec/compilers/map
+++ b/spec/compilers/map
@@ -9,9 +9,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   [
     [
       `a`,
@@ -22,5 +22,5 @@ export const A = () => {
       `World`
     ]
   ];
-  return B(`div`, {})
+  return A(`div`, {})
 };

--- a/spec/compilers/module_access_subscriptions
+++ b/spec/compilers/module_access_subscriptions
@@ -25,9 +25,9 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createProvider as B,
-  subscriptions as C,
-  useId as E
+  createProvider as A,
+  subscriptions as B,
+  useId as C
 } from "./runtime.js";
 
 export const
@@ -35,17 +35,17 @@ export const
     return b
   },
   c = new Map(),
-  A = B(c, async () => {
-    C(c);
+  D = A(c, async () => {
+    B(c);
     return await null
   }),
-  D = () => {
-    const d = E();
-    A(d, () => {
+  E = () => {
+    const d = C();
+    D(d, () => {
       return {
         test: ``
       }
     });
-    C(c);
+    B(c);
     return a(`a`)
   };

--- a/spec/compilers/next_call
+++ b/spec/compilers/next_call
@@ -18,16 +18,16 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  useSignal as B,
-  batch as C
+  useSignal as A,
+  batch as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const
-    a = B(`Joe`),
-    b = B(24),
+    a = A(`Joe`),
+    b = A(24),
     c = () => {
-      return C(() => {
+      return B(() => {
         a.value = `Hello`;
         b.value = 30
       })

--- a/spec/compilers/operation_chained
+++ b/spec/compilers/operation_chained
@@ -5,9 +5,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  B(`a`, `b`) && !B(true, false);
+export const B = () => {
+  A(`a`, `b`) && !A(true, false);
   return ``
 };

--- a/spec/compilers/operation_or
+++ b/spec/compilers/operation_or
@@ -15,15 +15,15 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  variant as B,
-  or as G
+  variant as A,
+  or as B
 } from "./runtime.js";
 
 export const
-  A = B(0),
-  C = B(1),
-  D = B(1),
-  E = B(1),
-  F = () => {
-    return G(A, D, new A(), `Hello`)
+  C = A(0),
+  D = A(1),
+  E = A(1),
+  F = A(1),
+  G = () => {
+    return B(C, E, new C(), `Hello`)
   };

--- a/spec/compilers/operation_simple
+++ b/spec/compilers/operation_simple
@@ -5,9 +5,9 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
-  B(`a`, `b`);
+export const B = () => {
+  A(`a`, `b`);
   return ``
 };

--- a/spec/compilers/pipe
+++ b/spec/compilers/pipe
@@ -7,10 +7,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
-  return B(`div`, {}, [
+export const B = () => {
+  return A(`div`, {}, [
     ((a) => {
       return a
     })(`3`),

--- a/spec/compilers/pipe_await
+++ b/spec/compilers/pipe_await
@@ -18,16 +18,16 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { compare as B } from "./runtime.js";
+import { compare as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   const
     a = async (b) => {
       return await b
     },
     c = async () => {
       const d = await a(await a(`Hello`));
-      return B(d, `asd`)
+      return A(d, `asd`)
     };
   c();
   return ``

--- a/spec/compilers/property
+++ b/spec/compilers/property
@@ -12,14 +12,14 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = ({
+  B = ({
     a = `Joe`
   }) => {
-    return B(`div`, {})
+    return A(`div`, {})
   },
   C = () => {
-    return B(A, {})
+    return A(B, {})
   };

--- a/spec/compilers/property_without_default
+++ b/spec/compilers/property_without_default
@@ -12,17 +12,16 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = ({
+  B = ({
     a
   }) => {
-    return B(`div`, {})
+    return A(`div`, {})
   },
   C = () => {
-    return B(A, {
+    return A(B, {
       a: `HELLO`
     })
   };
-

--- a/spec/compilers/provider_with_items
+++ b/spec/compilers/provider_with_items
@@ -33,10 +33,10 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createProvider as C,
-  createElement as F,
+  createProvider as B,
+  createElement as D,
   signal as A,
-  useId as E
+  useId as C
 } from "./runtime.js";
 
 export const
@@ -49,16 +49,16 @@ export const
     return c.value
   },
   e = new Map(),
-  B = C(e, async () => {
+  E = B(e, async () => {
     return await null
   }),
-  D = () => {
-    const f = E();
-    B(f, () => {
+  F = () => {
+    const f = C();
+    E(f, () => {
       return {
         a: true,
         b: false
       }
     });
-    return F(`div`, {})
+    return D(`div`, {})
   };

--- a/spec/compilers/record
+++ b/spec/compilers/record
@@ -14,12 +14,12 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as B } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   {
     a: `Hello`,
     b: 0
   };
-  return B(`div`, {})
+  return A(`div`, {})
 };

--- a/spec/compilers/record_update
+++ b/spec/compilers/record_update
@@ -12,17 +12,17 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  createElement as C,
-  useSignal as B
+  createElement as B,
+  useSignal as A
 } from "./runtime.js";
 
-export const A = () => {
-  const a = B({
+export const C = () => {
+  const a = A({
     name: `Doe`
   });
   {
     ...a.value,
     name: `John`
   };
-  return C(`div`, {})
+  return B(`div`, {})
 };

--- a/spec/compilers/signal
+++ b/spec/compilers/signal
@@ -23,4 +23,3 @@ export const
   B = () => {
     return a.value
   };
-

--- a/spec/compilers/state
+++ b/spec/compilers/state
@@ -11,15 +11,14 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { useSignal as B } from "./runtime.js";
+import { useSignal as A } from "./runtime.js";
 
-export const A = () => {
+export const B = () => {
   const
-    a = B(`Hello`),
-    b = B(`0`),
+    a = A(`Hello`),
+    b = A(`0`),
     c = () => {
       return a.value + b.value
     };
   return c()
 };
-

--- a/spec/compilers/state_setter
+++ b/spec/compilers/state_setter
@@ -7,10 +7,10 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { useSignal as B } from "./runtime.js";
+import { useSignal as A } from "./runtime.js";
 
-export const A = () => {
-  const a = B(``);
+export const B = () => {
+  const a = A(``);
   (b) => {
     a.value = b
   }(`Hello`);

--- a/spec/compilers/store_with_get
+++ b/spec/compilers/store_with_get
@@ -26,4 +26,3 @@ export const
     a.value;
     return b()
   };
-

--- a/spec/compilers/style_with_argument
+++ b/spec/compilers/style_with_argument
@@ -16,19 +16,19 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = (b) => {
     const _ = {
       [`--a-a`]: b
     };
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a(`red`)])
+    style: B([a(`red`)])
   })
 };

--- a/spec/compilers/style_with_default_argument
+++ b/spec/compilers/style_with_default_argument
@@ -16,19 +16,19 @@ component Main {
 
 ---=== /__mint__/index.js ===---
 import {
-  createElement as B,
-  style as C
+  createElement as A,
+  style as B
 } from "./runtime.js";
 
-export const A = () => {
+export const C = () => {
   const a = (b = `red`) => {
     const _ = {
       [`--a-a`]: b
     };
     return _
   };
-  return B(`div`, {
+  return A(`div`, {
     className: `Main_test`,
-    style: C([a()])
+    style: B([a()])
   })
 };

--- a/spec/compilers/type
+++ b/spec/compilers/type
@@ -20,20 +20,20 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  newVariant as I,
-  variant as B
+  newVariant as B,
+  variant as A
 } from "./runtime.js";
 
 export const
-  A = B(1),
-  C = B(0),
-  D = B(0),
-  E = B(1),
-  F = B(1),
-  G = B(2),
-  H = () => {
-    new C();
-    I(G)(``, ``);
-    I(E)(I(F)(``));
+  C = A(1),
+  D = A(0),
+  E = A(0),
+  F = A(1),
+  G = A(1),
+  H = A(2),
+  I = () => {
+    new D();
+    B(H)(``, ``);
+    B(F)(B(G)(``));
     return ``
   };

--- a/spec/compilers/type_with_variants
+++ b/spec/compilers/type_with_variants
@@ -13,32 +13,32 @@ component Main {
 }
 --------------------------------------------------------------------------------
 import {
-  patternVariable as H,
-  newVariant as F,
-  pattern as G,
-  variant as B,
-  match as E
+  patternVariable as E,
+  newVariant as C,
+  pattern as D,
+  variant as A,
+  match as B
 } from "./runtime.js";
 
 export const
-  A = B([
+  F = A([
     "name",
     "age"
   ]),
-  C = B(0),
-  D = () => {
-    return E(F(A)(`Joe`, 32), [
+  G = A(0),
+  H = () => {
+    return B(C(F)(`Joe`, 32), [
       [
-        G(A, [
-          H,
-          H
+        D(F, [
+          E,
+          E
         ]),
         (a, b) => {
           return a
         }
       ],
       [
-        G(C, []),
+        D(G, []),
         () => {
           return ``
         }

--- a/spec/compilers/variable_component_property
+++ b/spec/compilers/variable_component_property
@@ -12,14 +12,14 @@ component Main {
   }
 }
 --------------------------------------------------------------------------------
-import { createElement as C } from "./runtime.js";
+import { createElement as A } from "./runtime.js";
 
 export const
-  A = ({
+  B = ({
     a = `Hello`
   }) => {
     return a
   },
-  B = () => {
-    return C(A, {})
+  C = () => {
+    return A(B, {})
   };

--- a/spec/compilers_spec.cr
+++ b/spec/compilers_spec.cr
@@ -20,6 +20,7 @@ Dir
         config =
           Mint::Bundler::Config.new(
             json: Mint::MintJson.parse("{}", "mint.json"),
+            generate_source_maps: false,
             generate_manifest: false,
             include_program: false,
             live_reload: false,

--- a/spec/utils/markd_vdom_renderer_spec.cr
+++ b/spec/utils/markd_vdom_renderer_spec.cr
@@ -113,9 +113,10 @@ module Mint
 
             js_renderer =
               Renderer.new(
-                bundles: {} of Set(Ast::Node) | Bundle => Set(Ast::Node),
                 deferred_path: ->(_node : Set(Ast::Node) | Bundle) { "" },
+                bundles: {} of Set(Ast::Node) | Bundle => Set(Ast::Node),
                 asset_path: ->(_node : Ast::Node) { "" },
+                generate_source_maps: false,
                 class_pool: class_pool,
                 base: Bundle::Index,
                 pool: pool)

--- a/spec_cli/build_spec.cr
+++ b/spec_cli/build_spec.cr
@@ -20,15 +20,16 @@ context "build" do
       Builds the project for production.
 
       Flags:
-        --env, -e            # Loads the given .env file.
-        --generate-manifest  # If specified, the web manifest will be generated.
-        --help               # Displays help for the current command.
-        --no-optimize        # If specified, the resulting JavaScript code will not be optimized.
-        --runtime            # If specified, the supplied runtime will be used instead of the default.
-        --skip-icons         # If specified, the application icons will not be generated.
-        --timings            # If specified, timings will be printed.
-        --verbose            # If specified, all written files will be logged.
-        --watch, -w          # If specified, will build on every change.
+        --env, -e               # Loads the given .env file.
+        --generate-manifest     # If specified, the web manifest will be generated.
+        --generate-source-maps  # If specified, source maps will be generated.
+        --help                  # Displays help for the current command.
+        --no-optimize           # If specified, the resulting JavaScript code will not be optimized.
+        --runtime               # If specified, the supplied runtime will be used instead of the default.
+        --skip-icons            # If specified, the application icons will not be generated.
+        --timings               # If specified, timings will be printed.
+        --verbose               # If specified, all written files will be logged.
+        --watch, -w             # If specified, will build on every change.
       TEXT
   end
 

--- a/spec_cli/start_spec.cr
+++ b/spec_cli/start_spec.cr
@@ -22,6 +22,7 @@ context "test" do
       Flags:
         --env, -e                                            # Loads the given .env file.
         --format                                             # Formats the source files when they change.
+        --generate-source-maps                               # If specified, source maps will be generated.
         --help                                               # Displays help for the current command.
         --host, -h (default: ENV["HOST"]? || "0.0.0.0")      # The host to serve the application on.
         --no-reload                                          # Do not reload the browser when something changes.

--- a/spec_cli/test_spec.cr
+++ b/spec_cli/test_spec.cr
@@ -24,6 +24,7 @@ context "test" do
         --browser-host, -x (default: ENV["BROWSER_HOST"]? || "127.0.0.1")    # Target host, useful when hosted on another machine.
         --browser-port, -c (default: (ENV["BROWSER_PORT"]? || "3001").to_i)  # Target port, useful when hosted on another machine.
         --env, -e                                                            # Loads the given .env file.
+        --generate-source-maps                                               # If specified, source maps will be generated.
         --help                                                               # Displays help for the current command.
         --host, -h (default: ENV["HOST"]? || "127.0.0.1")                    # Host to serve the tests on.
         --manual, -m                                                         # Start the test server for manual testing.

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -20,6 +20,10 @@ module Mint
         description: "If specified, the web manifest will be generated.",
         default: false
 
+      define_flag generate_source_maps : Bool,
+        description: "If specified, source maps will be generated.",
+        default: false
+
       define_flag verbose : Bool,
         description: "If specified, all written files will be logged.",
         default: false
@@ -60,6 +64,7 @@ module Mint
                     Bundler.new(
                       artifacts: result.artifacts,
                       config: Bundler::Config.new(
+                        generate_source_maps: flags.generate_source_maps,
                         generate_manifest: flags.generate_manifest,
                         skip_icons: flags.skip_icons,
                         optimize: !flags.no_optimize,

--- a/src/commands/start.cr
+++ b/src/commands/start.cr
@@ -12,6 +12,10 @@ module Mint
         description: "Do not reload the browser when something changes.",
         default: false
 
+      define_flag generate_source_maps : Bool,
+        description: "If specified, source maps will be generated.",
+        default: false
+
       define_flag format : Bool,
         description: "Formats the source files when they change.",
         default: false
@@ -43,6 +47,7 @@ module Mint
             Bundler.new(
               artifacts: type_checker.artifacts,
               config: Bundler::Config.new(
+                generate_source_maps: flags.generate_source_maps,
                 live_reload: !flags.no_reload,
                 runtime_path: flags.runtime,
                 generate_manifest: false,

--- a/src/commands/test.cr
+++ b/src/commands/test.cr
@@ -23,6 +23,10 @@ module Mint
         default: (ENV["BROWSER_PORT"]? || "3001").to_i,
         short: "c"
 
+      define_flag generate_source_maps : Bool,
+        description: "If specified, source maps will be generated.",
+        default: false
+
       define_flag reporter : String,
         description: "Which reporter to use (dot, documentation),",
         default: "dot",

--- a/src/compilers/component.cr
+++ b/src/compilers/component.cr
@@ -149,8 +149,8 @@ module Mint
         effect =
           if mount || unmount
             body = [] of Compiled
-            body << ["("] + compile(mount, skip_const: true) + [")()"] if mount
-            body << js.return(compile(unmount, skip_const: true)) if unmount
+            body << ["("] + compile_function(mount, skip_const: true) + [")()"] if mount
+            body << js.return(compile_function(unmount, skip_const: true)) if unmount
 
             [
               js.call(Builtin::UseEffect, [
@@ -166,7 +166,7 @@ module Mint
           if did_update
             [
               js.call(Builtin::UseDidUpdate, [
-                compile(did_update, skip_const: true),
+                compile_function(did_update, skip_const: true),
               ]),
             ]
           else
@@ -178,7 +178,7 @@ module Mint
             refs + states + gets + functions + styles + constants + id + [
               {node,
                node,
-               compile(
+               compile_function(
                  render.not_nil!,
                  skip_const: true,
                  contents: js.statements(
@@ -198,7 +198,7 @@ module Mint
             [{
               node,
               node,
-              compile(
+              compile_function(
                 render.not_nil!,
                 args: arguments,
                 skip_const: true,

--- a/src/compilers/function.cr
+++ b/src/compilers/function.cr
@@ -2,17 +2,17 @@ module Mint
   class Compiler
     def resolve(node : Ast::Function)
       resolve node do
-        {node, node, compile(node, contents: nil, args: nil, skip_const: true)}
+        {node, node, compile_function(node, contents: nil, args: nil, skip_const: true)}
       end
     end
 
-    def compile(node : Ast::Function)
+    def compile_function(node : Ast::Function)
       compile node do
         compile(node, contents: nil, args: nil)
       end
     end
 
-    def compile(
+    def compile_function(
       node : Ast::Function, *,
       contents : Compiled | Nil = nil,
       args : Array(Compiled) | Nil = nil,
@@ -28,7 +28,11 @@ module Mint
       items << compile(node.body, for_function: true)
 
       body =
-        js.arrow_function(arguments) { js.statements(items) }
+        [
+          SourceMapped.new(
+            value: js.arrow_function(arguments) { js.statements(items) },
+            node: node),
+        ] of Item
 
       if skip_const
         body

--- a/src/compilers/provider.cr
+++ b/src/compilers/provider.cr
@@ -26,7 +26,7 @@ module Mint
             node,
             js.call(Builtin::CreateProvider, [
               [node.subscription] of Item,
-              compile(update, skip_const: true),
+              compile_function(update, skip_const: true),
             ]),
           }
 

--- a/src/compilers/string_literal.cr
+++ b/src/compilers/string_literal.cr
@@ -1,26 +1,28 @@
 module Mint
   class Compiler
     def compile(node : Ast::StringLiteral, quote : Bool = false) : Compiled
-      value =
-        node.value.flat_map do |item|
-          case item
-          in Ast::Node
-            ["${"] + compile(item) + ["}"]
-          in String
-            [
-              item
-                .gsub('`', "\\`")
-                .gsub("${", "\\${")
-                .gsub("\\\"", "\"")
-                .gsub("\\\#{", "\#{"),
-            ]
+      compile node do
+        value =
+          node.value.flat_map do |item|
+            case item
+            in Ast::Node
+              ["${"] + compile(item) + ["}"]
+            in String
+              [
+                item
+                  .gsub('`', "\\`")
+                  .gsub("${", "\\${")
+                  .gsub("\\\"", "\"")
+                  .gsub("\\\#{", "\#{"),
+              ]
+            end
           end
-        end
 
-      if quote
-        [%(`")] + value + [%("`)]
-      else
-        ["`"] + value + ["`"]
+        if quote
+          [%(`")] + value + [%("`)]
+        else
+          ["`"] + value + ["`"]
+        end
       end
     end
   end

--- a/src/ls/sandbox.cr
+++ b/src/ls/sandbox.cr
@@ -56,6 +56,7 @@ module Mint
             Bundler.new(
               artifacts: result.artifacts,
               config: Bundler::Config.new(
+                generate_source_maps: true,
                 generate_manifest: false,
                 include_program: true,
                 hash_assets: false,

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -34,6 +34,7 @@ module Mint
               Bundler.new(
                 artifacts: result.artifacts,
                 config: Bundler::Config.new(
+                  generate_source_maps: flags.generate_source_maps,
                   runtime_path: flags.runtime,
                   generate_manifest: false,
                   include_program: false,

--- a/src/utils/source_map_generator.cr
+++ b/src/utils/source_map_generator.cr
@@ -1,0 +1,110 @@
+module Mint
+  # This class is responsible for generating a source map.
+  class SourceMapGenerator
+    alias Mapping = Tuple(Ast::Node | Nil, Tuple(Int32, Int32), String | Nil)
+
+    # The line mappings.
+    getter mappings = {} of Int32 => Array(Mapping)
+
+    # The actual content of the sources.
+    getter sources_content = [] of String
+
+    # The source names for the mappings.
+    getter source_names = [] of String
+
+    # The filenames of the sources.
+    getter sources = [] of String
+
+    # The generate JavaScript file.
+    getter generated : String
+
+    def initialize(unsorted : Deque(Mapping), @generated)
+      # We sort the mappings into lines.
+      unsorted.each do |item|
+        mappings[item[1][0]] ||= [] of Mapping
+        mappings[item[1][0]] << item
+      end
+    end
+
+    def get_source_index(file)
+      sources.index(file.path) || begin
+        sources_content << file.contents
+        sources << file.path
+        sources.size - 1
+      end
+    end
+
+    def get_source_name_index(value)
+      source_names.index(value) || begin
+        source_names << value
+        source_names.size - 1
+      end
+    end
+
+    def generate : String
+      last_name_index = 0
+      last_column = 0
+      last_index = 0
+      last_line = 0
+
+      generated_mappings =
+        (0..generated.lines.size).map do |line_index|
+          if items = mappings[line_index]?
+            items.reduce({[] of String, 0}) do |(memo, last), item|
+              column =
+                item[1][1]
+
+              segment =
+                VLQ.encode(column - last)
+
+              if node = item[0]
+                # TODO: After the refactor of location remove
+                #       this temporary variable.
+                location =
+                  node.location
+
+                source_line =
+                  location.start[0] - 1
+
+                source_column =
+                  location.start[1]
+
+                source_index =
+                  get_source_index(node.file)
+
+                # The order is significant.
+                segment += VLQ.encode(source_index - last_index)
+                segment += VLQ.encode(source_line - last_line)
+                segment += VLQ.encode(source_column - last_column)
+
+                if name = item[2]
+                  source_name_index =
+                    get_source_name_index(name)
+
+                  segment += VLQ.encode(source_name_index - last_name_index)
+                  last_name_index = source_name_index
+                end
+
+                last_column = source_column
+                last_index = source_index
+                last_line = source_line
+              end
+
+              memo << segment
+              {memo, column}
+            end[0].join(",")
+          else
+            ""
+          end
+        end.join(";")
+
+      {
+        mappings:       generated_mappings,
+        sourcesContent: sources_content,
+        names:          source_names,
+        sources:        sources,
+        version:        3,
+      }.to_json
+    end
+  end
+end

--- a/src/utils/source_map_generator.cr
+++ b/src/utils/source_map_generator.cr
@@ -21,8 +21,7 @@ module Mint
     def initialize(unsorted : Deque(Mapping), @generated)
       # We sort the mappings into lines.
       unsorted.each do |item|
-        mappings[item[1][0]] ||= [] of Mapping
-        mappings[item[1][0]] << item
+        (mappings[item[1][0]] ||= [] of Mapping) << item
       end
     end
 
@@ -49,53 +48,51 @@ module Mint
 
       generated_mappings =
         (0..generated.lines.size).map do |line_index|
-          if items = mappings[line_index]?
-            items.reduce({[] of String, 0}) do |(memo, last), item|
-              column =
-                item[1][1]
+          next "" unless items = mappings[line_index]?
 
-              segment =
-                VLQ.encode(column - last)
+          items.reduce({[] of String, 0}) do |(memo, last), item|
+            column =
+              item[1][1]
 
-              if node = item[0]
-                # TODO: After the refactor of location remove
-                #       this temporary variable.
-                location =
-                  node.location
+            segment =
+              VLQ.encode(column - last)
 
-                source_line =
-                  location.start[0] - 1
+            if node = item[0]
+              # TODO: After the refactor of location remove
+              #       this temporary variable.
+              location =
+                node.location
 
-                source_column =
-                  location.start[1]
+              source_line =
+                location.start[0] - 1
 
-                source_index =
-                  get_source_index(node.file)
+              source_column =
+                location.start[1]
 
-                # The order is significant.
-                segment += VLQ.encode(source_index - last_index)
-                segment += VLQ.encode(source_line - last_line)
-                segment += VLQ.encode(source_column - last_column)
+              source_index =
+                get_source_index(node.file)
 
-                if name = item[2]
-                  source_name_index =
-                    get_source_name_index(name)
+              # The order is significant.
+              segment += VLQ.encode(source_index - last_index)
+              segment += VLQ.encode(source_line - last_line)
+              segment += VLQ.encode(source_column - last_column)
 
-                  segment += VLQ.encode(source_name_index - last_name_index)
-                  last_name_index = source_name_index
-                end
+              if name = item[2]
+                source_name_index =
+                  get_source_name_index(name)
 
-                last_column = source_column
-                last_index = source_index
-                last_line = source_line
+                segment += VLQ.encode(source_name_index - last_name_index)
+                last_name_index = source_name_index
               end
 
-              memo << segment
-              {memo, column}
-            end[0].join(",")
-          else
-            ""
-          end
+              last_column = source_column
+              last_index = source_index
+              last_line = source_line
+            end
+
+            memo << segment
+            {memo, column}
+          end.first.join(",")
         end.join(";")
 
       {

--- a/src/utils/vlq.cr
+++ b/src/utils/vlq.cr
@@ -30,9 +30,6 @@ module Mint
     BASE64_DIGITS =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".chars
 
-    BASE64_VALUES =
-      (0..64).reduce({} of Char => Int32) { |hash, i| hash[BASE64_DIGITS[i]] = i }
-
     # Returns the base 64 VLQ encoded value.
     def self.encode(int)
       vlq = to_vlq_signed(int)

--- a/src/utils/vlq.cr
+++ b/src/utils/vlq.cr
@@ -1,0 +1,116 @@
+module Mint
+  # Support for encoding/decoding the variable length quantity format.
+  #
+  # This implementation is heavily based on https://github.com/mozilla/source-map
+  # Copyright 2009-2011, Mozilla Foundation and contributors, BSD
+  #
+  module VLQ
+    # A single base 64 digit can contain 6 bits of data. For the base 64
+    # variable length quantities we use in the source map spec, the first bit
+    # is the sign, the next four bits are the actual value, and the 6th bit is
+    # the continuation bit. The continuation bit tells us whether there are
+    # more digits in this value following this digit.
+    #
+    #   Continuation
+    #   |    Sign
+    #   |    |
+    #   V    V
+    #   101011
+    VLQ_BASE_SHIFT = 5
+
+    # binary: 100000
+    VLQ_BASE = 1 << VLQ_BASE_SHIFT
+
+    # binary: 011111
+    VLQ_BASE_MASK = VLQ_BASE - 1
+
+    # binary: 100000
+    VLQ_CONTINUATION_BIT = VLQ_BASE
+
+    BASE64_DIGITS =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".chars
+
+    BASE64_VALUES =
+      (0..64).reduce({} of Char => Int32) { |hash, i| hash[BASE64_DIGITS[i]] = i }
+
+    # Returns the base 64 VLQ encoded value.
+    def self.encode(int)
+      vlq = to_vlq_signed(int)
+      encoded = ""
+      cond = true
+
+      while cond
+        digit = vlq & VLQ_BASE_MASK
+        vlq >>= VLQ_BASE_SHIFT
+        digit |= VLQ_CONTINUATION_BIT if vlq > 0
+        encoded += base64_encode(digit)
+        cond = vlq > 0
+      end
+
+      encoded
+    end
+
+    # Decodes the next base 64 VLQ value from the given string and returns the
+    # value and the rest of the string.
+    def self.decode(str)
+      chars = str.chars
+      continue = true
+      shift = 0
+      vlq = 0
+
+      while continue
+        char = chars.shift or raise "Expected more digits in base 64 VLQ value."
+        digit = base64_decode(char)
+        continue = false if (digit & VLQ_CONTINUATION_BIT) == 0
+        digit &= VLQ_BASE_MASK
+        vlq += digit << shift
+        shift += VLQ_BASE_SHIFT
+      end
+
+      [from_vlq_signed(vlq), String.new(chars)]
+    end
+
+    # Decode an array of variable length quantities from the given string
+    def self.decode_array(str)
+      output = [] of Tuple(Int32, String)
+      while !str.empty?
+        int, str = decode(str)
+        output << int
+      end
+      output
+    end
+
+    private def self.base64_encode(int)
+      BASE64_DIGITS[int]? || raise ArgumentError.new "#{int} is not a valid base64 digit"
+    end
+
+    private def self.base64_decode(char)
+      BASE64_VALUES[char]? || raise ArgumentError.new "#{char} is not a valid base64 digit"
+    end
+
+    # Converts from a two's-complement integer to an integer where the
+    # sign bit is placed in the least significant bit. For example, as decimals:
+    #  1 becomes 2 (10 binary), -1 becomes 3 (11 binary)
+    #  2 becomes 4 (100 binary), -2 becomes 5 (101 binary)
+    private def self.to_vlq_signed(int)
+      if int < 0
+        ((-int) << 1) + 1
+      else
+        int << 1
+      end
+    end
+
+    # Converts to a two's-complement value from a value where the sign bit is
+    # placed in the least significant bit. For example, as decimals:
+    #
+    #  2 (10 binary) becomes 1, 3 (11 binary) becomes -1
+    #  4 (100 binary) becomes 2, 5 (101 binary) becomes -2
+    private def self.from_vlq_signed(vlq)
+      if vlq & 1 == 1
+        -(vlq >> 1)
+      else
+        vlq >> 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR builds on and supersedes #356 (Mainly the VLQ implementation is brought over).
- SPEC: https://tc39.es/source-map/
- Testing: https://evanw.github.io/source-map-visualization/ https://sokra.github.io/source-map-visualization/
- I've tested this with `mint-website` and `mint-ui-website` and it seems to be working.
- It's slow at this time (~1s from a ~2.2s build).

--------

Developer Notes:
- Because of the new compiler architecture it was relatively easy to implement.
- Changes in specs are because the order of resolving entities changed.

TODO:
- [x] Mappings and sources
- [x] Wiring to commands (`--generate-source-maps` flag)
- [x] Symbol names for the debugger 
- [x] Cleanup pass

The reason for the slowness is `Ast::Node#location` calculation from offset to line/column, which needs to be calculated when parsing so it will be in a separate PR.