### PR TITLE
Allow referencing assets from the root of the project.

### DIFF
--- a/spec/compilers/dbg
+++ b/spec/compilers/dbg
@@ -9,7 +9,7 @@ import { inspect as A } from "./runtime.js";
 export const B = () => {
   return (() => {
     const a = `Hello World!`;
-    console.log(`./spec/compilers/dbg:3:4`);
+    console.log(`compilers/dbg:3:4`);
     console.log(A(a));
     return a
   })()

--- a/spec/compilers/dbg_as_function
+++ b/spec/compilers/dbg_as_function
@@ -8,7 +8,7 @@ import { inspect as A } from "./runtime.js";
 
 export const B = () => {
   return (a) => {
-    console.log(`./spec/compilers/dbg_as_function:3:22`);
+    console.log(`compilers/dbg_as_function:3:22`);
     console.log(A(a));
     return a
   }(`Hello World!`)

--- a/spec/compilers/directives/asset-absolute
+++ b/spec/compilers/directives/asset-absolute
@@ -1,0 +1,15 @@
+component Main {
+  fun render : String {
+    @asset(/fixtures/icon.svg)
+  }
+}
+--------------------------------------------------------------------------------
+---=== /__mint__/index.js ===---
+export const A = () => {
+  return `/__mint__/icon_c97b81630bc53286dadc8996727d348e.svg`
+};
+
+---=== /__mint__/icon_c97b81630bc53286dadc8996727d348e.svg ===---
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z"/>
+</svg>

--- a/spec/compilers/directives/highlight-file-absolute
+++ b/spec/compilers/directives/highlight-file-absolute
@@ -1,0 +1,67 @@
+component Main {
+  fun render : Html {
+    @highlight-file(/fixtures/Test.mint)
+  }
+}
+--------------------------------------------------------------------------------
+import {
+  createElement as A,
+  fragment as B
+} from "./runtime.js";
+
+export const C = () => {
+  return A(B, {}, [
+    A("span", {
+      className: "line"
+    }, [
+      A("span", {
+        className: "keyword"
+      }, [`component`]),
+      ` `,
+      A("span", {
+        className: "type"
+      }, [`Main`]),
+      ` {
+`
+    ]),
+    A("span", {
+      className: "line"
+    }, [
+      `  `,
+      A("span", {
+        className: "keyword"
+      }, [`fun`]),
+      ` render : `,
+      A("span", {
+        className: "type"
+      }, [`Html`]),
+      ` {
+`
+    ]),
+    A("span", {
+      className: "line"
+    }, [
+      `    <`,
+      A("span", {
+        className: "namespace"
+      }, [`div`]),
+      `></`,
+      A("span", {
+        className: "namespace"
+      }, [`div`]),
+      `>
+`
+    ]),
+    A("span", {
+      className: "line"
+    }, [`  }
+`]),
+    A("span", {
+      className: "line"
+    }, [`}
+`]),
+    A("span", {
+      className: "line"
+    }, [``])
+  ])
+};

--- a/spec/compilers/directives/inline-absolute
+++ b/spec/compilers/directives/inline-absolute
@@ -1,14 +1,10 @@
 component Main {
   fun render : String {
-    dbg! "Hello World!"
+    @inline(/fixtures/data.txt)
   }
 }
 --------------------------------------------------------------------------------
 export const A = () => {
-  return (() => {
-    const a = `Hello World!`;
-    console.log(`compilers/dbg_bang:3:4`);
-    console.log(a);
-    return a
-  })()
+  return `Hello World!
+`
 };

--- a/spec/compilers/directives/svg-absolute
+++ b/spec/compilers/directives/svg-absolute
@@ -1,0 +1,20 @@
+component Main {
+  fun render : Html {
+    @svg(/fixtures/icon.svg)
+  }
+}
+--------------------------------------------------------------------------------
+import { createElement as A } from "./runtime.js";
+
+export const
+  a = A(`svg`, {
+    dangerouslySetInnerHTML: {
+      __html: `<path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z"/>`
+    },
+    viewBox: `0 0 24 24`,
+    height: `24`,
+    width: `24`
+  }),
+  B = () => {
+    return a
+  };

--- a/spec/compilers_spec.cr
+++ b/spec/compilers_spec.cr
@@ -11,7 +11,7 @@ Dir
         sample, expected = File.read(file).split("-" * 80)
 
         # Parse the sample
-        ast = Mint::Parser.parse(sample, file)
+        ast = Mint::Parser.parse(sample, File.dirname(__FILE__) + file.lchop("./spec"))
         ast.class.should eq(Mint::Ast)
 
         artifacts =

--- a/spec/mint.json
+++ b/spec/mint.json
@@ -1,0 +1,3 @@
+{
+  "name": "ROOT FOR TESTS"
+}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,5 @@
 require "spec"
 
-ENV["SPEC"] = "TRUE"
 MINT_ENV["TEST"] = "TRUE"
 
 require "./spec_helpers"

--- a/src/compilers/dbg.cr
+++ b/src/compilers/dbg.cr
@@ -3,7 +3,7 @@ module Mint
     def compile(node : Ast::Dbg) : Compiled
       compile node do
         location =
-          js.string("#{node.file.path}:#{node.from.line}:#{node.from.column}")
+          js.string("#{node.file.relative_path}:#{node.from.line}:#{node.from.column}")
 
         var =
           [Variable.new] of Item

--- a/src/ext/file.cr
+++ b/src/ext/file.cr
@@ -4,6 +4,11 @@ class File
     File.write path, contents
   end
 
+  def self.relative_path_from_ancestor(path : String, name : String) : String
+    return path unless directory = File.find_in_ancestors(path, "mint.json")
+    Path[path].relative_to(File.dirname(directory)).to_s
+  end
+
   def self.find_in_ancestors(base : String, name : String) : String?
     root = File.dirname(base)
 

--- a/src/ext/file.cr
+++ b/src/ext/file.cr
@@ -5,7 +5,7 @@ class File
   end
 
   def self.relative_path_from_ancestor(path : String, name : String) : String
-    return path unless directory = File.find_in_ancestors(path, "mint.json")
+    return path unless directory = File.find_in_ancestors(path, name)
     Path[path].relative_to(File.dirname(directory)).to_s
   end
 

--- a/src/parser/file.cr
+++ b/src/parser/file.cr
@@ -3,6 +3,11 @@ module Mint
     class File
       getter contents, path
 
+      # The relative path of the file to the project root (closest `mint.json`).
+      getter relative_path : String do
+        ::File.relative_path_from_ancestor(path, "mint.json")
+      end
+
       def initialize(@contents : String, @path : String)
       end
 

--- a/src/type_checkers/directives/asset.cr
+++ b/src/type_checkers/directives/asset.cr
@@ -2,14 +2,7 @@ module Mint
   class TypeChecker
     def check(node : Ast::Directives::Asset) : Checkable
       error! :asset_directive_expected_file do
-        block "The path specified for an asset directive does not exist: "
-
-        if ENV["SPEC"]?
-          snippet node.path.to_s
-        else
-          snippet node.real_path.to_s
-        end
-
+        snippet "The path specified for an asset directive does not exist:", node.relative_path
         snippet "The asset directive in question is here:", node
       end unless node.exists?
 

--- a/src/type_checkers/directives/highlight_file.cr
+++ b/src/type_checkers/directives/highlight_file.cr
@@ -2,14 +2,7 @@ module Mint
   class TypeChecker
     def check(node : Ast::Directives::HighlightFile) : Checkable
       error! :highlight_file_directive_expected_file do
-        block "The path specified for an highlight file directive does not exist: "
-
-        if ENV["SPEC"]?
-          snippet node.path.to_s
-        else
-          snippet node.real_path.to_s
-        end
-
+        snippet "The path specified for an highlight file directive does not exist:", node.relative_path
         snippet "The highlight file directive in question is here:", node
       end unless node.exists?
 

--- a/src/type_checkers/directives/inline.cr
+++ b/src/type_checkers/directives/inline.cr
@@ -2,14 +2,7 @@ module Mint
   class TypeChecker
     def check(node : Ast::Directives::Inline) : Checkable
       error! :inline_directive_expected_file do
-        block "The path specified for an inline directive does not exist:"
-
-        if ENV["SPEC"]?
-          snippet node.path.to_s
-        else
-          snippet node.real_path.to_s
-        end
-
+        snippet "The path specified for an inline directive does not exist:", node.relative_path
         snippet "The inline directive in question is here:", node
       end unless node.exists?
 

--- a/src/type_checkers/directives/svg.cr
+++ b/src/type_checkers/directives/svg.cr
@@ -2,14 +2,7 @@ module Mint
   class TypeChecker
     def check(node : Ast::Directives::Svg) : Checkable
       error! :svg_directive_expected_file do
-        path =
-          if ENV["SPEC"]?
-            node.path.to_s
-          else
-            node.real_path.to_s
-          end
-
-        snippet "The specified file for an svg directive does not exist:", path
+        snippet "The specified file for an svg directive does not exist:", node.relative_path
         snippet "The svg directive in question is here:", node
       end unless node.exists?
 


### PR DESCRIPTION
Currently, assets an only be referenced relative to the file which references them. As per the issue, if there is a file deep in the source directory, referencing a file in the project root requires a lot of `../`.

The PR makes it so that the root path `/` is the project root directory which have the `mint.json` file.

Resolves #459 