### PR TITLE
Use relative path for error messages.

### DIFF
--- a/spec/errors/access_expected_field
+++ b/spec/errors/access_expected_field
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the name of the accessed entity but I found "a space" instead:
 
-   ┌ ./spec/errors/access_expected_field:3:7
-   ├────────────────────────────────────────
+   ┌ errors/access_expected_field:3:7
+   ├─────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "".

--- a/spec/errors/access_field_not_found
+++ b/spec/errors/access_field_not_found
@@ -19,8 +19,8 @@ The accessed field "blaha" does not exists on the entity:
 
 The access in question is here:
 
-    ┌ ./spec/errors/access_field_not_found:10:5
-    ├──────────────────────────────────────────
+    ┌ errors/access_field_not_found:10:5
+    ├───────────────────────────────────
    6│   fun render : Bool {
    7│     let blah =
    8│       { blah: "Hello" }

--- a/spec/errors/access_not_record
+++ b/spec/errors/access_not_record
@@ -14,8 +14,8 @@ You are trying to access a field on an entity which is not a record:
 
 The access in question is here:
 
-   ┌ ./spec/errors/access_not_record:5:5
-   ├────────────────────────────────────
+   ┌ errors/access_not_record:5:5
+   ├─────────────────────────────
   1│ component Main {
   2│   fun render : Bool {
   3│     let blah = ""

--- a/spec/errors/argument_expected_colon
+++ b/spec/errors/argument_expected_colon
@@ -9,8 +9,8 @@ A colon must separate the arguments name from its type, here is an example:
 
 I was expecting the colon of the argument but I found "a space" instead:
 
-   ┌ ./spec/errors/argument_expected_colon:2:15
-   ├───────────────────────────────────────────
+   ┌ errors/argument_expected_colon:2:15
+   ├────────────────────────────────────
   1│ component Main {
   2│   fun render (a
    │                ⌃⌃⌃⌃

--- a/spec/errors/argument_expected_default_value
+++ b/spec/errors/argument_expected_default_value
@@ -10,8 +10,8 @@ an example:
 
 I was expecting the default value of the argument but I found "a space" instead:
 
-   ┌ ./spec/errors/argument_expected_default_value:2:26
-   ├───────────────────────────────────────────────────
+   ┌ errors/argument_expected_default_value:2:26
+   ├────────────────────────────────────────────
   1│ component Main {
   2│   fun render (a : String =
    │                           ⌃⌃⌃⌃

--- a/spec/errors/argument_expected_type
+++ b/spec/errors/argument_expected_type
@@ -9,8 +9,8 @@ An argument must have its type defined, here is an example:
 
 I was expecting the type of the argument but I found "a space" instead:
 
-   ┌ ./spec/errors/argument_expected_type:2:17
-   ├──────────────────────────────────────────
+   ┌ errors/argument_expected_type:2:17
+   ├───────────────────────────────────
   1│ component Main {
   2│   fun render (a :
    │                  ⌃⌃⌃⌃

--- a/spec/errors/array_destructuring_expected_closing_bracket
+++ b/spec/errors/array_destructuring_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of an array destructuring but I found "a
 space" instead:
 
-   ┌ ./spec/errors/array_destructuring_expected_closing_bracket:3:10
-   ├────────────────────────────────────────────────────────────────
+   ┌ errors/array_destructuring_expected_closing_bracket:3:10
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     let [x

--- a/spec/errors/array_expected_closing_bracket
+++ b/spec/errors/array_expected_closing_bracket
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the closing bracket of an array but I found "a space" instead:
 
-   ┌ ./spec/errors/array_expected_closing_bracket:3:8
-   ├─────────────────────────────────────────────────
+   ┌ errors/array_expected_closing_bracket:3:8
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(String) {
   3│     ["A"

--- a/spec/errors/array_expected_type_or_variable
+++ b/spec/errors/array_expected_type_or_variable
@@ -11,8 +11,8 @@ example:
 
 I was expecting the type but I found "a space" instead:
 
-   ┌ ./spec/errors/array_expected_type_or_variable:3:9
-   ├──────────────────────────────────────────────────
+   ┌ errors/array_expected_type_or_variable:3:9
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(String) {
   3│     [] of

--- a/spec/errors/array_not_matches
+++ b/spec/errors/array_not_matches
@@ -13,7 +13,8 @@ component Main {
     <div/>
   }
 }
---------------------------------------------------------------------------------░ ERROR (ARRAY_NOT_MATCHES) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+--------------------------------------------------------------------------------
+░ ERROR (ARRAY_NOT_MATCHES) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 The 2nd item of an array does not match the type of the 1st item.
 
@@ -27,8 +28,8 @@ Instead it is:
 
 The item in question is here:
 
-    ┌ ./spec/errors/array_not_matches:5:7
-    ├────────────────────────────────────
+    ┌ errors/array_not_matches:5:7
+    ├─────────────────────────────
    1│ component Main {
    2│   fun test : Array(String) {
    3│     [

--- a/spec/errors/array_not_matches_defined_type
+++ b/spec/errors/array_not_matches_defined_type
@@ -27,8 +27,8 @@ Instead it is:
 
 The array in question is here:
 
-    ┌ ./spec/errors/array_not_matches_defined_type:6:10
-    ├──────────────────────────────────────────────────
+    ┌ errors/array_not_matches_defined_type:6:10
+    ├───────────────────────────────────────────
    2│   fun test : Array(String) {
    3│     [
    4│       "Hello",

--- a/spec/errors/asset_directive_expected_closing_parenthesis
+++ b/spec/errors/asset_directive_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of an asset directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/asset_directive_expected_closing_parenthesis:3:15
-   ├────────────────────────────────────────────────────────────────
+   ┌ errors/asset_directive_expected_closing_parenthesis:3:15
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @asset(path

--- a/spec/errors/asset_directive_expected_file
+++ b/spec/errors/asset_directive_expected_file
@@ -12,12 +12,11 @@ The path specified for an asset directive does not exist:
 
 The asset directive in question is here:
 
-   ┌ ./spec/errors/asset_directive_expected_file:3:5
-   ├────────────────────────────────────────────────
+   ┌ errors/asset_directive_expected_file:3:5
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @asset(path)
    │     ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
   4│   }
   5│ }
-

--- a/spec/errors/asset_directive_expected_opening_parenthesis
+++ b/spec/errors/asset_directive_expected_opening_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening parenthesis of an asset directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/asset_directive_expected_opening_parenthesis:3:10
-   ├────────────────────────────────────────────────────────────────
+   ┌ errors/asset_directive_expected_opening_parenthesis:3:10
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @asset

--- a/spec/errors/asset_directive_expected_path
+++ b/spec/errors/asset_directive_expected_path
@@ -7,8 +7,8 @@ component Main {
 I was expecting the path (to the asset) of an asset directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/asset_directive_expected_path:3:11
-   ├─────────────────────────────────────────────────
+   ┌ errors/asset_directive_expected_path:3:11
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @asset(

--- a/spec/errors/block_no_expressions
+++ b/spec/errors/block_no_expressions
@@ -12,8 +12,8 @@ component Main {
 
 This block doesn't have any statements. It should have at least one.
 
-   ┌ ./spec/errors/block_no_expressions:2:26
-   ├────────────────────────────────────────
+   ┌ errors/block_no_expressions:2:26
+   ├─────────────────────────────────
   1│ component Main {
    │   ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   2│   fun componentDidUpdate {

--- a/spec/errors/bracket_access_expected_closing_bracket
+++ b/spec/errors/bracket_access_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of a bracket access but I found "a space"
 instead:
 
-   ┌ ./spec/errors/bracket_access_expected_closing_bracket:3:11
-   ├───────────────────────────────────────────────────────────
+   ┌ errors/bracket_access_expected_closing_bracket:3:11
+   ├────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     array[0

--- a/spec/errors/bracket_access_expected_index
+++ b/spec/errors/bracket_access_expected_index
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the index of a bracket access but I found "a space" instead:
 
-   ┌ ./spec/errors/bracket_access_expected_index:3:10
-   ├─────────────────────────────────────────────────
+   ┌ errors/bracket_access_expected_index:3:10
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     array[

--- a/spec/errors/bracket_access_index_not_number
+++ b/spec/errors/bracket_access_index_not_number
@@ -28,8 +28,8 @@ Instead it is:
 
 The index in question is here:
 
-    ┌ ./spec/errors/bracket_access_index_not_number:7:7
-    ├──────────────────────────────────────────────────
+    ┌ errors/bracket_access_index_not_number:7:7
+    ├───────────────────────────────────────────
    3│     [
    4│       "Hello",
    5│       "Blah",

--- a/spec/errors/bracket_access_invalid_tuple
+++ b/spec/errors/bracket_access_invalid_tuple
@@ -21,8 +21,8 @@ of the tuple is:
 
 The tuple in question is here:
 
-   ┌ ./spec/errors/bracket_access_invalid_tuple:3:5
-   ├───────────────────────────────────────────────
+   ┌ errors/bracket_access_invalid_tuple:3:5
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun test : Maybe(String) {
   3│     {"Hello", ""}[2]

--- a/spec/errors/bracket_access_not_accessible
+++ b/spec/errors/bracket_access_not_accessible
@@ -25,8 +25,8 @@ Instead it is:
 
 The array in question is here:
 
-   ┌ ./spec/errors/bracket_access_not_accessible:3:5
-   ├────────────────────────────────────────────────
+   ┌ errors/bracket_access_not_accessible:3:5
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun test : Maybe(String) {
   3│     0[0]

--- a/spec/errors/call_argument_size_mismatch
+++ b/spec/errors/call_argument_size_mismatch
@@ -26,8 +26,8 @@ The type of the function is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/call_argument_size_mismatch:7:5
-    ├──────────────────────────────────────────────
+    ┌ errors/call_argument_size_mismatch:7:5
+    ├───────────────────────────────────────
    3│     input
    4│   }
    5│

--- a/spec/errors/call_argument_type_mismatch
+++ b/spec/errors/call_argument_type_mismatch
@@ -28,8 +28,8 @@ Instead it is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/call_argument_type_mismatch:7:5
-    ├──────────────────────────────────────────────
+    ┌ errors/call_argument_type_mismatch:7:5
+    ├───────────────────────────────────────
    3│     input
    4│   }
    5│

--- a/spec/errors/call_expected_closing_parenthesis
+++ b/spec/errors/call_expected_closing_parenthesis
@@ -10,8 +10,8 @@ The arguments of a call must be enclosed by parenthesis, here is an example:
 
 I was expecting the closing parenthesis of a call but I found "a space" instead:
 
-   ┌ ./spec/errors/call_expected_closing_parenthesis:3:12
-   ├─────────────────────────────────────────────────────
+   ┌ errors/call_expected_closing_parenthesis:3:12
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     test("A"

--- a/spec/errors/call_not_a_function
+++ b/spec/errors/call_not_a_function
@@ -20,8 +20,8 @@ The entity you called is not a function, instead it is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/call_not_a_function:5:5
-    ├──────────────────────────────────────
+    ┌ errors/call_not_a_function:5:5
+    ├───────────────────────────────
    1│ component Main {
    2│   state x : String = ""
    3│

--- a/spec/errors/call_not_found_argument
+++ b/spec/errors/call_not_found_argument
@@ -23,8 +23,8 @@ The type of the function is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/call_not_found_argument:7:5
-    ├──────────────────────────────────────────
+    ┌ errors/call_not_found_argument:7:5
+    ├──────────────────────────────────────
    3│     <div/>
    4│   }
    5│

--- a/spec/errors/call_with_mixed_arguments
+++ b/spec/errors/call_with_mixed_arguments
@@ -15,8 +15,8 @@ specific cases I cannot pair the arguments with the values.
 
 The call in question is here:
 
-    ┌ ./spec/errors/call_with_mixed_arguments:7:5
-    ├────────────────────────────────────────────
+    ┌ errors/call_with_mixed_arguments:7:5
+    ├─────────────────────────────────────
    3│     <div/>
    4│   }
    5│

--- a/spec/errors/case_branch_expected_expression
+++ b/spec/errors/case_branch_expected_expression
@@ -11,8 +11,8 @@ A case branch must have an value, here is an example:
 
 I was expecting the value of a case branch but I found "a space" instead:
 
-   ┌ ./spec/errors/case_branch_expected_expression:4:8
-   ├──────────────────────────────────────────────────
+   ┌ errors/case_branch_expected_expression:4:8
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case ("a") {

--- a/spec/errors/case_branch_not_matches
+++ b/spec/errors/case_branch_not_matches
@@ -23,8 +23,8 @@ Instead it is:
 
 The branch in question is here:
 
-    ┌ ./spec/errors/case_branch_not_matches:5:7
-    ├──────────────────────────────────────────
+    ┌ errors/case_branch_not_matches:5:7
+    ├───────────────────────────────────
    1│ component Main {
    2│   fun render : String {
    3│     case ("x") {

--- a/spec/errors/case_expected_branches
+++ b/spec/errors/case_expected_branches
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the branches of a case but I found "a space" instead:
 
-   ┌ ./spec/errors/case_expected_branches:3:16
-   ├──────────────────────────────────────────
+   ┌ errors/case_expected_branches:3:16
+   ├───────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case ("a") {

--- a/spec/errors/case_expected_closing_bracket
+++ b/spec/errors/case_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 
 I was expecting the closing bracket of a case but I found "a space" instead:
 
-   ┌ ./spec/errors/case_expected_closing_bracket:4:12
-   ├─────────────────────────────────────────────────
+   ┌ errors/case_expected_closing_bracket:4:12
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case ("a") {

--- a/spec/errors/case_expected_closing_parenthesis
+++ b/spec/errors/case_expected_closing_parenthesis
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the closing parenthesis of a case but I found "a space" instead:
 
-   ┌ ./spec/errors/case_expected_closing_parenthesis:3:13
-   ├─────────────────────────────────────────────────────
+   ┌ errors/case_expected_closing_parenthesis:3:13
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case ("a"

--- a/spec/errors/case_expected_condition
+++ b/spec/errors/case_expected_condition
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the condition of a case but I found "a space" instead:
 
-   ┌ ./spec/errors/case_expected_condition:3:8
-   ├──────────────────────────────────────────
+   ┌ errors/case_expected_condition:3:8
+   ├───────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case

--- a/spec/errors/case_expected_opening_bracket
+++ b/spec/errors/case_expected_opening_bracket
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the opening bracket of a case but I found "a space" instead:
 
-   ┌ ./spec/errors/case_expected_opening_bracket:3:14
-   ├─────────────────────────────────────────────────
+   ┌ errors/case_expected_opening_bracket:3:14
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case ("a")

--- a/spec/errors/case_not_exhaustive
+++ b/spec/errors/case_not_exhaustive
@@ -22,8 +22,8 @@ possibilities create branches for the following cases:
 
 The case in question is here:
 
-    ┌ ./spec/errors/case_not_exhaustive:9:5
-    ├──────────────────────────────────────
+    ┌ errors/case_not_exhaustive:9:5
+    ├───────────────────────────────
    5│ }
    6│
    7│ component Main {

--- a/spec/errors/case_unnecessary
+++ b/spec/errors/case_unnecessary
@@ -22,8 +22,8 @@ needed and can be safely removed.
 
 The case in question is here:
 
-    ┌ ./spec/errors/case_unnecessary:8:5
-    ├───────────────────────────────────
+    ┌ errors/case_unnecessary:8:5
+    ├────────────────────────────
    4│ }
    5│
    6│ component Main {

--- a/spec/errors/component_expected_body
+++ b/spec/errors/component_expected_body
@@ -4,7 +4,7 @@ component Main {
 
 I was expecting the body of a component but I found "a space" instead:
 
-   ┌ ./spec/errors/component_expected_body:1:16
-   ├───────────────────────────────────────────
+   ┌ errors/component_expected_body:1:16
+   ├────────────────────────────────────
   1│ component Main {
    │                 ⌃⌃⌃⌃

--- a/spec/errors/component_expected_closing_bracket
+++ b/spec/errors/component_expected_closing_bracket
@@ -6,8 +6,8 @@ component Main {
 I was expecting the closing bracket of the component but I found "a space"
 instead:
 
-   ┌ ./spec/errors/component_expected_closing_bracket:2:26
-   ├──────────────────────────────────────────────────────
+   ┌ errors/component_expected_closing_bracket:2:26
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   state test : String = ""
    │                           ⌃⌃⌃⌃

--- a/spec/errors/component_expected_name
+++ b/spec/errors/component_expected_name
@@ -7,7 +7,7 @@ lowercase, uppercase letters and numbers.
 
 I was expecting name of the component but I found "a space" instead:
 
-   ┌ ./spec/errors/component_expected_name:1:9
-   ├──────────────────────────────────────────
+   ┌ errors/component_expected_name:1:9
+   ├───────────────────────────────────
   1│ component
    │          ⌃⌃⌃⌃

--- a/spec/errors/component_expected_opening_bracket
+++ b/spec/errors/component_expected_opening_bracket
@@ -5,7 +5,7 @@ component Main
 I was expecting the opening bracket of the component but I found "a space"
 instead:
 
-   ┌ ./spec/errors/component_expected_opening_bracket:1:14
-   ├──────────────────────────────────────────────────────
+   ┌ errors/component_expected_opening_bracket:1:14
+   ├───────────────────────────────────────────────
   1│ component Main
    │               ⌃⌃⌃⌃

--- a/spec/errors/component_exposed_name_conflict
+++ b/spec/errors/component_exposed_name_conflict
@@ -16,8 +16,8 @@ You cannot expose "x" from the store because the name is already taken.
 
 The entity with the same name is here:
 
-    ┌ ./spec/errors/component_exposed_name_conflict:4:3
-    ├──────────────────────────────────────────────────
+    ┌ errors/component_exposed_name_conflict:4:3
+    ├───────────────────────────────────────────
    1│ component A {
    2│   connect Test exposing { x }
    3│
@@ -33,8 +33,8 @@ The entity with the same name is here:
 
 The expose in question is here:
 
-   ┌ ./spec/errors/component_exposed_name_conflict:2:27
-   ├───────────────────────────────────────────────────
+   ┌ errors/component_exposed_name_conflict:2:27
+   ├────────────────────────────────────────────
   1│ component A {
   2│   connect Test exposing { x }
    │                           ⌃

--- a/spec/errors/component_lifecycle_function_mismatch
+++ b/spec/errors/component_lifecycle_function_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The function in question is here:
 
-   ┌ ./spec/errors/component_lifecycle_function_mismatch:2:3
-   ├────────────────────────────────────────────────────────
+   ┌ errors/component_lifecycle_function_mismatch:2:3
+   ├─────────────────────────────────────────────────
   1│ component Main {
    │   ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   2│   fun componentDidUpdate (a : String) : String {

--- a/spec/errors/component_main_properties
+++ b/spec/errors/component_main_properties
@@ -13,8 +13,8 @@ to them.
 
 A property is defined here:
 
-   ┌ ./spec/errors/component_main_properties:2:3
-   ├────────────────────────────────────────────
+   ┌ errors/component_main_properties:2:3
+   ├─────────────────────────────────────
   1│ component Main {
   2│   property name : String = "Joe"
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -25,8 +25,8 @@ A property is defined here:
 
 The component in question is here:
 
-   ┌ ./spec/errors/component_main_properties:1:1
-   ├────────────────────────────────────────────
+   ┌ errors/component_main_properties:1:1
+   ├─────────────────────────────────────
   1│ component Main {
   2│   property name : String = "Joe"
   3│

--- a/spec/errors/component_multiple_exposed
+++ b/spec/errors/component_multiple_exposed
@@ -12,8 +12,8 @@ The entity "x" from a store is exposed multiple times.
 
 It is exposed here:
 
-   ┌ ./spec/errors/component_multiple_exposed:2:27
-   ├──────────────────────────────────────────────
+   ┌ errors/component_multiple_exposed:2:27
+   ├───────────────────────────────────────
   1│ component A {
   2│   connect Test exposing { x, x }
    │                           ⌃
@@ -24,8 +24,8 @@ It is exposed here:
 
 It is also exposed here:
 
-   ┌ ./spec/errors/component_multiple_exposed:2:30
-   ├──────────────────────────────────────────────
+   ┌ errors/component_multiple_exposed:2:30
+   ├───────────────────────────────────────
   1│ component A {
   2│   connect Test exposing { x, x }
    │                              ⌃

--- a/spec/errors/component_multiple_providers
+++ b/spec/errors/component_multiple_providers
@@ -13,8 +13,8 @@ You are subcribing to the provider "Provider" in a component multiple times.
 
 A subscription is here:
 
-   ┌ ./spec/errors/component_multiple_providers:3:3
-   ├───────────────────────────────────────────────
+   ┌ errors/component_multiple_providers:3:3
+   ├────────────────────────────────────────
   1│ component Main {
   2│   use Provider { a: "" }
   3│   use Provider { a: "" }
@@ -26,8 +26,8 @@ A subscription is here:
 
 An other subscription is here:
 
-   ┌ ./spec/errors/component_multiple_providers:2:3
-   ├───────────────────────────────────────────────
+   ┌ errors/component_multiple_providers:2:3
+   ├────────────────────────────────────────
   1│ component Main {
   2│   use Provider { a: "" }
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -35,4 +35,3 @@ An other subscription is here:
   4│
   5│   fun render : Html {
   6│     <div/>
-

--- a/spec/errors/component_multiple_stores
+++ b/spec/errors/component_multiple_stores
@@ -13,8 +13,8 @@ The component is connected to the store "Test" multiple times.
 
 It is connected here:
 
-   ┌ ./spec/errors/component_multiple_stores:3:3
-   ├────────────────────────────────────────────
+   ┌ errors/component_multiple_stores:3:3
+   ├─────────────────────────────────────
   1│ component A {
   2│   connect Test exposing { x }
   3│   connect Test exposing { x }
@@ -26,8 +26,8 @@ It is connected here:
 
 It is also connected here:
 
-   ┌ ./spec/errors/component_multiple_stores:2:3
-   ├────────────────────────────────────────────
+   ┌ errors/component_multiple_stores:2:3
+   ├─────────────────────────────────────
   1│ component A {
   2│   connect Test exposing { x }
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -35,4 +35,3 @@ It is also connected here:
   4│
   5│   fun render : Html {
   6│     <div/>
-

--- a/spec/errors/component_no_render_function
+++ b/spec/errors/component_no_render_function
@@ -8,8 +8,8 @@ component Main {
 
 A component must have a render function. This component does not have one:
 
-   ┌ ./spec/errors/component_no_render_function:1:1
-   ├───────────────────────────────────────────────
+   ┌ errors/component_no_render_function:1:1
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun a : String {
   3│     ""

--- a/spec/errors/component_reference_name_conflict
+++ b/spec/errors/component_reference_name_conflict
@@ -14,8 +14,8 @@ There are multiple references with the name:
 
 One reference is here:
 
-   ┌ ./spec/errors/component_reference_name_conflict:3:13
-   ├─────────────────────────────────────────────────────
+   ┌ errors/component_reference_name_conflict:3:13
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div as myDiv>
@@ -27,8 +27,8 @@ One reference is here:
 
 The other reference is here:
 
-   ┌ ./spec/errors/component_reference_name_conflict:4:15
-   ├─────────────────────────────────────────────────────
+   ┌ errors/component_reference_name_conflict:4:15
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div as myDiv>

--- a/spec/errors/component_render_function_mismatch
+++ b/spec/errors/component_render_function_mismatch
@@ -19,8 +19,8 @@ Instead the type of the function is:
 
 The function in question is here:
 
-   ┌ ./spec/errors/component_render_function_mismatch:2:3
-   ├─────────────────────────────────────────────────────
+   ┌ errors/component_render_function_mismatch:2:3
+   ├──────────────────────────────────────────────
   1│ component Main {
    │   ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   2│   fun render : Bool {

--- a/spec/errors/component_style_name_conflict
+++ b/spec/errors/component_style_name_conflict
@@ -20,8 +20,8 @@ There are multiple styles with the name:
 
 One style is here:
 
-    ┌ ./spec/errors/component_style_name_conflict:6:3
-    ├────────────────────────────────────────────────
+    ┌ errors/component_style_name_conflict:6:3
+    ├─────────────────────────────────────────
    2│   style title {
    3│     color: red;
    4│   }
@@ -38,8 +38,8 @@ One style is here:
 
 An other style is here:
 
-   ┌ ./spec/errors/component_style_name_conflict:2:3
-   ├────────────────────────────────────────────────
+   ┌ errors/component_style_name_conflict:2:3
+   ├─────────────────────────────────────────
   1│ component Main {
    │   ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   2│   style title {

--- a/spec/errors/connect_expected_closing_bracket
+++ b/spec/errors/connect_expected_closing_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the closing bracket of a connect but I found "a space" instead:
 
-   ┌ ./spec/errors/connect_expected_closing_bracket:2:30
-   ├────────────────────────────────────────────────────
+   ┌ errors/connect_expected_closing_bracket:2:30
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   connect Test exposing { item
    │                               ⌃⌃⌃⌃

--- a/spec/errors/connect_expected_exposing
+++ b/spec/errors/connect_expected_exposing
@@ -6,8 +6,8 @@ component Main {
 I was expecting the "exposing" keyword for a connect but I found "a space"
 instead:
 
-   ┌ ./spec/errors/connect_expected_exposing:2:14
-   ├─────────────────────────────────────────────
+   ┌ errors/connect_expected_exposing:2:14
+   ├──────────────────────────────────────
   1│ component Main {
   2│   connect Test
    │               ⌃⌃⌃⌃

--- a/spec/errors/connect_expected_keys
+++ b/spec/errors/connect_expected_keys
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the exposed entities of a connect but I found "a space" instead:
 
-   ┌ ./spec/errors/connect_expected_keys:2:25
-   ├─────────────────────────────────────────
+   ┌ errors/connect_expected_keys:2:25
+   ├──────────────────────────────────
   1│ component Main {
   2│   connect Test exposing {
    │                          ⌃⌃⌃⌃

--- a/spec/errors/connect_expected_opening_bracket
+++ b/spec/errors/connect_expected_opening_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the opening bracket of a connect but I found "a space" instead:
 
-   ┌ ./spec/errors/connect_expected_opening_bracket:2:23
-   ├────────────────────────────────────────────────────
+   ┌ errors/connect_expected_opening_bracket:2:23
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   connect Test exposing
    │                        ⌃⌃⌃⌃

--- a/spec/errors/connect_expected_store
+++ b/spec/errors/connect_expected_store
@@ -6,8 +6,8 @@ component Main {
 I was expecting the name of the store for a connect but I found "a space"
 instead:
 
-   ┌ ./spec/errors/connect_expected_store:2:9
-   ├─────────────────────────────────────────
+   ┌ errors/connect_expected_store:2:9
+   ├──────────────────────────────────
   1│ component Main {
   2│   connect
    │          ⌃⌃⌃⌃

--- a/spec/errors/connect_not_found_member
+++ b/spec/errors/connect_not_found_member
@@ -16,8 +16,8 @@ The entity "y" does not exist in the connected store.
 
 The connect in question is here:
 
-    ┌ ./spec/errors/connect_not_found_member:6:3
-    ├───────────────────────────────────────────
+    ┌ errors/connect_not_found_member:6:3
+    ├────────────────────────────────────
    2│   state x : String = ""
    3│ }
    4│

--- a/spec/errors/connect_not_found_store
+++ b/spec/errors/connect_not_found_store
@@ -10,8 +10,8 @@ component Main {
 
 I was looking for the store Test but could not find it.
 
-   ┌ ./spec/errors/connect_not_found_store:2:11
-   ├───────────────────────────────────────────
+   ┌ errors/connect_not_found_store:2:11
+   ├────────────────────────────────────
   1│ component Main {
   2│   connect Test exposing { x, y }
    │           ⌃⌃⌃⌃

--- a/spec/errors/connect_variable_expected_as
+++ b/spec/errors/connect_variable_expected_as
@@ -9,8 +9,8 @@ The exposed name of a connection must be specified, here is an example:
 
 I was expecting the exposed name but I found "a space" instead:
 
-   ┌ ./spec/errors/connect_variable_expected_as:2:33
-   ├────────────────────────────────────────────────
+   ┌ errors/connect_variable_expected_as:2:33
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   connect Test exposing { item as
    │                                  ⌃⌃⌃⌃

--- a/spec/errors/constant_expected_equal_sign
+++ b/spec/errors/constant_expected_equal_sign
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the equal sign of a constant but I found "a space" instead:
 
-   ┌ ./spec/errors/constant_expected_equal_sign:2:12
-   ├────────────────────────────────────────────────
+   ┌ errors/constant_expected_equal_sign:2:12
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   const TEST
    │             ⌃⌃⌃⌃

--- a/spec/errors/constant_expected_expression
+++ b/spec/errors/constant_expected_expression
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the expression of a constant but I found "a space" instead:
 
-   ┌ ./spec/errors/constant_expected_expression:2:14
-   ├────────────────────────────────────────────────
+   ┌ errors/constant_expected_expression:2:14
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   const TEST =
    │               ⌃⌃⌃⌃

--- a/spec/errors/constant_expected_name
+++ b/spec/errors/constant_expected_name
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the name of a constant but I found "a space" instead:
 
-   ┌ ./spec/errors/constant_expected_name:2:7
-   ├─────────────────────────────────────────
+   ┌ errors/constant_expected_name:2:7
+   ├──────────────────────────────────
   1│ component Main {
   2│   const
    │        ⌃⌃⌃⌃

--- a/spec/errors/css_definition_expected_semicolon
+++ b/spec/errors/css_definition_expected_semicolon
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the semicolon of a CSS definition but I found "a space" instead:
 
-   ┌ ./spec/errors/css_definition_expected_semicolon:3:19
-   ├─────────────────────────────────────────────────────
+   ┌ errors/css_definition_expected_semicolon:3:19
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     background: red

--- a/spec/errors/css_definition_no_property
+++ b/spec/errors/css_definition_no_property
@@ -12,8 +12,8 @@ component Main {
 
 There is no CSS property with the name: "colorasd"
 
-   ┌ ./spec/errors/css_definition_no_property:3:5
-   ├─────────────────────────────────────────────
+   ┌ errors/css_definition_no_property:3:5
+   ├──────────────────────────────────────
   1│ component Main {
   2│   style test {
   3│     colorasd: hello;

--- a/spec/errors/css_definition_type_mismatch
+++ b/spec/errors/css_definition_type_mismatch
@@ -23,8 +23,8 @@ Instead it is:
 
 The css definition in question is here:
 
-   ┌ ./spec/errors/css_definition_type_mismatch:3:5
-   ├───────────────────────────────────────────────
+   ┌ errors/css_definition_type_mismatch:3:5
+   ├────────────────────────────────────────
   1│ component Main {
   2│   style test {
   3│     color: #{true};

--- a/spec/errors/css_font_face_expected_closing_bracket
+++ b/spec/errors/css_font_face_expected_closing_bracket
@@ -8,8 +8,8 @@ component Main {
 I was expecting the closing bracket of a CSS font-face rule but I found "a
 space" instead:
 
-   ┌ ./spec/errors/css_font_face_expected_closing_bracket:4:17
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/css_font_face_expected_closing_bracket:4:17
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @font-face {

--- a/spec/errors/css_font_face_expected_definitions
+++ b/spec/errors/css_font_face_expected_definitions
@@ -7,8 +7,8 @@ component Main {
 I was expecting the definitions of a CSS font-face rule but I found "a space"
 instead:
 
-   ┌ ./spec/errors/css_font_face_expected_definitions:3:16
-   ├──────────────────────────────────────────────────────
+   ┌ errors/css_font_face_expected_definitions:3:16
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @font-face {

--- a/spec/errors/css_font_face_expected_opening_bracket
+++ b/spec/errors/css_font_face_expected_opening_bracket
@@ -7,10 +7,9 @@ component Main {
 I was expecting the opening bracket of a CSS font-face rule but I found "a
 space" instead:
 
-   ┌ ./spec/errors/css_font_face_expected_opening_bracket:3:14
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/css_font_face_expected_opening_bracket:3:14
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @font-face
    │               ⌃⌃⌃⌃
-

--- a/spec/errors/css_font_face_interpolation
+++ b/spec/errors/css_font_face_interpolation
@@ -15,8 +15,8 @@ component Main {
 
 Interpolations are not allowed inside a font-face rule.
 
-    ┌ ./spec/errors/css_font_face_interpolation:5:20
-    ├───────────────────────────────────────────────
+    ┌ errors/css_font_face_interpolation:5:20
+    ├────────────────────────────────────────
    1│ component Main {
    2│   style test {
    3│     @font-face {

--- a/spec/errors/css_keyframes_expected_closing_bracket
+++ b/spec/errors/css_keyframes_expected_closing_bracket
@@ -10,8 +10,8 @@ component Main {
 I was expecting the closing bracket of a CSS keyframes rule but I found "a
 space" instead:
 
-   ┌ ./spec/errors/css_keyframes_expected_closing_bracket:6:7
-   ├─────────────────────────────────────────────────────────
+   ┌ errors/css_keyframes_expected_closing_bracket:6:7
+   ├──────────────────────────────────────────────────
   2│   style root {
   3│     @keyframes name {
   4│       0% {

--- a/spec/errors/css_keyframes_expected_name
+++ b/spec/errors/css_keyframes_expected_name
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the name of a CSS keyframes rule but I found "a space" instead:
 
-   ┌ ./spec/errors/css_keyframes_expected_name:3:14
-   ├───────────────────────────────────────────────
+   ┌ errors/css_keyframes_expected_name:3:14
+   ├────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @keyframes

--- a/spec/errors/css_keyframes_expected_opening_bracket
+++ b/spec/errors/css_keyframes_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of a CSS keyframes rule but I found "a
 space" instead:
 
-   ┌ ./spec/errors/css_keyframes_expected_opening_bracket:3:19
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/css_keyframes_expected_opening_bracket:3:19
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @keyframes name

--- a/spec/errors/css_keyframes_expected_selectors
+++ b/spec/errors/css_keyframes_expected_selectors
@@ -7,8 +7,8 @@ component Main {
 I was expecting the selectors of a CSS keyframes rule but I found "a space"
 instead:
 
-   ┌ ./spec/errors/css_keyframes_expected_selectors:3:21
-   ├────────────────────────────────────────────────────
+   ┌ errors/css_keyframes_expected_selectors:3:21
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @keyframes name {

--- a/spec/errors/css_nested_at_expected_body
+++ b/spec/errors/css_nested_at_expected_body
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the body of a CSS at rule but I found "a space" instead:
 
-   ┌ ./spec/errors/css_nested_at_expected_body:3:31
-   ├───────────────────────────────────────────────
+   ┌ errors/css_nested_at_expected_body:3:31
+   ├────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @media (max-width: 100px) {

--- a/spec/errors/css_nested_at_expected_closing_bracket
+++ b/spec/errors/css_nested_at_expected_closing_bracket
@@ -8,8 +8,8 @@ component Main {
 I was expecting the closing bracket of a CSS at rule but I found "a space"
 instead:
 
-   ┌ ./spec/errors/css_nested_at_expected_closing_bracket:4:17
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/css_nested_at_expected_closing_bracket:4:17
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @media (max-width: 100px) {

--- a/spec/errors/css_nested_at_expected_condition
+++ b/spec/errors/css_nested_at_expected_condition
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the condition of a CSS at rule but I found "a space" instead:
 
-   ┌ ./spec/errors/css_nested_at_expected_condition:3:10
-   ├────────────────────────────────────────────────────
+   ┌ errors/css_nested_at_expected_condition:3:10
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @media

--- a/spec/errors/css_nested_at_expected_opening_bracket
+++ b/spec/errors/css_nested_at_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of a CSS at rule but I found "a space"
 instead:
 
-   ┌ ./spec/errors/css_nested_at_expected_opening_bracket:3:29
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/css_nested_at_expected_opening_bracket:3:29
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     @media (max-width: 100px)

--- a/spec/errors/css_selector_expected_body
+++ b/spec/errors/css_selector_expected_body
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the body of a CSS selector but I found "a space" instead:
 
-   ┌ ./spec/errors/css_selector_expected_body:3:9
-   ├─────────────────────────────────────────────
+   ┌ errors/css_selector_expected_body:3:9
+   ├──────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     div {

--- a/spec/errors/css_selector_expected_closing_bracket
+++ b/spec/errors/css_selector_expected_closing_bracket
@@ -8,8 +8,8 @@ component Main {
 I was expecting the opening closing of a CSS selector but I found "a space"
 instead:
 
-   ┌ ./spec/errors/css_selector_expected_closing_bracket:4:17
-   ├─────────────────────────────────────────────────────────
+   ┌ errors/css_selector_expected_closing_bracket:4:17
+   ├──────────────────────────────────────────────────
   1│ component Main {
   2│   style root {
   3│     div {

--- a/spec/errors/decode_complex_type
+++ b/spec/errors/decode_complex_type
@@ -29,8 +29,8 @@ Only these types and records containing them cantext be automatically decoded:
 
 The decode question is here:
 
-    ┌ ./spec/errors/decode_complex_type:7:5
-    ├──────────────────────────────────────
+    ┌ errors/decode_complex_type:7:5
+    ├───────────────────────────────
    3│ }
    4│
    5│ component Main {

--- a/spec/errors/decode_expected_as
+++ b/spec/errors/decode_expected_as
@@ -7,8 +7,8 @@ component Main {
 I was expecting the "as" keyword of a decode expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/decode_expected_as:3:13
-   ├──────────────────────────────────────
+   ┌ errors/decode_expected_as:3:13
+   ├───────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     decode ""

--- a/spec/errors/decode_expected_object
+++ b/spec/errors/decode_expected_object
@@ -18,8 +18,8 @@ Only the "Object" type can be decoded but you tried to decode:
 
 The decode question is here:
 
-    ┌ ./spec/errors/decode_expected_object:7:5
-    ├─────────────────────────────────────────
+    ┌ errors/decode_expected_object:7:5
+    ├──────────────────────────────────
    3│ }
    4│
    5│ component Main {

--- a/spec/errors/decode_expected_subject
+++ b/spec/errors/decode_expected_subject
@@ -7,8 +7,8 @@ component Main {
 I was expecting the subject of a decode expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/decode_expected_subject:3:10
-   ├───────────────────────────────────────────
+   ┌ errors/decode_expected_subject:3:10
+   ├────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     decode

--- a/spec/errors/decode_expected_type
+++ b/spec/errors/decode_expected_type
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the type of a decode expression but I found "a space" instead:
 
-   ┌ ./spec/errors/decode_expected_type:3:16
-   ├────────────────────────────────────────
+   ┌ errors/decode_expected_type:3:16
+   ├─────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     decode "" as

--- a/spec/errors/destructuring_multiple_spreads
+++ b/spec/errors/destructuring_multiple_spreads
@@ -13,8 +13,8 @@ don't know how to distribute the leftover items.
 
 This array destructuring contains 2 spread notations:
 
-   ┌ ./spec/errors/destructuring_multiple_spreads:4:7
-   ├─────────────────────────────────────────────────
+   ┌ errors/destructuring_multiple_spreads:4:7
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case [] {

--- a/spec/errors/destructuring_tuple_mismatch
+++ b/spec/errors/destructuring_tuple_mismatch
@@ -19,8 +19,8 @@ Instead it is this:
 
 The destructuring in question is here:
 
-   ┌ ./spec/errors/destructuring_tuple_mismatch:4:7
-   ├───────────────────────────────────────────────
+   ┌ errors/destructuring_tuple_mismatch:4:7
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case {"a", "b"} {

--- a/spec/errors/destructuring_type_mismatch
+++ b/spec/errors/destructuring_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The destructuring in question is here:
 
-   ┌ ./spec/errors/destructuring_type_mismatch:4:7
-   ├──────────────────────────────────────────────
+   ┌ errors/destructuring_type_mismatch:4:7
+   ├───────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     case "x" {

--- a/spec/errors/destructuring_type_missing
+++ b/spec/errors/destructuring_type_missing
@@ -13,8 +13,8 @@ I could not find the type for a destructuring with the name:
 
 The destructuring in question is here:
 
-   ┌ ./spec/errors/destructuring_type_missing:3:9
-   ├─────────────────────────────────────────────
+   ┌ errors/destructuring_type_missing:3:9
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     let Maybe.Just(a) = "" or return ""

--- a/spec/errors/destructuring_type_variant_missing
+++ b/spec/errors/destructuring_type_variant_missing
@@ -13,8 +13,8 @@ component Main {
 
 I could not find the variant "Just" of type "Maybe" for a destructuring:
 
-    ┌ ./spec/errors/destructuring_type_variant_missing:7:9
-    ├─────────────────────────────────────────────────────
+    ┌ errors/destructuring_type_variant_missing:7:9
+    ├──────────────────────────────────────────────
    3│ }
    4│
    5│ component Main {
@@ -27,8 +27,8 @@ I could not find the variant "Just" of type "Maybe" for a destructuring:
 
 The type is defined here:
 
-   ┌ ./spec/errors/destructuring_type_variant_missing:1:1
-   ├─────────────────────────────────────────────────────
+   ┌ errors/destructuring_type_variant_missing:1:1
+   ├──────────────────────────────────────────────
    │ ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   1│ type Maybe {
   2│   Nothing

--- a/spec/errors/emit_no_signal
+++ b/spec/errors/emit_no_signal
@@ -9,8 +9,8 @@ component Main {
 
 Emit cannot be used outside of signals:
 
-   ┌ ./spec/errors/emit_no_signal:3:5
-   ├─────────────────────────────────
+   ┌ errors/emit_no_signal:3:5
+   ├──────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     emit 0

--- a/spec/errors/emit_type_mismatch
+++ b/spec/errors/emit_type_mismatch
@@ -14,8 +14,8 @@ The type of the emitted value is:
 
 The emit in question is here:
 
-   ┌ ./spec/errors/emit_type_mismatch:2:23
-   ├──────────────────────────────────────
+   ┌ errors/emit_type_mismatch:2:23
+   ├───────────────────────────────
   1│ store Test {
   2│   signal b : String { emit 0 }
    │                       ⌃⌃⌃⌃⌃⌃

--- a/spec/errors/encode_complex_type
+++ b/spec/errors/encode_complex_type
@@ -27,8 +27,8 @@ Only these types and records containing them can be automatically decoded:
 
 The encode in question is here:
 
-    ┌ ./spec/errors/encode_complex_type:7:5
-    ├──────────────────────────────────────
+    ┌ errors/encode_complex_type:7:5
+    ├───────────────────────────────
    3│ }
    4│
    5│ component Main {

--- a/spec/errors/encode_expected_expression
+++ b/spec/errors/encode_expected_expression
@@ -10,8 +10,8 @@ The object to be encoded must come from an expression, here is an example:
 
 I was expecting the expression but I found "a space" instead:
 
-   ┌ ./spec/errors/encode_expected_expression:3:10
-   ├──────────────────────────────────────────────
+   ┌ errors/encode_expected_expression:3:10
+   ├───────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     encode

--- a/spec/errors/entity_name_conflict
+++ b/spec/errors/entity_name_conflict
@@ -10,8 +10,8 @@ component Main {
 
 There is already a property with the name "render" in this component:
 
-   ┌ ./spec/errors/entity_name_conflict:2:3
-   ├───────────────────────────────────────
+   ┌ errors/entity_name_conflict:2:3
+   ├────────────────────────────────
   1│ component Main {
   2│   property render : String = ""
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -22,8 +22,8 @@ There is already a property with the name "render" in this component:
 
 You are trying to define something with the same name here:
 
-   ┌ ./spec/errors/entity_name_conflict:4:3
-   ├───────────────────────────────────────
+   ┌ errors/entity_name_conflict:4:3
+   ├────────────────────────────────
   1│ component Main {
   2│   property render : String = ""
   3│

--- a/spec/errors/env_expected_name
+++ b/spec/errors/env_expected_name
@@ -7,8 +7,8 @@ component Main {
 I was expecting the name of the environment variable but I found "a space"
 instead:
 
-   ┌ ./spec/errors/env_expected_name:3:5
-   ├────────────────────────────────────
+   ┌ errors/env_expected_name:3:5
+   ├─────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @

--- a/spec/errors/env_not_found_variable
+++ b/spec/errors/env_not_found_variable
@@ -12,8 +12,8 @@ I cannot find the environment variable with the name:
 
 Here is where it is referenced:
 
-   ┌ ./spec/errors/env_not_found_variable:3:5
-   ├─────────────────────────────────────────
+   ┌ errors/env_not_found_variable:3:5
+   ├──────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @XXX

--- a/spec/errors/field_access_expected_closing_parenthesis
+++ b/spec/errors/field_access_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parentheses of a field access but I found "a space"
 instead:
 
-   ┌ ./spec/errors/field_access_expected_closing_parenthesis:3:8
-   ├────────────────────────────────────────────────────────────
+   ┌ errors/field_access_expected_closing_parenthesis:3:8
+   ├─────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     .a(A

--- a/spec/errors/field_access_expected_opening_parenthesis
+++ b/spec/errors/field_access_expected_opening_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening parenthesis of a field access but I found "a space"
 instead:
 
-   ┌ ./spec/errors/field_access_expected_opening_parenthesis:3:6
-   ├────────────────────────────────────────────────────────────
+   ┌ errors/field_access_expected_opening_parenthesis:3:6
+   ├─────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     .a

--- a/spec/errors/field_access_expected_type
+++ b/spec/errors/field_access_expected_type
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the type of a field access but I found "a space" instead:
 
-   ┌ ./spec/errors/field_access_expected_type:3:7
-   ├─────────────────────────────────────────────
+   ┌ errors/field_access_expected_type:3:7
+   ├──────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     .a(

--- a/spec/errors/field_access_expected_variable
+++ b/spec/errors/field_access_expected_variable
@@ -7,8 +7,8 @@ component Main {
 I was expecting the field of the accessed entity of a field access but I found
 "a space" instead:
 
-   ┌ ./spec/errors/field_access_expected_variable:3:5
-   ├─────────────────────────────────────────────────
+   ┌ errors/field_access_expected_variable:3:5
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     .

--- a/spec/errors/field_access_field_not_found
+++ b/spec/errors/field_access_field_not_found
@@ -16,8 +16,8 @@ The field a does not exists on the type:
 
 The field access in question is here:
 
-    ┌ ./spec/errors/field_access_field_not_found:7:5
-    ├───────────────────────────────────────────────
+    ┌ errors/field_access_field_not_found:7:5
+    ├────────────────────────────────────────
    3│ }
    4│
    5│ component Main {

--- a/spec/errors/field_access_not_record
+++ b/spec/errors/field_access_not_record
@@ -12,8 +12,8 @@ The type of the accessed entity is not a record:
 
 The field access in question is here:
 
-   ┌ ./spec/errors/field_access_not_record:3:5
-   ├──────────────────────────────────────────
+   ┌ errors/field_access_not_record:3:5
+   ├───────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     .a(String)

--- a/spec/errors/for_array_or_set_arguments_mismatch
+++ b/spec/errors/for_array_or_set_arguments_mismatch
@@ -13,8 +13,8 @@ component Main {
 If the iterable object of a for expression is a set or an array. Then it needs
 to the have only 1 argument:
 
-   ┌ ./spec/errors/for_array_or_set_arguments_mismatch:3:10
-   ├───────────────────────────────────────────────────────
+   ┌ errors/for_array_or_set_arguments_mismatch:3:10
+   ├────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (item, item2, item3 of ["A", "B"]) {

--- a/spec/errors/for_condition_type_mismatch
+++ b/spec/errors/for_condition_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The value in question is here:
 
-    ┌ ./spec/errors/for_condition_type_mismatch:8:7
-    ├──────────────────────────────────────────────
+    ┌ errors/for_condition_type_mismatch:8:7
+    ├───────────────────────────────────────
    4│       <div>
    5│         item
    6│       </div>

--- a/spec/errors/for_expected_body
+++ b/spec/errors/for_expected_body
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the body of a for expression but I found "a space" instead:
 
-   ┌ ./spec/errors/for_expected_body:3:21
-   ├─────────────────────────────────────
+   ┌ errors/for_expected_body:3:21
+   ├──────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b of c) {

--- a/spec/errors/for_expected_closing_bracket
+++ b/spec/errors/for_expected_closing_bracket
@@ -8,8 +8,8 @@ component Main {
 I was expecting the closing bracket of a for expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/for_expected_closing_bracket:4:7
-   ├───────────────────────────────────────────────
+   ┌ errors/for_expected_closing_bracket:4:7
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b of c) {

--- a/spec/errors/for_expected_closing_parenthesis
+++ b/spec/errors/for_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of a for expression but I found "a
 space" instead:
 
-   ┌ ./spec/errors/for_expected_closing_parenthesis:3:18
-   ├────────────────────────────────────────────────────
+   ┌ errors/for_expected_closing_parenthesis:3:18
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b of c

--- a/spec/errors/for_expected_of
+++ b/spec/errors/for_expected_of
@@ -7,8 +7,8 @@ component Main {
 I was expecting the "of" keyword of a for expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/for_expected_of:3:13
-   ├───────────────────────────────────
+   ┌ errors/for_expected_of:3:13
+   ├─────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b

--- a/spec/errors/for_expected_opening_bracket
+++ b/spec/errors/for_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of a for expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/for_expected_opening_bracket:3:19
-   ├────────────────────────────────────────────────
+   ┌ errors/for_expected_opening_bracket:3:19
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b of c)

--- a/spec/errors/for_expected_subject
+++ b/spec/errors/for_expected_subject
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the subject of a for expression but I found "a space" instead:
 
-   ┌ ./spec/errors/for_expected_subject:3:16
-   ├────────────────────────────────────────
+   ┌ errors/for_expected_subject:3:16
+   ├─────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (a, b of

--- a/spec/errors/for_index_mismatch
+++ b/spec/errors/for_index_mismatch
@@ -12,8 +12,8 @@ component Main {
 
 The index argument cannot be destructured, it must be a variable.
 
-   ┌ ./spec/errors/for_index_mismatch:3:16
-   ├──────────────────────────────────────
+   ┌ errors/for_index_mismatch:3:16
+   ├────────────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (item, {x} of ["A", "B"]) {

--- a/spec/errors/for_map_arguments_mismatch
+++ b/spec/errors/for_map_arguments_mismatch
@@ -17,8 +17,8 @@ component Main {
 If the iterable object of a for expression is a map, then it needs to the have 2
 arguments:
 
-    ┌ ./spec/errors/for_map_arguments_mismatch:7:10
-    ├──────────────────────────────────────────────
+    ┌ errors/for_map_arguments_mismatch:7:10
+    ├───────────────────────────────────────
    3│     ``
    4│   }
    5│

--- a/spec/errors/for_type_mismatch
+++ b/spec/errors/for_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The iterable object in question is here:
 
-   ┌ ./spec/errors/for_type_mismatch:3:18
-   ├─────────────────────────────────────
+   ┌ errors/for_type_mismatch:3:18
+   ├──────────────────────────────
   1│ component Main {
   2│   fun render : Array(Html) {
   3│     for (item of "A") {

--- a/spec/errors/format_directive_expected_body
+++ b/spec/errors/format_directive_expected_body
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the body of a format directive but I found "a space" instead:
 
-   ┌ ./spec/errors/format_directive_expected_body:3:13
-   ├──────────────────────────────────────────────────
+   ┌ errors/format_directive_expected_body:3:13
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @format {

--- a/spec/errors/format_directive_expected_closing_bracket
+++ b/spec/errors/format_directive_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of a format directive but I found "a space"
 instead:
 
-   ┌ ./spec/errors/format_directive_expected_closing_bracket:3:18
-   ├─────────────────────────────────────────────────────────────
+   ┌ errors/format_directive_expected_closing_bracket:3:18
+   ├──────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @format { test

--- a/spec/errors/format_directive_expected_opening_bracket
+++ b/spec/errors/format_directive_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of a format directive but I found "a space"
 instead:
 
-   ┌ ./spec/errors/format_directive_expected_opening_bracket:3:11
-   ├─────────────────────────────────────────────────────────────
+   ┌ errors/format_directive_expected_opening_bracket:3:11
+   ├──────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @format

--- a/spec/errors/function_argument_conflict
+++ b/spec/errors/function_argument_conflict
@@ -16,8 +16,8 @@ The argument "a" is declared multiple times.
 
 It is declared here:
 
-   ┌ ./spec/errors/function_argument_conflict:2:25
-   ├──────────────────────────────────────────────
+   ┌ errors/function_argument_conflict:2:25
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun test (a : String, a : String) : Bool {
    │                         ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -28,8 +28,8 @@ It is declared here:
 
 It is also declared here:
 
-   ┌ ./spec/errors/function_argument_conflict:2:13
-   ├──────────────────────────────────────────────
+   ┌ errors/function_argument_conflict:2:13
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun test (a : String, a : String) : Bool {
    │             ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/function_argument_must_have_a_default_value
+++ b/spec/errors/function_argument_must_have_a_default_value
@@ -17,8 +17,8 @@ default value.
 
 The argument in question is here:
 
-   ┌ ./spec/errors/function_argument_must_have_a_default_value:2:35
-   ├───────────────────────────────────────────────────────────────
+   ┌ errors/function_argument_must_have_a_default_value:2:35
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun test (a : String = "Hello", b : String) : Number {
    │                                   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/function_expected_closing_bracket
+++ b/spec/errors/function_expected_closing_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the closing bracket of a function but I found "a space" instead:
 
-   ┌ ./spec/errors/function_expected_closing_bracket:2:16
-   ├─────────────────────────────────────────────────────
+   ┌ errors/function_expected_closing_bracket:2:16
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render { a
    │                 ⌃⌃⌃⌃

--- a/spec/errors/function_expected_closing_parenthesis
+++ b/spec/errors/function_expected_closing_parenthesis
@@ -6,8 +6,8 @@ component Main {
 I was expecting the closing parenthesis of a function but I found "a space"
 instead:
 
-   ┌ ./spec/errors/function_expected_closing_parenthesis:2:14
-   ├─────────────────────────────────────────────────────────
+   ┌ errors/function_expected_closing_parenthesis:2:14
+   ├──────────────────────────────────────────────────
   1│ component Main {
   2│   fun render (
    │               ⌃⌃⌃⌃

--- a/spec/errors/function_expected_expression
+++ b/spec/errors/function_expected_expression
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the body of a function but I found "a space" instead:
 
-   ┌ ./spec/errors/function_expected_expression:2:14
-   ├────────────────────────────────────────────────
+   ┌ errors/function_expected_expression:2:14
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render {
    │               ⌃⌃⌃⌃

--- a/spec/errors/function_expected_name
+++ b/spec/errors/function_expected_name
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the name of the function but I found "a space" instead:
 
-   ┌ ./spec/errors/function_expected_name:2:5
-   ├─────────────────────────────────────────
+   ┌ errors/function_expected_name:2:5
+   ├──────────────────────────────────
   1│ component Main {
   2│   fun
    │      ⌃⌃⌃⌃

--- a/spec/errors/function_expected_opening_bracket
+++ b/spec/errors/function_expected_opening_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the opening bracket of a function but I found "a space" instead:
 
-   ┌ ./spec/errors/function_expected_opening_bracket:2:12
-   ├─────────────────────────────────────────────────────
+   ┌ errors/function_expected_opening_bracket:2:12
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render
    │             ⌃⌃⌃⌃

--- a/spec/errors/function_expected_type_or_variable
+++ b/spec/errors/function_expected_type_or_variable
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the type of a function but I found "a space" instead:
 
-   ┌ ./spec/errors/function_expected_type_or_variable:2:14
-   ├──────────────────────────────────────────────────────
+   ┌ errors/function_expected_type_or_variable:2:14
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   fun render :
    │               ⌃⌃⌃⌃

--- a/spec/errors/function_type_mismatch
+++ b/spec/errors/function_type_mismatch
@@ -20,8 +20,8 @@ I was expecting:
 
 Which is defined here:
 
-   ┌ ./spec/errors/function_type_mismatch:2:14
-   ├──────────────────────────────────────────
+   ┌ errors/function_type_mismatch:2:14
+   ├───────────────────────────────────
   1│ component Main {
   2│   fun test : Bool {
    │              ⌃⌃⌃⌃
@@ -36,8 +36,8 @@ Instead it is:
 
 Which is returned here:
 
-   ┌ ./spec/errors/function_type_mismatch:3:5
-   ├─────────────────────────────────────────
+   ┌ errors/function_type_mismatch:3:5
+   ├──────────────────────────────────
   1│ component Main {
   2│   fun test : Bool {
   3│     "hello"
@@ -46,4 +46,3 @@ Which is returned here:
   5│
   6│   fun render : String {
   7│     test()
-

--- a/spec/errors/get_expected_closing_bracket
+++ b/spec/errors/get_expected_closing_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the closing bracket of a get but I found "a space" instead:
 
-   ┌ ./spec/errors/get_expected_closing_bracket:2:14
-   ├────────────────────────────────────────────────
+   ┌ errors/get_expected_closing_bracket:2:14
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   get name { a
    │               ⌃⌃⌃⌃

--- a/spec/errors/get_expected_expression
+++ b/spec/errors/get_expected_expression
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the body of a get but I found "a space" instead:
 
-   ┌ ./spec/errors/get_expected_expression:2:12
-   ├───────────────────────────────────────────
+   ┌ errors/get_expected_expression:2:12
+   ├────────────────────────────────────
   1│ component Main {
   2│   get name {
    │             ⌃⌃⌃⌃

--- a/spec/errors/get_expected_name
+++ b/spec/errors/get_expected_name
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the name of a get but I found "a space" instead:
 
-   ┌ ./spec/errors/get_expected_name:2:5
-   ├────────────────────────────────────
+   ┌ errors/get_expected_name:2:5
+   ├─────────────────────────────
   1│ component Main {
   2│   get
    │      ⌃⌃⌃⌃

--- a/spec/errors/get_expected_opening_bracket
+++ b/spec/errors/get_expected_opening_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the opening bracket of a get but I found "a space" instead:
 
-   ┌ ./spec/errors/get_expected_opening_bracket:2:10
-   ├────────────────────────────────────────────────
+   ┌ errors/get_expected_opening_bracket:2:10
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   get name
    │           ⌃⌃⌃⌃

--- a/spec/errors/get_expected_type
+++ b/spec/errors/get_expected_type
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the type of a get but I found "a space" instead:
 
-   ┌ ./spec/errors/get_expected_type:2:12
-   ├─────────────────────────────────────
+   ┌ errors/get_expected_type:2:12
+   ├──────────────────────────────
   1│ component Main {
   2│   get name :
    │             ⌃⌃⌃⌃

--- a/spec/errors/get_type_mismatch
+++ b/spec/errors/get_type_mismatch
@@ -20,8 +20,8 @@ I was expecting:
 
 Which is defined here:
 
-   ┌ ./spec/errors/get_type_mismatch:2:14
-   ├─────────────────────────────────────
+   ┌ errors/get_type_mismatch:2:14
+   ├──────────────────────────────
   1│ component Main {
   2│   get test : Number {
    │              ⌃⌃⌃⌃⌃⌃
@@ -36,8 +36,8 @@ Instead it is:
 
 Which is returned here:
 
-   ┌ ./spec/errors/get_type_mismatch:3:5
-   ├────────────────────────────────────
+   ┌ errors/get_type_mismatch:3:5
+   ├─────────────────────────────
   1│ component Main {
   2│   get test : Number {
   3│     "asd"

--- a/spec/errors/here_doc_expected_end
+++ b/spec/errors/here_doc_expected_end
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the end tag of a here document but I found "a space" instead:
 
-   ┌ ./spec/errors/here_doc_expected_end:3:11
-   ├─────────────────────────────────────────
+   ┌ errors/here_doc_expected_end:3:11
+   ├──────────────────────────────────
   1│ component Main {
   2│   fun render {
   3│     <<-TEST

--- a/spec/errors/here_doc_interpolation_type_mismatch
+++ b/spec/errors/here_doc_interpolation_type_mismatch
@@ -20,8 +20,8 @@ Instead it is:
 
 The interpolation in question is here:
 
-   ┌ ./spec/errors/here_doc_interpolation_type_mismatch:4:7
-   ├───────────────────────────────────────────────────────
+   ┌ errors/here_doc_interpolation_type_mismatch:4:7
+   ├────────────────────────────────────────────────
   1│ component Main {
   2│   fun render {
   3│     <<-TEST

--- a/spec/errors/here_document_expected_start
+++ b/spec/errors/here_document_expected_start
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the start tag of a here document but I found "a space" instead:
 
-   ┌ ./spec/errors/here_document_expected_start:3:7
-   ├───────────────────────────────────────────────
+   ┌ errors/here_document_expected_start:3:7
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render {
   3│     <<-

--- a/spec/errors/highlight_directive_expected_body
+++ b/spec/errors/highlight_directive_expected_body
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the body of a highlight directive but I found "a space" instead:
 
-   ┌ ./spec/errors/highlight_directive_expected_body:3:16
-   ├─────────────────────────────────────────────────────
+   ┌ errors/highlight_directive_expected_body:3:16
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @highlight {

--- a/spec/errors/highlight_directive_expected_closing_bracket
+++ b/spec/errors/highlight_directive_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of a highlight directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/highlight_directive_expected_closing_bracket:3:21
-   ├────────────────────────────────────────────────────────────────
+   ┌ errors/highlight_directive_expected_closing_bracket:3:21
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @highlight { test

--- a/spec/errors/highlight_directive_expected_opening_bracket
+++ b/spec/errors/highlight_directive_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of a highlight directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/highlight_directive_expected_opening_bracket:3:14
-   ├────────────────────────────────────────────────────────────────
+   ┌ errors/highlight_directive_expected_opening_bracket:3:14
+   ├─────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @highlight

--- a/spec/errors/html_attribute_component_key_type_mismatch
+++ b/spec/errors/html_attribute_component_key_type_mismatch
@@ -24,8 +24,8 @@ Instead it is:
 
 The attribute in question is here:
 
-    ┌ ./spec/errors/html_attribute_component_key_type_mismatch:9:8
-    ├─────────────────────────────────────────────────────────────
+    ┌ errors/html_attribute_component_key_type_mismatch:9:8
+    ├──────────────────────────────────────────────────────
    5│ }
    6│
    7│ component Main {

--- a/spec/errors/html_attribute_component_property_type_mismatch
+++ b/spec/errors/html_attribute_component_property_type_mismatch
@@ -27,8 +27,8 @@ Instead it is:
 
 The attribute in question is here:
 
-    ┌ ./spec/errors/html_attribute_component_property_type_mismatch:11:11
-    ├────────────────────────────────────────────────────────────────────
+    ┌ errors/html_attribute_component_property_type_mismatch:11:11
+    ├─────────────────────────────────────────────────────────────
    7│ }
    8│
    9│ component Main {

--- a/spec/errors/html_attribute_element_attribute_type_mismatch
+++ b/spec/errors/html_attribute_element_attribute_type_mismatch
@@ -19,8 +19,8 @@ Instead it is:
 
 The attribute in question is here:
 
-   ┌ ./spec/errors/html_attribute_element_attribute_type_mismatch:3:10
-   ├──────────────────────────────────────────────────────────────────
+   ┌ errors/html_attribute_element_attribute_type_mismatch:3:10
+   ├───────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div name={0}/>

--- a/spec/errors/html_attribute_expected_closing_bracket
+++ b/spec/errors/html_attribute_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of an HTML attribute but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_attribute_expected_closing_bracket:3:16
-   ├───────────────────────────────────────────────────────────
+   ┌ errors/html_attribute_expected_closing_bracket:3:16
+   ├────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div name={a

--- a/spec/errors/html_attribute_expected_equal_sign
+++ b/spec/errors/html_attribute_expected_equal_sign
@@ -7,8 +7,8 @@ component Main {
 I was expecting the equal sign of an HTML attribute but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_attribute_expected_equal_sign:3:13
-   ├──────────────────────────────────────────────────────
+   ┌ errors/html_attribute_expected_equal_sign:3:13
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div name

--- a/spec/errors/html_attribute_expected_expression
+++ b/spec/errors/html_attribute_expected_expression
@@ -7,8 +7,8 @@ component Main {
 I was expecting the expression of an HTML attribute but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_attribute_expected_expression:3:15
-   ├──────────────────────────────────────────────────────
+   ┌ errors/html_attribute_expected_expression:3:15
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div name={

--- a/spec/errors/html_attribute_expected_opening_bracket
+++ b/spec/errors/html_attribute_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of an HTML attribute but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_attribute_expected_opening_bracket:3:14
-   ├───────────────────────────────────────────────────────────
+   ┌ errors/html_attribute_expected_opening_bracket:3:14
+   ├────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div name=

--- a/spec/errors/html_attribute_not_found_component_property
+++ b/spec/errors/html_attribute_not_found_component_property
@@ -24,8 +24,8 @@ Maybe you want one of its properties:
 
 The attribute in question is here:
 
-    ┌ ./spec/errors/html_attribute_not_found_component_property:11:18
-    ├────────────────────────────────────────────────────────────────
+    ┌ errors/html_attribute_not_found_component_property:11:18
+    ├─────────────────────────────────────────────────────────
    7│ }
    8│
    9│ component Main {

--- a/spec/errors/html_component_attribute_required
+++ b/spec/errors/html_component_attribute_required
@@ -16,8 +16,8 @@ component Main {
 
 One of the required properties were not specified for a component:
 
-   ┌ ./spec/errors/html_component_attribute_required:2:3
-   ├────────────────────────────────────────────────────
+   ┌ errors/html_component_attribute_required:2:3
+   ├─────────────────────────────────────────────
   1│ component Test {
   2│   property name : String
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -28,8 +28,8 @@ One of the required properties were not specified for a component:
 
 The component was referenced here:
 
-    ┌ ./spec/errors/html_component_attribute_required:11:5
-    ├─────────────────────────────────────────────────────
+    ┌ errors/html_component_attribute_required:11:5
+    ├──────────────────────────────────────────────
    7│ }
    8│
    9│ component Main {

--- a/spec/errors/html_component_expected_closing_bracket
+++ b/spec/errors/html_component_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of a HTML component but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_component_expected_closing_bracket:3:9
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/html_component_expected_closing_bracket:3:9
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <Test

--- a/spec/errors/html_component_expected_closing_tag
+++ b/spec/errors/html_component_expected_closing_tag
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing tag of a HTML component but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_component_expected_closing_tag:3:10
-   ├───────────────────────────────────────────────────────
+   ┌ errors/html_component_expected_closing_tag:3:10
+   ├────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <Test>

--- a/spec/errors/html_component_expected_reference
+++ b/spec/errors/html_component_expected_reference
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the reference of the HTML component but I found "/>" instead:
 
-   ┌ ./spec/errors/html_component_expected_reference:3:14
-   ├─────────────────────────────────────────────────────
+   ┌ errors/html_component_expected_reference:3:14
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <Test as />

--- a/spec/errors/html_component_global_component
+++ b/spec/errors/html_component_global_component
@@ -15,8 +15,8 @@ component Main {
 Global components are added to the body and always rendered and cannot be used
 as regular components:
 
-    ┌ ./spec/errors/html_component_global_component:9:5
-    ├──────────────────────────────────────────────────
+    ┌ errors/html_component_global_component:9:5
+    ├───────────────────────────────────────────
    5│ }
    6│
    7│ component Main {
@@ -25,4 +25,3 @@ as regular components:
     │     ⌃⌃⌃⌃
   10│   }
   11│ }
-

--- a/spec/errors/html_component_not_found_component
+++ b/spec/errors/html_component_not_found_component
@@ -12,8 +12,8 @@ I was looking for a component but could not find one with the name:
 
 It's used here:
 
-   ┌ ./spec/errors/html_component_not_found_component:3:5
-   ├─────────────────────────────────────────────────────
+   ┌ errors/html_component_not_found_component:3:5
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <X/>

--- a/spec/errors/html_component_reference_outside_of_component
+++ b/spec/errors/html_component_reference_outside_of_component
@@ -20,8 +20,8 @@ component Main {
 
 Referencing components outside of components is not allowed:
 
-   ┌ ./spec/errors/html_component_reference_outside_of_component:3:14
-   ├─────────────────────────────────────────────────────────────────
+   ┌ errors/html_component_reference_outside_of_component:3:14
+   ├──────────────────────────────────────────────────────────
   1│ module X {
   2│   fun render : Html {
   3│     <Test as x/>

--- a/spec/errors/html_element_expected_closing_bracket
+++ b/spec/errors/html_element_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of an HTML element but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_element_expected_closing_bracket:3:9
-   ├────────────────────────────────────────────────────────
+   ┌ errors/html_element_expected_closing_bracket:3:9
+   ├─────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <test

--- a/spec/errors/html_element_expected_closing_tag
+++ b/spec/errors/html_element_expected_closing_tag
@@ -8,8 +8,8 @@ component Main {
 
 I was expecting the closing tag of an HTML element but I found "}" instead:
 
-   ┌ ./spec/errors/html_element_expected_closing_tag:4:3
-   ├────────────────────────────────────────────────────
+   ┌ errors/html_element_expected_closing_tag:4:3
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <test>

--- a/spec/errors/html_element_expected_reference
+++ b/spec/errors/html_element_expected_reference
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the reference of an HTML element but I found "/>" instead:
 
-   ┌ ./spec/errors/html_element_expected_reference:3:14
-   ├───────────────────────────────────────────────────
+   ┌ errors/html_element_expected_reference:3:14
+   ├────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <test as />

--- a/spec/errors/html_element_expected_style
+++ b/spec/errors/html_element_expected_style
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the style for an HTML element but I found "a space" instead:
 
-   ┌ ./spec/errors/html_element_expected_style:3:11
-   ├───────────────────────────────────────────────
+   ┌ errors/html_element_expected_style:3:11
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <test::

--- a/spec/errors/html_element_ref_forbidden
+++ b/spec/errors/html_element_ref_forbidden
@@ -8,8 +8,8 @@ component Main {
 
 The use of "ref" attribute is forbidden:
 
-   ┌ ./spec/errors/html_element_ref_forbidden:3:10
-   ├──────────────────────────────────────────────
+   ┌ errors/html_element_ref_forbidden:3:10
+   ├───────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div ref="Hello"/>

--- a/spec/errors/html_element_reference_outside_of_component
+++ b/spec/errors/html_element_reference_outside_of_component
@@ -14,8 +14,8 @@ component Main {
 
 Referencing elements outside of components is not allowed:
 
-   ┌ ./spec/errors/html_element_reference_outside_of_component:3:13
-   ├───────────────────────────────────────────────────────────────
+   ┌ errors/html_element_reference_outside_of_component:3:13
+   ├────────────────────────────────────────────────────────
   1│ module X {
   2│   fun render : Html {
   3│     <div as x/>

--- a/spec/errors/html_element_style_outside_of_component
+++ b/spec/errors/html_element_style_outside_of_component
@@ -14,8 +14,8 @@ component Main {
 
 Styling of elements outside of components is not allowed:
 
-   ┌ ./spec/errors/html_element_style_outside_of_component:3:5
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/html_element_style_outside_of_component:3:5
+   ├───────────────────────────────────────────────────
   1│ module X {
   2│   fun render : Html {
   3│     <div::base/>

--- a/spec/errors/html_fragment_expected_closing_tag
+++ b/spec/errors/html_fragment_expected_closing_tag
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing tag of an HTML fragment but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_fragment_expected_closing_tag:3:6
-   ├─────────────────────────────────────────────────────
+   ┌ errors/html_fragment_expected_closing_tag:3:6
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <>

--- a/spec/errors/html_style_argument_size_mismatch
+++ b/spec/errors/html_style_argument_size_mismatch
@@ -21,8 +21,8 @@ The type of the function is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/html_style_argument_size_mismatch:7:9
-    ├────────────────────────────────────────────────────
+    ┌ errors/html_style_argument_size_mismatch:7:9
+    ├─────────────────────────────────────────────
    3│     color: red;
    4│   }
    5│

--- a/spec/errors/html_style_argument_type_mismatch
+++ b/spec/errors/html_style_argument_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The call in question is here:
 
-    ┌ ./spec/errors/html_style_argument_type_mismatch:7:9
-    ├────────────────────────────────────────────────────
+    ┌ errors/html_style_argument_type_mismatch:7:9
+    ├─────────────────────────────────────────────
    3│     color: red;
    4│   }
    5│

--- a/spec/errors/html_style_expected_closing_parenthesis
+++ b/spec/errors/html_style_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of a style call but I found "a space"
 instead:
 
-   ┌ ./spec/errors/html_style_expected_closing_parenthesis:3:15
-   ├───────────────────────────────────────────────────────────
+   ┌ errors/html_style_expected_closing_parenthesis:3:15
+   ├────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div::root(

--- a/spec/errors/html_style_not_found
+++ b/spec/errors/html_style_not_found
@@ -8,8 +8,8 @@ component Main {
 
 I was looking for a style but it's not defined in the component:
 
-   ┌ ./spec/errors/html_style_not_found:3:9
-   ├───────────────────────────────────────
+   ┌ errors/html_style_not_found:3:9
+   ├────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     <div::base/>

--- a/spec/errors/if_condition_type_mismatch
+++ b/spec/errors/if_condition_type_mismatch
@@ -17,8 +17,8 @@ is:
 
 The condition in question is here:
 
-   ┌ ./spec/errors/if_condition_type_mismatch:3:8
-   ├─────────────────────────────────────────────
+   ┌ errors/if_condition_type_mismatch:3:8
+   ├──────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("a") {

--- a/spec/errors/if_else_type_mismatch
+++ b/spec/errors/if_else_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The value for the else branch is here:
 
-    ┌ ./spec/errors/if_else_type_mismatch:6:7
-    ├────────────────────────────────────────
+    ┌ errors/if_else_type_mismatch:6:7
+    ├─────────────────────────────────
    2│   fun render : String {
    3│     if ("a" == "b") {
    4│       "x"
@@ -33,4 +33,3 @@ The value for the else branch is here:
    7│     }
    8│   }
    9│ }
-

--- a/spec/errors/if_expected_condition
+++ b/spec/errors/if_expected_condition
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the condition but I found "a space" instead:
 
-   ┌ ./spec/errors/if_expected_condition:3:6
-   ├────────────────────────────────────────
+   ┌ errors/if_expected_condition:3:6
+   ├─────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if

--- a/spec/errors/if_expected_else_closing_bracket
+++ b/spec/errors/if_expected_else_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of the else branch but I found "a space"
 instead:
 
-   ┌ ./spec/errors/if_expected_else_closing_bracket:3:28
-   ├────────────────────────────────────────────────────
+   ┌ errors/if_expected_else_closing_bracket:3:28
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("") { "a" } else { a

--- a/spec/errors/if_expected_else_expression
+++ b/spec/errors/if_expected_else_expression
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting an expression for the else branch but I found "a space" instead:
 
-   ┌ ./spec/errors/if_expected_else_expression:3:26
-   ├───────────────────────────────────────────────
+   ┌ errors/if_expected_else_expression:3:26
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("") { "a" } else {

--- a/spec/errors/if_expected_else_opening_bracket
+++ b/spec/errors/if_expected_else_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of the else branch but I found "a space"
 instead:
 
-   ┌ ./spec/errors/if_expected_else_opening_bracket:3:24
-   ├────────────────────────────────────────────────────
+   ┌ errors/if_expected_else_opening_bracket:3:24
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("") { "a" } else

--- a/spec/errors/if_expected_truthy_closing_bracket
+++ b/spec/errors/if_expected_truthy_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of the truthy branch but I found "a space"
 instead:
 
-   ┌ ./spec/errors/if_expected_truthy_closing_bracket:3:15
-   ├──────────────────────────────────────────────────────
+   ┌ errors/if_expected_truthy_closing_bracket:3:15
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("") { a

--- a/spec/errors/if_expected_truthy_expression
+++ b/spec/errors/if_expected_truthy_expression
@@ -7,8 +7,8 @@ component Main {
 I was expecting an expression for the truthy branch but I found "a space"
 instead:
 
-   ┌ ./spec/errors/if_expected_truthy_expression:3:13
-   ├─────────────────────────────────────────────────
+   ┌ errors/if_expected_truthy_expression:3:13
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("") {

--- a/spec/errors/if_expected_truthy_opening_bracket
+++ b/spec/errors/if_expected_truthy_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of the truthy branch but I found "a space"
 instead:
 
-   ┌ ./spec/errors/if_expected_truthy_opening_bracket:3:11
-   ├──────────────────────────────────────────────────────
+   ┌ errors/if_expected_truthy_opening_bracket:3:11
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     if ("")

--- a/spec/errors/inline_directive_expected_closing_parenthesis
+++ b/spec/errors/inline_directive_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of an inline directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/inline_directive_expected_closing_parenthesis:3:16
-   ├─────────────────────────────────────────────────────────────────
+   ┌ errors/inline_directive_expected_closing_parenthesis:3:16
+   ├──────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @inline(path

--- a/spec/errors/inline_directive_expected_file
+++ b/spec/errors/inline_directive_expected_file
@@ -12,8 +12,8 @@ The path specified for an inline directive does not exist:
 
 The inline directive in question is here:
 
-   ┌ ./spec/errors/inline_directive_expected_file:3:5
-   ├─────────────────────────────────────────────────
+   ┌ errors/inline_directive_expected_file:3:5
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @inline(path)

--- a/spec/errors/inline_directive_expected_opening_parenthesis
+++ b/spec/errors/inline_directive_expected_opening_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening parenthesis of an inline directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/inline_directive_expected_opening_parenthesis:3:11
-   ├─────────────────────────────────────────────────────────────────
+   ┌ errors/inline_directive_expected_opening_parenthesis:3:11
+   ├──────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @inline

--- a/spec/errors/inline_directive_expected_path
+++ b/spec/errors/inline_directive_expected_path
@@ -7,8 +7,8 @@ component Main {
 I was expecting the path (to the file to be inlined) of an inline directive but
 I found "a space" instead:
 
-   ┌ ./spec/errors/inline_directive_expected_path:3:12
-   ├──────────────────────────────────────────────────
+   ┌ errors/inline_directive_expected_path:3:12
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @inline(

--- a/spec/errors/inline_function_expected_body
+++ b/spec/errors/inline_function_expected_body
@@ -6,10 +6,9 @@ component Main {
 
 I was expecting the body of an inline function but I found "a space" instead:
 
-   ┌ ./spec/errors/inline_function_expected_body:3:8
-   ├────────────────────────────────────────────────
+   ┌ errors/inline_function_expected_body:3:8
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     () {
    │         ⌃⌃⌃⌃
-

--- a/spec/errors/inline_function_expected_closing_bracket
+++ b/spec/errors/inline_function_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of an inline function but I found "a space"
 instead:
 
-   ┌ ./spec/errors/inline_function_expected_closing_bracket:3:10
-   ├────────────────────────────────────────────────────────────
+   ┌ errors/inline_function_expected_closing_bracket:3:10
+   ├─────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     () { a

--- a/spec/errors/inline_function_expected_closing_parenthesis
+++ b/spec/errors/inline_function_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of an inline function but I found "a
 space" instead:
 
-   ┌ ./spec/errors/inline_function_expected_closing_parenthesis:3:5
-   ├───────────────────────────────────────────────────────────────
+   ┌ errors/inline_function_expected_closing_parenthesis:3:5
+   ├────────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     (

--- a/spec/errors/inline_function_expected_opening_bracket
+++ b/spec/errors/inline_function_expected_opening_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening bracket of an inline function but I found "a space"
 instead:
 
-   ┌ ./spec/errors/inline_function_expected_opening_bracket:3:6
-   ├───────────────────────────────────────────────────────────
+   ┌ errors/inline_function_expected_opening_bracket:3:6
+   ├────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     ()

--- a/spec/errors/inline_function_expected_type
+++ b/spec/errors/inline_function_expected_type
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the type of an inline function but I found "a space" instead:
 
-   ┌ ./spec/errors/inline_function_expected_type:3:8
-   ├────────────────────────────────────────────────
+   ┌ errors/inline_function_expected_type:3:8
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     () :

--- a/spec/errors/inline_function_type_mismatch
+++ b/spec/errors/inline_function_type_mismatch
@@ -21,8 +21,8 @@ I was expecting:
 
 Which is defined here:
 
-   ┌ ./spec/errors/inline_function_type_mismatch:4:12
-   ├─────────────────────────────────────────────────
+   ┌ errors/inline_function_type_mismatch:4:12
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun test : String {
   3│     let a =
@@ -39,8 +39,8 @@ Instead it is:
 
 Which is returned here:
 
-   ┌ ./spec/errors/inline_function_type_mismatch:4:21
-   ├─────────────────────────────────────────────────
+   ┌ errors/inline_function_type_mismatch:4:21
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun test : String {
   3│     let a =

--- a/spec/errors/interpolation_expected_closing_bracket
+++ b/spec/errors/interpolation_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of an interpolation but I found "a space"
 instead:
 
-   ┌ ./spec/errors/interpolation_expected_closing_bracket:3:8
-   ├─────────────────────────────────────────────────────────
+   ┌ errors/interpolation_expected_closing_bracket:3:8
+   ├──────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "#{a

--- a/spec/errors/interpolation_expected_expression
+++ b/spec/errors/interpolation_expected_expression
@@ -7,8 +7,8 @@ component Main {
 I was expecting the expression of an interpolation but I found "a space"
 instead:
 
-   ┌ ./spec/errors/interpolation_expected_expression:3:7
-   ├────────────────────────────────────────────────────
+   ┌ errors/interpolation_expected_expression:3:7
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "#{

--- a/spec/errors/invalid_self_reference
+++ b/spec/errors/invalid_self_reference
@@ -14,8 +14,8 @@ initialized.
 
 Then entity you are referencing:
 
-   ┌ ./spec/errors/invalid_self_reference:2:3
-   ├─────────────────────────────────────────
+   ┌ errors/invalid_self_reference:2:3
+   ├──────────────────────────────────
   1│ component Main {
   2│   state c : String = b
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -26,8 +26,8 @@ Then entity you are referencing:
 
 The entity you are referencing it from:
 
-   ┌ ./spec/errors/invalid_self_reference:3:3
-   ├─────────────────────────────────────────
+   ┌ errors/invalid_self_reference:3:3
+   ├──────────────────────────────────
   1│ component Main {
   2│   state c : String = b
   3│   state b : String = ""

--- a/spec/errors/locale_expected_closing_bracket
+++ b/spec/errors/locale_expected_closing_bracket
@@ -4,7 +4,7 @@ locale en {
 
 I was expecting the opening bracket of a locale but I found "a space" instead:
 
-   ┌ ./spec/errors/locale_expected_closing_bracket:1:11
-   ├───────────────────────────────────────────────────
+   ┌ errors/locale_expected_closing_bracket:1:11
+   ├────────────────────────────────────────────
   1│ locale en {
    │            ⌃⌃⌃⌃

--- a/spec/errors/locale_expected_language
+++ b/spec/errors/locale_expected_language
@@ -4,7 +4,7 @@ locale
 
 I was expecting the language code of the locale but I found "a space" instead:
 
-   ┌ ./spec/errors/locale_expected_language:1:6
-   ├───────────────────────────────────────────
+   ┌ errors/locale_expected_language:1:6
+   ├────────────────────────────────────
   1│ locale
    │       ⌃⌃⌃⌃

--- a/spec/errors/locale_expected_opening_bracket
+++ b/spec/errors/locale_expected_opening_bracket
@@ -4,7 +4,7 @@ locale en
 
 I was expecting the opening bracket of a locale but I found "a space" instead:
 
-   ┌ ./spec/errors/locale_expected_opening_bracket:1:9
-   ├──────────────────────────────────────────────────
+   ┌ errors/locale_expected_opening_bracket:1:9
+   ├───────────────────────────────────────────
   1│ locale en
    │          ⌃⌃⌃⌃

--- a/spec/errors/module_expected_body
+++ b/spec/errors/module_expected_body
@@ -4,7 +4,7 @@ module Test {
 
 I was expecting the body of the module but I found "a space" instead:
 
-   ┌ ./spec/errors/module_expected_body:1:13
-   ├────────────────────────────────────────
+   ┌ errors/module_expected_body:1:13
+   ├─────────────────────────────────
   1│ module Test {
    │              ⌃⌃⌃⌃

--- a/spec/errors/module_expected_closing_bracket
+++ b/spec/errors/module_expected_closing_bracket
@@ -5,8 +5,8 @@ module Test {
 
 I was expecting the closing bracket of a module but I found "a space" instead:
 
-   ┌ ./spec/errors/module_expected_closing_bracket:2:17
-   ├───────────────────────────────────────────────────
+   ┌ errors/module_expected_closing_bracket:2:17
+   ├────────────────────────────────────────────
   1│ module Test {
   2│   const TEST = ""
    │                  ⌃⌃⌃⌃

--- a/spec/errors/module_expected_name
+++ b/spec/errors/module_expected_name
@@ -7,7 +7,7 @@ lowercase, uppercase letters and numbers.
 
 I was expecting name of the module but I found "a space" instead:
 
-   ┌ ./spec/errors/module_expected_name:1:6
-   ├───────────────────────────────────────
+   ┌ errors/module_expected_name:1:6
+   ├────────────────────────────────
   1│ module
    │       ⌃⌃⌃⌃

--- a/spec/errors/module_expected_opening_bracket
+++ b/spec/errors/module_expected_opening_bracket
@@ -4,7 +4,7 @@ module Test
 
 I was expecting the opening bracket of a module but I found "a space" instead:
 
-   ┌ ./spec/errors/module_expected_opening_bracket:1:11
-   ├───────────────────────────────────────────────────
+   ┌ errors/module_expected_opening_bracket:1:11
+   ├────────────────────────────────────────────
   1│ module Test
    │            ⌃⌃⌃⌃

--- a/spec/errors/negated_expression_expected_expression
+++ b/spec/errors/negated_expression_expected_expression
@@ -1,13 +1,14 @@
 component Main {
   fun render : String {
     !
---------------------------------------------------------------------------------░ ERROR (NEGATED_EXPRESSION_EXPECTED_EXPRESSION) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+--------------------------------------------------------------------------------
+░ ERROR (NEGATED_EXPRESSION_EXPECTED_EXPRESSION) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 I was expecting the expression of a negated expression but I found "a space"
 instead:
 
-   ┌ ./spec/errors/negated_expression_expected_expression:3:5
-   ├─────────────────────────────────────────────────────────
+   ┌ errors/negated_expression_expected_expression:3:5
+   ├──────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     !

--- a/spec/errors/negated_expression_not_bool
+++ b/spec/errors/negated_expression_not_bool
@@ -13,7 +13,8 @@ component Main {
     }
   }
 }
---------------------------------------------------------------------------------░ ERROR (NEGATED_EXPRESSION_NOT_BOOL) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+--------------------------------------------------------------------------------
+░ ERROR (NEGATED_EXPRESSION_NOT_BOOL) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 A negated expressions expression must evaluate to a boolean, but it is:
 
@@ -21,8 +22,8 @@ A negated expressions expression must evaluate to a boolean, but it is:
 
 The negated expression in question is here:
 
-   ┌ ./spec/errors/negated_expression_not_bool:3:5
-   ├──────────────────────────────────────────────
+   ┌ errors/negated_expression_not_bool:3:5
+   ├───────────────────────────────────────
   1│ module Test {
   2│   fun test : Bool {
   3│     !"asd"

--- a/spec/errors/next_call_expected_fields
+++ b/spec/errors/next_call_expected_fields
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the fields for a next call but I found "a" instead:
 
-   ┌ ./spec/errors/next_call_expected_fields:3:10
-   ├─────────────────────────────────────────────
+   ┌ errors/next_call_expected_fields:3:10
+   ├──────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     next a

--- a/spec/errors/next_call_invalid_invocation
+++ b/spec/errors/next_call_invalid_invocation
@@ -18,8 +18,8 @@ component Main {
 A next call can only called inside a component, store or provider but you tried
 to call it here:
 
-   ┌ ./spec/errors/next_call_invalid_invocation:3:5
-   ├───────────────────────────────────────────────
+   ┌ errors/next_call_invalid_invocation:3:5
+   ├────────────────────────────────────────
   1│ module Test {
   2│   fun test : Promise(Void) {
   3│     next { age: 30 }

--- a/spec/errors/next_call_state_not_found
+++ b/spec/errors/next_call_state_not_found
@@ -16,8 +16,8 @@ I was looking for a state but could not find it:
 
 The next call in question is here:
 
-    ┌ ./spec/errors/next_call_state_not_found:5:5
-    ├────────────────────────────────────────────
+    ┌ errors/next_call_state_not_found:5:5
+    ├─────────────────────────────────────
    1│ component Main {
    2│   state name : String = "Joe"
    3│

--- a/spec/errors/next_call_state_type_mismatch
+++ b/spec/errors/next_call_state_type_mismatch
@@ -24,8 +24,8 @@ But the type you are trying to assign to it is:
 
 Here is where you did the assignment:
 
-    ┌ ./spec/errors/next_call_state_type_mismatch:5:12
-    ├─────────────────────────────────────────────────
+    ┌ errors/next_call_state_type_mismatch:5:12
+    ├──────────────────────────────────────────
    1│ component Main {
    2│   state name : String = "Joe"
    3│
@@ -39,8 +39,8 @@ Here is where you did the assignment:
 
 And here is where the state is defined:
 
-   ┌ ./spec/errors/next_call_state_type_mismatch:2:3
-   ├────────────────────────────────────────────────
+   ┌ errors/next_call_state_type_mismatch:2:3
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   state name : String = "Joe"
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/number_literal_expected_decimal
+++ b/spec/errors/number_literal_expected_decimal
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the decimals for a number literal but I found "a space" instead:
 
-   ┌ ./spec/errors/number_literal_expected_decimal:3:6
-   ├──────────────────────────────────────────────────
+   ┌ errors/number_literal_expected_decimal:3:6
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     0.

--- a/spec/errors/operation_expected_expression
+++ b/spec/errors/operation_expected_expression
@@ -7,8 +7,8 @@ component Main {
 I was expecting the right side expression of an operation but I found "{"
 instead:
 
-   ┌ ./spec/errors/operation_expected_expression:3:11
-   ├─────────────────────────────────────────────────
+   ┌ errors/operation_expected_expression:3:11
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "A" + {

--- a/spec/errors/operation_numeric_type_mismatch
+++ b/spec/errors/operation_numeric_type_mismatch
@@ -22,8 +22,8 @@ Instead it is:
 
 The operation in question is here:
 
-   ┌ ./spec/errors/operation_numeric_type_mismatch:3:5
-   ├──────────────────────────────────────────────────
+   ┌ errors/operation_numeric_type_mismatch:3:5
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   fun test : Number {
   3│     "Hello" * 0

--- a/spec/errors/operation_or_not_maybe_or_result
+++ b/spec/errors/operation_or_not_maybe_or_result
@@ -23,8 +23,8 @@ Instead it is:
 
 The operation in question is here:
 
-    ┌ ./spec/errors/operation_or_not_maybe_or_result:8:5
-    ├───────────────────────────────────────────────────
+    ┌ errors/operation_or_not_maybe_or_result:8:5
+    ├────────────────────────────────────────────
    4│ }
    5│
    6│ component Main {

--- a/spec/errors/operation_or_type_mismatch
+++ b/spec/errors/operation_or_type_mismatch
@@ -24,8 +24,8 @@ Instead it is:
 
 The operation in question is here:
 
-    ┌ ./spec/errors/operation_or_type_mismatch:8:5
-    ├─────────────────────────────────────────────
+    ┌ errors/operation_or_type_mismatch:8:5
+    ├──────────────────────────────────────
    4│ }
    5│
    6│ component Main {

--- a/spec/errors/operation_pipe_ambiguous
+++ b/spec/errors/operation_pipe_ambiguous
@@ -15,7 +15,7 @@ ambiguous. Wrap operands in parentheses to avoid ambiguity.
 
 The piped call in question is here:
 
-    ┌ ./spec/errors/operation_pipe_ambiguous:7:15
+    ┌ errors/operation_pipe_ambiguous:7:15
     ├────────────────────────────────────────────
    3│     ""
    4│   }

--- a/spec/errors/operation_plus_type_mismatch
+++ b/spec/errors/operation_plus_type_mismatch
@@ -18,8 +18,8 @@ Instead it is:
 
 The operation in question is here:
 
-   ┌ ./spec/errors/operation_plus_type_mismatch:3:5
-   ├───────────────────────────────────────────────
+   ┌ errors/operation_plus_type_mismatch:3:5
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "Hello" + void

--- a/spec/errors/property_children_default_requried
+++ b/spec/errors/property_children_default_requried
@@ -20,8 +20,8 @@ There should be a default value for the children property:
 
 The property in question is here:
 
-   ┌ ./spec/errors/property_children_default_requried:2:3
-   ├─────────────────────────────────────────────────────
+   ┌ errors/property_children_default_requried:2:3
+   ├──────────────────────────────────────────────
   1│ component Test {
   2│   property children : Array(Html)
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/property_children_mismatch
+++ b/spec/errors/property_children_mismatch
@@ -24,8 +24,8 @@ Instead it is:
 
 The property in question is here:
 
-   ┌ ./spec/errors/property_children_mismatch:2:3
-   ├─────────────────────────────────────────────
+   ┌ errors/property_children_mismatch:2:3
+   ├──────────────────────────────────────
   1│ component Test {
   2│   property children : String
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/property_expected_default_value
+++ b/spec/errors/property_expected_default_value
@@ -5,8 +5,8 @@ component Test {
 
 I was expecting the default value of a property but I found "a space" instead:
 
-   ┌ ./spec/errors/property_expected_default_value:2:17
-   ├───────────────────────────────────────────────────
+   ┌ errors/property_expected_default_value:2:17
+   ├────────────────────────────────────────────
   1│ component Test {
   2│   property test =
    │                  ⌃⌃⌃⌃

--- a/spec/errors/property_expected_name
+++ b/spec/errors/property_expected_name
@@ -5,8 +5,8 @@ component Test {
 
 I was expecting the name of a property but I found "a space" instead:
 
-   ┌ ./spec/errors/property_expected_name:2:10
-   ├──────────────────────────────────────────
+   ┌ errors/property_expected_name:2:10
+   ├───────────────────────────────────
   1│ component Test {
   2│   property
    │           ⌃⌃⌃⌃

--- a/spec/errors/property_expected_type
+++ b/spec/errors/property_expected_type
@@ -5,8 +5,8 @@ component Test {
 
 I was expecting the type of a property but I found "a space" instead:
 
-   ┌ ./spec/errors/property_expected_type:2:17
-   ├──────────────────────────────────────────
+   ┌ errors/property_expected_type:2:17
+   ├───────────────────────────────────
   1│ component Test {
   2│   property test :
    │                  ⌃⌃⌃⌃

--- a/spec/errors/property_type_mismatch
+++ b/spec/errors/property_type_mismatch
@@ -26,8 +26,8 @@ Instead it is:
 
 The property in question is here:
 
-   ┌ ./spec/errors/property_type_mismatch:2:3
-   ├─────────────────────────────────────────
+   ┌ errors/property_type_mismatch:2:3
+   ├──────────────────────────────────
   1│ component Test {
   2│   property name : String = true
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/property_type_or_default_needed
+++ b/spec/errors/property_type_or_default_needed
@@ -16,8 +16,8 @@ component Main {
 
 The type or default value of a property needs to be defined, but neither was.
 
-   ┌ ./spec/errors/property_type_or_default_needed:2:3
-   ├──────────────────────────────────────────────────
+   ┌ errors/property_type_or_default_needed:2:3
+   ├───────────────────────────────────────────
   1│ component Test {
   2│   property name
    │   ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/property_with_type_variables
+++ b/spec/errors/property_with_type_variables
@@ -29,8 +29,8 @@ The type is:
 
 The property in question is here:
 
-    ┌ ./spec/errors/property_with_type_variables:7:3
-    ├───────────────────────────────────────────────
+    ┌ errors/property_with_type_variables:7:3
+    ├───────────────────────────────────────────
    3│   Just(a)
    4│ }
    5│

--- a/spec/errors/provider_expeceted_colon
+++ b/spec/errors/provider_expeceted_colon
@@ -4,7 +4,7 @@ provider Test
 
 I was expecting the colon of a provider but I found "a space" instead:
 
-   ┌ ./spec/errors/provider_expeceted_colon:1:13
-   ├────────────────────────────────────────────
+   ┌ errors/provider_expeceted_colon:1:13
+   ├─────────────────────────────────────
   1│ provider Test
    │              ⌃⌃⌃⌃

--- a/spec/errors/provider_expected_body
+++ b/spec/errors/provider_expected_body
@@ -4,7 +4,7 @@ provider Test : Test {
 
 I was expecting the body of a provider but I found "a space" instead:
 
-   ┌ ./spec/errors/provider_expected_body:1:22
-   ├──────────────────────────────────────────
+   ┌ errors/provider_expected_body:1:22
+   ├───────────────────────────────────
   1│ provider Test : Test {
    │                       ⌃⌃⌃⌃

--- a/spec/errors/provider_expected_closing_bracket
+++ b/spec/errors/provider_expected_closing_bracket
@@ -5,8 +5,8 @@ provider Test : Test {
 
 I was expecting the closing bracket of a provider but I found "a space" instead:
 
-   ┌ ./spec/errors/provider_expected_closing_bracket:2:17
-   ├─────────────────────────────────────────────────────
+   ┌ errors/provider_expected_closing_bracket:2:17
+   ├──────────────────────────────────────────────
   1│ provider Test : Test {
   2│   const TEST = ""
    │                  ⌃⌃⌃⌃

--- a/spec/errors/provider_expected_name
+++ b/spec/errors/provider_expected_name
@@ -4,7 +4,7 @@ provider
 
 I was expecting the name of a provider but I found "a space" instead:
 
-   ┌ ./spec/errors/provider_expected_name:1:8
-   ├─────────────────────────────────────────
+   ┌ errors/provider_expected_name:1:8
+   ├──────────────────────────────────
   1│ provider
    │         ⌃⌃⌃⌃

--- a/spec/errors/provider_expected_opening_bracket
+++ b/spec/errors/provider_expected_opening_bracket
@@ -4,7 +4,7 @@ provider Test : Test
 
 I was expecting the opening bracket of a provider but I found "a space" instead:
 
-   ┌ ./spec/errors/provider_expected_opening_bracket:1:20
-   ├─────────────────────────────────────────────────────
+   ┌ errors/provider_expected_opening_bracket:1:20
+   ├──────────────────────────────────────────────
   1│ provider Test : Test
    │                     ⌃⌃⌃⌃

--- a/spec/errors/provider_expected_subscription
+++ b/spec/errors/provider_expected_subscription
@@ -5,7 +5,7 @@ provider Test :
 I was expecting the subscription type of a provider but I found "a space"
 instead:
 
-   ┌ ./spec/errors/provider_expected_subscription:1:15
-   ├──────────────────────────────────────────────────
+   ┌ errors/provider_expected_subscription:1:15
+   ├───────────────────────────────────────────
   1│ provider Test :
    │                ⌃⌃⌃⌃

--- a/spec/errors/provider_not_found_subscription
+++ b/spec/errors/provider_not_found_subscription
@@ -9,8 +9,8 @@ provider Provider : Subscription {
 I was looking for the record type of the subscription "Subscription" but could
 not find it:
 
-   ┌ ./spec/errors/provider_not_found_subscription:1:1
-   ├──────────────────────────────────────────────────
+   ┌ errors/provider_not_found_subscription:1:1
+   ├───────────────────────────────────────────
   1│ provider Provider : Subscription {
   2│   fun test : Bool {
   3│     true

--- a/spec/errors/record_not_found_matching_record_definition
+++ b/spec/errors/record_not_found_matching_record_definition
@@ -16,8 +16,8 @@ I could not find a record that matches this structure:
 
 It was used here:
 
-   ┌ ./spec/errors/record_not_found_matching_record_definition:2:16
-   ├───────────────────────────────────────────────────────────────
+   ┌ errors/record_not_found_matching_record_definition:2:16
+   ├────────────────────────────────────────────────────────
   1│ component Main {
   2│   state data = { name: "" }
    │                ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/record_update_expected_closing_bracket
+++ b/spec/errors/record_update_expected_closing_bracket
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing bracket of a record update but I found "a space"
 instead:
 
-   ┌ ./spec/errors/record_update_expected_closing_bracket:3:15
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/record_update_expected_closing_bracket:3:15
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   get record : Record(String, Bool) {
   3│     { a | a: ""

--- a/spec/errors/record_update_expected_fields
+++ b/spec/errors/record_update_expected_fields
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the fields for a record update but I found "a space" instead:
 
-   ┌ ./spec/errors/record_update_expected_fields:3:9
-   ├────────────────────────────────────────────────
+   ┌ errors/record_update_expected_fields:3:9
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   get record : Record(String, Bool) {
   3│     { a |

--- a/spec/errors/record_update_not_found_key
+++ b/spec/errors/record_update_not_found_key
@@ -32,8 +32,8 @@ The field "c" does not exists on the target record:
 
 Here is where you tried to assign a value to it:
 
-    ┌ ./spec/errors/record_update_not_found_key:16:7
-    ├───────────────────────────────────────────────
+    ┌ errors/record_update_not_found_key:16:7
+    ├────────────────────────────────────────
   12│       }
   13│
   14│     { x |

--- a/spec/errors/record_update_not_updating_record
+++ b/spec/errors/record_update_not_updating_record
@@ -28,8 +28,8 @@ The target of a record update is not a record, instead it is:
 
 Here is where you want to update it:
 
-    ┌ ./spec/errors/record_update_not_updating_record:10:5
-    ├─────────────────────────────────────────────────────
+    ┌ errors/record_update_not_updating_record:10:5
+    ├──────────────────────────────────────────────
    6│ component Main {
    7│   fun test : Test {
    8│     let x = ""
@@ -47,8 +47,8 @@ Here is where you want to update it:
 
 Here is where the target is defined:
 
-    ┌ ./spec/errors/record_update_not_updating_record:8:9
-    ├────────────────────────────────────────────────────
+    ┌ errors/record_update_not_updating_record:8:9
+    ├─────────────────────────────────────────────
    4│ }
    5│
    6│ component Main {

--- a/spec/errors/record_update_type_mismatch
+++ b/spec/errors/record_update_type_mismatch
@@ -28,8 +28,8 @@ component Main {
 
 One of the updated fields of a record do not match its type:
 
-    ┌ ./spec/errors/record_update_type_mismatch:16:7
-    ├───────────────────────────────────────────────
+    ┌ errors/record_update_type_mismatch:16:7
+    ├────────────────────────────────────────
   12│       }
   13│
   14│     { x |
@@ -51,8 +51,8 @@ Instead it is:
 
 The record is here:
 
-    ┌ ./spec/errors/record_update_type_mismatch:8:9
-    ├──────────────────────────────────────────────
+    ┌ errors/record_update_type_mismatch:8:9
+    ├───────────────────────────────────────
    4│ }
    5│
    6│ component Main {

--- a/spec/errors/record_with_holes
+++ b/spec/errors/record_with_holes
@@ -7,8 +7,8 @@ type Test {
 
 Records with type variables are not allow at this time. I found one here:
 
-   ┌ ./spec/errors/record_with_holes:1:1
-   ├────────────────────────────────────
+   ┌ errors/record_with_holes:1:1
+   ├─────────────────────────────
   1│ type Test {
   2│   a : Array(a),
   3│   b : Number

--- a/spec/errors/recursion
+++ b/spec/errors/recursion
@@ -17,7 +17,7 @@ component Main {
 Recursion is only supported in specific cases at this time. Unfortunatly here is
 not supported:
 
-   ┌ ./spec/errors/recursion:2:3
+   ┌ errors/recursion:2:3
    ├────────────────────────────────────────
   1│ component Test {
   2│   property greeting : String = greeting
@@ -29,7 +29,7 @@ not supported:
 
 The previous step in the recursion was here:
 
-   ┌ ./spec/errors/recursion:2:32
+   ┌ errors/recursion:2:32
    ├────────────────────────────────────────
   1│ component Test {
   2│   property greeting : String = greeting

--- a/spec/errors/regexp_literal_expected_closing_slash
+++ b/spec/errors/regexp_literal_expected_closing_slash
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing slash of a regexp literal but I found "a space"
 instead:
 
-   ┌ ./spec/errors/regexp_literal_expected_closing_slash:3:8
-   ├────────────────────────────────────────────────────────
+   ┌ errors/regexp_literal_expected_closing_slash:3:8
+   ├─────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     /asd

--- a/spec/errors/route_expected_body
+++ b/spec/errors/route_expected_body
@@ -5,8 +5,8 @@ routes {
 
 I was expecting the body of a route but I found "a space" instead:
 
-   ┌ ./spec/errors/route_expected_body:2:5
-   ├──────────────────────────────────────
+   ┌ errors/route_expected_body:2:5
+   ├───────────────────────────────
   1│ routes {
   2│   * {
    │      ⌃⌃⌃⌃

--- a/spec/errors/route_expected_closing_bracket
+++ b/spec/errors/route_expected_closing_bracket
@@ -6,8 +6,8 @@ routes {
 
 I was expecting the closing bracket of a route but I found "a space" instead:
 
-   ┌ ./spec/errors/route_expected_closing_bracket:3:6
-   ├─────────────────────────────────────────────────
+   ┌ errors/route_expected_closing_bracket:3:6
+   ├──────────────────────────────────────────
   1│ routes {
   2│   * {
   3│     ""

--- a/spec/errors/route_expected_closing_parenthesis
+++ b/spec/errors/route_expected_closing_parenthesis
@@ -6,8 +6,8 @@ routes {
 I was expecting the closing parenthesis of a route but I found "a space"
 instead:
 
-   ┌ ./spec/errors/route_expected_closing_parenthesis:2:5
-   ├─────────────────────────────────────────────────────
+   ┌ errors/route_expected_closing_parenthesis:2:5
+   ├──────────────────────────────────────────────
   1│ routes {
   2│   * (
    │      ⌃⌃⌃⌃

--- a/spec/errors/route_expected_opening_bracket
+++ b/spec/errors/route_expected_opening_bracket
@@ -5,8 +5,8 @@ routes {
 
 I was expecting the opening bracket of a route but I found "a space" instead:
 
-   ┌ ./spec/errors/route_expected_opening_bracket:2:3
-   ├─────────────────────────────────────────────────
+   ┌ errors/route_expected_opening_bracket:2:3
+   ├──────────────────────────────────────────
   1│ routes {
   2│   *
    │    ⌃⌃⌃⌃

--- a/spec/errors/route_param_invalid
+++ b/spec/errors/route_param_invalid
@@ -8,8 +8,8 @@ routes {
 
 The type of a route parameter cannot be used in routes:
 
-   ┌ ./spec/errors/route_param_invalid:2:18
-   ├───────────────────────────────────────
+   ┌ errors/route_param_invalid:2:18
+   ├──────────────────────────────────
   1│ routes {
   2│   /:name (name : Array(String)) {
    │                  ⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃⌃
@@ -21,4 +21,3 @@ Only these types can be used as route parameters:
 
   String
   Number
-

--- a/spec/errors/routes_expected_body
+++ b/spec/errors/routes_expected_body
@@ -4,7 +4,7 @@ routes {
 
 I was expecting the body of a routes block but I found "a space" instead:
 
-   ┌ ./spec/errors/routes_expected_body:1:8
-   ├───────────────────────────────────────
+   ┌ errors/routes_expected_body:1:8
+   ├────────────────────────────────
   1│ routes {
    │         ⌃⌃⌃⌃

--- a/spec/errors/routes_expected_closing_bracket
+++ b/spec/errors/routes_expected_closing_bracket
@@ -8,8 +8,8 @@ routes {
 I was expecting the closing bracket of a routes block but I found "a space"
 instead:
 
-   ┌ ./spec/errors/routes_expected_closing_bracket:4:3
-   ├──────────────────────────────────────────────────
+   ┌ errors/routes_expected_closing_bracket:4:3
+   ├───────────────────────────────────────────
   1│ routes {
   2│   * {
   3│     ""

--- a/spec/errors/routes_expected_opening_bracket
+++ b/spec/errors/routes_expected_opening_bracket
@@ -5,7 +5,7 @@ routes
 I was expecting the opening bracket of a routes block but I found "a space"
 instead:
 
-   ┌ ./spec/errors/routes_expected_opening_bracket:1:6
-   ├──────────────────────────────────────────────────
+   ┌ errors/routes_expected_opening_bracket:1:6
+   ├───────────────────────────────────────────
   1│ routes
    │       ⌃⌃⌃⌃

--- a/spec/errors/signal_expected_block
+++ b/spec/errors/signal_expected_block
@@ -5,8 +5,8 @@ store Test {
 
 I was expecting the block of a signal but I found "a space" instead:
 
-   ┌ ./spec/errors/signal_expected_block:2:17
-   ├─────────────────────────────────────────
+   ┌ errors/signal_expected_block:2:17
+   ├──────────────────────────────────
   1│ store Test {
   2│   signal name : A
    │                  ⌃⌃⌃⌃

--- a/spec/errors/signal_expected_colon
+++ b/spec/errors/signal_expected_colon
@@ -6,8 +6,8 @@ store Test {
 I was expecting the colon separating the type from the signal but I found "a
 space" instead:
 
-   ┌ ./spec/errors/signal_expected_colon:2:13
-   ├─────────────────────────────────────────
+   ┌ errors/signal_expected_colon:2:13
+   ├──────────────────────────────────
   1│ store Test {
   2│   signal name
    │              ⌃⌃⌃⌃

--- a/spec/errors/signal_expected_name
+++ b/spec/errors/signal_expected_name
@@ -5,8 +5,8 @@ store Test {
 
 I was expecting the name of a signal but I found "a space" instead:
 
-   ┌ ./spec/errors/signal_expected_name:2:8
-   ├───────────────────────────────────────
+   ┌ errors/signal_expected_name:2:8
+   ├────────────────────────────────
   1│ store Test {
   2│   signal
    │         ⌃⌃⌃⌃

--- a/spec/errors/signal_expected_type
+++ b/spec/errors/signal_expected_type
@@ -5,8 +5,8 @@ store Test {
 
 I was expecting the type of a signal but I found "a space" instead:
 
-   ┌ ./spec/errors/signal_expected_type:2:15
-   ├────────────────────────────────────────
+   ┌ errors/signal_expected_type:2:15
+   ├─────────────────────────────────
   1│ store Test {
   2│   signal name :
    │                ⌃⌃⌃⌃

--- a/spec/errors/signal_type_mismatch
+++ b/spec/errors/signal_type_mismatch
@@ -17,8 +17,8 @@ Instead it is:
 
 The block in question is here:
 
-   ┌ ./spec/errors/signal_type_mismatch:2:21
-   ├────────────────────────────────────────
+   ┌ errors/signal_type_mismatch:2:21
+   ├─────────────────────────────────
   1│ store Test {
   2│   signal b : String { 0 }
    │                     ⌃⌃⌃⌃⌃

--- a/spec/errors/spread_expected_variable
+++ b/spec/errors/spread_expected_variable
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the name of a spread but I found "a space" instead:
 
-   ┌ ./spec/errors/spread_expected_variable:3:15
-   ├────────────────────────────────────────────
+   ┌ errors/spread_expected_variable:3:15
+   ├─────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     let [x, ...

--- a/spec/errors/state_expected_default_value
+++ b/spec/errors/state_expected_default_value
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the default value of a state but I found "a space" instead:
 
-   ┌ ./spec/errors/state_expected_default_value:2:14
-   ├────────────────────────────────────────────────
+   ┌ errors/state_expected_default_value:2:14
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   state test =
    │               ⌃⌃⌃⌃

--- a/spec/errors/state_expected_equal_sign
+++ b/spec/errors/state_expected_equal_sign
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the equal sign of a state but I found "a space" instead:
 
-   ┌ ./spec/errors/state_expected_equal_sign:2:12
-   ├─────────────────────────────────────────────
+   ┌ errors/state_expected_equal_sign:2:12
+   ├──────────────────────────────────────
   1│ component Main {
   2│   state test
    │             ⌃⌃⌃⌃

--- a/spec/errors/state_expected_name
+++ b/spec/errors/state_expected_name
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the name of a state but I found "a space" instead:
 
-   ┌ ./spec/errors/state_expected_name:2:7
-   ├──────────────────────────────────────
+   ┌ errors/state_expected_name:2:7
+   ├───────────────────────────────
   1│ component Main {
   2│   state
    │        ⌃⌃⌃⌃

--- a/spec/errors/state_expected_type
+++ b/spec/errors/state_expected_type
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the type value of a state but I found "a space" instead:
 
-   ┌ ./spec/errors/state_expected_type:2:14
-   ├───────────────────────────────────────
+   ┌ errors/state_expected_type:2:14
+   ├────────────────────────────────
   1│ component Main {
   2│   state test :
    │               ⌃⌃⌃⌃

--- a/spec/errors/state_type_mismatch
+++ b/spec/errors/state_type_mismatch
@@ -10,8 +10,8 @@ component Main {
 
 The type of the default value of the a state does not match its type annotation:
 
-   ┌ ./spec/errors/state_type_mismatch:2:22
-   ├───────────────────────────────────────
+   ┌ errors/state_type_mismatch:2:22
+   ├────────────────────────────────
   1│ component Main {
   2│   state b : String = 0
    │                      ⌃
@@ -27,4 +27,3 @@ I was expecting:
 Instead it is:
 
   Number
-

--- a/spec/errors/statement_last_target
+++ b/spec/errors/statement_last_target
@@ -8,8 +8,8 @@ component Main {
 
 The last statement of a block cannot be an assignment:
 
-   ┌ ./spec/errors/statement_last_target:2:23
-   ├─────────────────────────────────────────
+   ┌ errors/statement_last_target:2:23
+   ├──────────────────────────────────
   1│ component Main {
    │   ⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄⌄
   2│   fun render : String {

--- a/spec/errors/statement_return_required
+++ b/spec/errors/statement_return_required
@@ -10,8 +10,8 @@ component Main {
 
 This statement needs a return call because the destructuring is not exhaustive:
 
-   ┌ ./spec/errors/statement_return_required:3:5
-   ├────────────────────────────────────────────
+   ┌ errors/statement_return_required:3:5
+   ├─────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     let [a, b] = []

--- a/spec/errors/statement_return_type_mismatch
+++ b/spec/errors/statement_return_type_mismatch
@@ -24,8 +24,8 @@ I was expecting:
 
 It return call in question is here:
 
-    ┌ ./spec/errors/statement_return_type_mismatch:9:33
-    ├──────────────────────────────────────────────────
+    ┌ errors/statement_return_type_mismatch:9:33
+    ├───────────────────────────────────────────
    5│
    6│ component Main {
    7│   fun render : String {
@@ -39,8 +39,8 @@ It return call in question is here:
 
 The returned value of the block is here:
 
-    ┌ ./spec/errors/statement_return_type_mismatch:11:5
-    ├──────────────────────────────────────────────────
+    ┌ errors/statement_return_type_mismatch:11:5
+    ├───────────────────────────────────────────
    7│   fun render : String {
    8│     let Test.B(x) =
    9│       Test.A("Hello") or return 0

--- a/spec/errors/store_expected_body
+++ b/spec/errors/store_expected_body
@@ -4,7 +4,7 @@ store X {
 
 I was expecting the body of a store but I found "a space" instead:
 
-   ┌ ./spec/errors/store_expected_body:1:9
-   ├──────────────────────────────────────
+   ┌ errors/store_expected_body:1:9
+   ├───────────────────────────────
   1│ store X {
    │          ⌃⌃⌃⌃

--- a/spec/errors/store_expected_closing_bracket
+++ b/spec/errors/store_expected_closing_bracket
@@ -5,8 +5,8 @@ store X {
 
 I was expecting the closing bracket of a store but I found "a space" instead:
 
-   ┌ ./spec/errors/store_expected_closing_bracket:2:26
-   ├──────────────────────────────────────────────────
+   ┌ errors/store_expected_closing_bracket:2:26
+   ├───────────────────────────────────────────
   1│ store X {
   2│   state test : String = ""
    │                           ⌃⌃⌃⌃

--- a/spec/errors/store_expected_name
+++ b/spec/errors/store_expected_name
@@ -4,7 +4,7 @@ store
 
 I was expecting the name of a store but I found "a space" instead:
 
-   ┌ ./spec/errors/store_expected_name:1:5
-   ├──────────────────────────────────────
+   ┌ errors/store_expected_name:1:5
+   ├───────────────────────────────
   1│ store
    │      ⌃⌃⌃⌃

--- a/spec/errors/store_expected_opening_bracket
+++ b/spec/errors/store_expected_opening_bracket
@@ -4,7 +4,7 @@ store X
 
 I was expecting the opening bracket of a store but I found "a space" instead:
 
-   ┌ ./spec/errors/store_expected_opening_bracket:1:7
-   ├─────────────────────────────────────────────────
+   ┌ errors/store_expected_opening_bracket:1:7
+   ├──────────────────────────────────────────
   1│ store X
    │        ⌃⌃⌃⌃

--- a/spec/errors/string_expected_closing_quote
+++ b/spec/errors/string_expected_closing_quote
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing quoute of a string literal but I found "a space"
 instead:
 
-   ┌ ./spec/errors/string_expected_closing_quote:3:5
-   ├────────────────────────────────────────────────
+   ┌ errors/string_expected_closing_quote:3:5
+   ├─────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "

--- a/spec/errors/string_expected_other_string
+++ b/spec/errors/string_expected_other_string
@@ -7,8 +7,8 @@ component Main {
 I was expecting another string literal after a string separator but I found "a
 space" instead:
 
-   ┌ ./spec/errors/string_expected_other_string:3:8
-   ├───────────────────────────────────────────────
+   ┌ errors/string_expected_other_string:3:8
+   ├────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     "" \

--- a/spec/errors/string_literal_interpolation_type_mismatch
+++ b/spec/errors/string_literal_interpolation_type_mismatch
@@ -18,8 +18,8 @@ Instead it is:
 
 The interpolation in question is here:
 
-   ┌ ./spec/errors/string_literal_interpolation_type_mismatch:5:18
-   ├──────────────────────────────────────────────────────────────
+   ┌ errors/string_literal_interpolation_type_mismatch:5:18
+   ├───────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     let name = void

--- a/spec/errors/style_expected_body
+++ b/spec/errors/style_expected_body
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the body of a style but I found "a space" instead:
 
-   ┌ ./spec/errors/style_expected_body:2:11
-   ├───────────────────────────────────────
+   ┌ errors/style_expected_body:2:11
+   ├────────────────────────────────
   1│ component Main {
   2│   style x {
    │            ⌃⌃⌃⌃

--- a/spec/errors/style_expected_closing_bracket
+++ b/spec/errors/style_expected_closing_bracket
@@ -6,8 +6,8 @@ component Main {
 
 I was expecting the closing bracket of a style but I found "a space" instead:
 
-   ┌ ./spec/errors/style_expected_closing_bracket:3:15
-   ├──────────────────────────────────────────────────
+   ┌ errors/style_expected_closing_bracket:3:15
+   ├───────────────────────────────────────────
   1│ component Main {
   2│   style x {
   3│     color: red;

--- a/spec/errors/style_expected_closing_parenthesis
+++ b/spec/errors/style_expected_closing_parenthesis
@@ -6,8 +6,8 @@ component Main {
 I was expecting the closing parenthesis of a style but I found "a space"
 instead:
 
-   ┌ ./spec/errors/style_expected_closing_parenthesis:2:11
-   ├──────────────────────────────────────────────────────
+   ┌ errors/style_expected_closing_parenthesis:2:11
+   ├───────────────────────────────────────────────
   1│ component Main {
   2│   style x (
    │            ⌃⌃⌃⌃

--- a/spec/errors/style_expected_name
+++ b/spec/errors/style_expected_name
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the name of a style but I found "a space" instead:
 
-   ┌ ./spec/errors/style_expected_name:2:7
-   ├──────────────────────────────────────
+   ┌ errors/style_expected_name:2:7
+   ├───────────────────────────────
   1│ component Main {
   2│   style
    │        ⌃⌃⌃⌃

--- a/spec/errors/style_expected_opening_bracket
+++ b/spec/errors/style_expected_opening_bracket
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the opening bracket of a style but I found "a space" instead:
 
-   ┌ ./spec/errors/style_expected_opening_bracket:2:9
-   ├─────────────────────────────────────────────────
+   ┌ errors/style_expected_opening_bracket:2:9
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   style x
    │          ⌃⌃⌃⌃

--- a/spec/errors/suite_expected_body
+++ b/spec/errors/suite_expected_body
@@ -4,7 +4,7 @@ suite "X" {
 
 I was expecting the body of a suite but I found "a space" instead:
 
-   ┌ ./spec/errors/suite_expected_body:1:11
-   ├───────────────────────────────────────
+   ┌ errors/suite_expected_body:1:11
+   ├────────────────────────────────
   1│ suite "X" {
    │            ⌃⌃⌃⌃

--- a/spec/errors/suite_expected_closing_bracket
+++ b/spec/errors/suite_expected_closing_bracket
@@ -7,8 +7,8 @@ suite "X" {
 
 I was expecting the closing bracket of a suite but I found "a space" instead:
 
-   ┌ ./spec/errors/suite_expected_closing_bracket:4:3
-   ├─────────────────────────────────────────────────
+   ┌ errors/suite_expected_closing_bracket:4:3
+   ├──────────────────────────────────────────
   1│ suite "X" {
   2│   test "X" {
   3│     true

--- a/spec/errors/suite_expected_name
+++ b/spec/errors/suite_expected_name
@@ -4,7 +4,7 @@ suite
 
 I was expecting the name of a suite but I found "a space" instead:
 
-   ┌ ./spec/errors/suite_expected_name:1:5
-   ├──────────────────────────────────────
+   ┌ errors/suite_expected_name:1:5
+   ├───────────────────────────────
   1│ suite
    │      ⌃⌃⌃⌃

--- a/spec/errors/suite_expected_opening_bracket
+++ b/spec/errors/suite_expected_opening_bracket
@@ -4,7 +4,7 @@ suite "X"
 
 I was expecting the opening bracket of a suite but I found "a space" instead:
 
-   ┌ ./spec/errors/suite_expected_opening_bracket:1:9
-   ├─────────────────────────────────────────────────
+   ┌ errors/suite_expected_opening_bracket:1:9
+   ├──────────────────────────────────────────
   1│ suite "X"
    │          ⌃⌃⌃⌃

--- a/spec/errors/svg_directive_expected_closing_parenthesis
+++ b/spec/errors/svg_directive_expected_closing_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the closing parenthesis of an svg directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/svg_directive_expected_closing_parenthesis:3:13
-   ├──────────────────────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_closing_parenthesis:3:13
+   ├───────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @svg(path

--- a/spec/errors/svg_directive_expected_dimensions
+++ b/spec/errors/svg_directive_expected_dimensions
@@ -19,8 +19,8 @@ These are the first few lines of the file:
 
 The svg directive in question is here:
 
-   ┌ ./spec/errors/svg_directive_expected_dimensions:3:5
-   ├────────────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_dimensions:3:5
+   ├─────────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     @svg(../fixtures/icon-no-dimensions)

--- a/spec/errors/svg_directive_expected_file
+++ b/spec/errors/svg_directive_expected_file
@@ -12,8 +12,8 @@ The specified file for an svg directive does not exist:
 
 The svg directive in question is here:
 
-   ┌ ./spec/errors/svg_directive_expected_file:3:5
-   ├──────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_file:3:5
+   ├───────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     @svg(../../fixtures/icon-missing)

--- a/spec/errors/svg_directive_expected_opening_parenthesis
+++ b/spec/errors/svg_directive_expected_opening_parenthesis
@@ -7,8 +7,8 @@ component Main {
 I was expecting the opening parenthesis of an svg directive but I found "a
 space" instead:
 
-   ┌ ./spec/errors/svg_directive_expected_opening_parenthesis:3:8
-   ├─────────────────────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_opening_parenthesis:3:8
+   ├──────────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @svg

--- a/spec/errors/svg_directive_expected_path
+++ b/spec/errors/svg_directive_expected_path
@@ -7,8 +7,8 @@ component Main {
 I was expecting the path (to the svg) of an svg directive but I found "a space"
 instead:
 
-   ┌ ./spec/errors/svg_directive_expected_path:3:9
-   ├──────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_path:3:9
+   ├───────────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     @svg(

--- a/spec/errors/svg_directive_expected_svg
+++ b/spec/errors/svg_directive_expected_svg
@@ -17,8 +17,8 @@ These are the first few lines of the file:
 
 The svg directive in question is here:
 
-   ┌ ./spec/errors/svg_directive_expected_svg:3:5
-   ├─────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_svg:3:5
+   ├──────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     @svg(../fixtures/icon-not-svg)

--- a/spec/errors/svg_directive_expected_svg_tag
+++ b/spec/errors/svg_directive_expected_svg_tag
@@ -13,8 +13,8 @@ the first few lines of the file:
 
 The svg directive in question is here:
 
-   ┌ ./spec/errors/svg_directive_expected_svg_tag:3:5
-   ├─────────────────────────────────────────────────
+   ┌ errors/svg_directive_expected_svg_tag:3:5
+   ├──────────────────────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     @svg(../fixtures/icon-no-svg-tag)

--- a/spec/errors/test_expected_body
+++ b/spec/errors/test_expected_body
@@ -5,8 +5,8 @@ suite "X" {
 
 I was expecting the body of a test but I found "a space" instead:
 
-   ┌ ./spec/errors/test_expected_body:2:12
-   ├──────────────────────────────────────
+   ┌ errors/test_expected_body:2:12
+   ├───────────────────────────────
   1│ suite "X" {
   2│   test "X" {
    │             ⌃⌃⌃⌃

--- a/spec/errors/test_expected_closing_bracket
+++ b/spec/errors/test_expected_closing_bracket
@@ -6,8 +6,8 @@ suite "X" {
 
 I was expecting the closing bracket of a test but I found "a space" instead:
 
-   ┌ ./spec/errors/test_expected_closing_bracket:3:6
-   ├────────────────────────────────────────────────
+   ┌ errors/test_expected_closing_bracket:3:6
+   ├─────────────────────────────────────────
   1│ suite "X" {
   2│   test "X" {
   3│     ""

--- a/spec/errors/test_expected_name
+++ b/spec/errors/test_expected_name
@@ -5,8 +5,8 @@ suite "X" {
 
 I was expecting the name of a test but I found "a space" instead:
 
-   ┌ ./spec/errors/test_expected_name:2:6
-   ├─────────────────────────────────────
+   ┌ errors/test_expected_name:2:6
+   ├──────────────────────────────
   1│ suite "X" {
   2│   test
    │       ⌃⌃⌃⌃

--- a/spec/errors/test_expected_opening_bracket
+++ b/spec/errors/test_expected_opening_bracket
@@ -5,8 +5,8 @@ suite "X" {
 
 I was expecting the opening bracket of a test but I found "a space" instead:
 
-   ┌ ./spec/errors/test_expected_opening_bracket:2:10
-   ├─────────────────────────────────────────────────
+   ┌ errors/test_expected_opening_bracket:2:10
+   ├──────────────────────────────────────────
   1│ suite "X" {
   2│   test "X"
    │           ⌃⌃⌃⌃

--- a/spec/errors/test_type_mismatch
+++ b/spec/errors/test_type_mismatch
@@ -21,8 +21,8 @@ Instead it is:
 
 The test in question is here:
 
-   ┌ ./spec/errors/test_type_mismatch:3:5
-   ├─────────────────────────────────────
+   ┌ errors/test_type_mismatch:3:5
+   ├──────────────────────────────
   1│ suite "X" {
   2│   test "X" {
   3│     "true"

--- a/spec/errors/translation_mismatch
+++ b/spec/errors/translation_mismatch
@@ -27,8 +27,8 @@ Instead it is:
 
 The defined value in language "hu" is here:
 
-    ┌ ./spec/errors/translation_mismatch:6:9
-    ├───────────────────────────────────────
+    ┌ errors/translation_mismatch:6:9
+    ├────────────────────────────────
    2│   test: ""
    3│ }
    4│
@@ -42,8 +42,8 @@ The defined value in language "hu" is here:
 
 The defined value in language "en" is here:
 
-   ┌ ./spec/errors/translation_mismatch:2:9
-   ├───────────────────────────────────────
+   ┌ errors/translation_mismatch:2:9
+   ├────────────────────────────────
   1│ locale en {
   2│   test: ""
    │         ⌃⌃
@@ -54,8 +54,8 @@ The defined value in language "en" is here:
 
 The locale key in question is here:
 
-    ┌ ./spec/errors/translation_mismatch:11:5
-    ├────────────────────────────────────────
+    ┌ errors/translation_mismatch:11:5
+    ├─────────────────────────────────
    7│ }
    8│
    9│ component Main {

--- a/spec/errors/translation_missing
+++ b/spec/errors/translation_missing
@@ -8,8 +8,8 @@ component Main {
 
 Translations are not specified for this key:
 
-   ┌ ./spec/errors/translation_missing:3:5
-   ├──────────────────────────────────────
+   ┌ errors/translation_missing:3:5
+   ├───────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     :test

--- a/spec/errors/translation_not_translated
+++ b/spec/errors/translation_not_translated
@@ -18,8 +18,8 @@ There is no translation for the key "test" in the language "hu".
 
 The locale key in question is here:
 
-    ┌ ./spec/errors/translation_not_translated:11:5
-    ├──────────────────────────────────────────────
+    ┌ errors/translation_not_translated:11:5
+    ├───────────────────────────────────────
    7│ }
    8│
    9│ component Main {

--- a/spec/errors/type_definition_expected_closing_parenthesis
+++ b/spec/errors/type_definition_expected_closing_parenthesis
@@ -5,7 +5,7 @@ type A {
 I was expecting the closing bracket of a type definition but I found "a space"
 instead:
 
-   ┌ ./spec/errors/type_definition_expected_closing_parenthesis:1:8
-   ├───────────────────────────────────────────────────────────────
+   ┌ errors/type_definition_expected_closing_parenthesis:1:8
+   ├────────────────────────────────────────────────────────
   1│ type A {
    │         ⌃⌃⌃⌃

--- a/spec/errors/type_definition_expected_name
+++ b/spec/errors/type_definition_expected_name
@@ -4,7 +4,7 @@ type
 
 I was expecting the name of a type but I found "a space" instead:
 
-   ┌ ./spec/errors/type_definition_expected_name:1:4
-   ├────────────────────────────────────────────────
+   ┌ errors/type_definition_expected_name:1:4
+   ├─────────────────────────────────────────
   1│ type
    │     ⌃⌃⌃⌃

--- a/spec/errors/type_definition_field_expected_colon
+++ b/spec/errors/type_definition_field_expected_colon
@@ -6,8 +6,8 @@ type A {
 I was expecting the colon separating a type field from the type but I found "a
 space" instead:
 
-   ┌ ./spec/errors/type_definition_field_expected_colon:2:3
-   ├───────────────────────────────────────────────────────
+   ┌ errors/type_definition_field_expected_colon:2:3
+   ├────────────────────────────────────────────────
   1│ type A {
   2│   x
    │    ⌃⌃⌃⌃

--- a/spec/errors/type_definition_field_expected_mapping
+++ b/spec/errors/type_definition_field_expected_mapping
@@ -5,8 +5,8 @@ type A {
 
 I was expecting the mapping of a record field but I found "a space" instead:
 
-   ┌ ./spec/errors/type_definition_field_expected_mapping:2:17
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/type_definition_field_expected_mapping:2:17
+   ├───────────────────────────────────────────────────
   1│ type A {
   2│   x: String using
    │                  ⌃⌃⌃⌃

--- a/spec/errors/type_definition_field_expected_type
+++ b/spec/errors/type_definition_field_expected_type
@@ -5,8 +5,8 @@ type A {
 
 I was expecting the type of a type field but I found "a space" instead:
 
-   ┌ ./spec/errors/type_definition_field_expected_type:2:4
-   ├──────────────────────────────────────────────────────
+   ┌ errors/type_definition_field_expected_type:2:4
+   ├───────────────────────────────────────────────
   1│ type A {
   2│   x:
    │     ⌃⌃⌃⌃

--- a/spec/errors/type_definition_not_defined_parameter
+++ b/spec/errors/type_definition_not_defined_parameter
@@ -7,8 +7,8 @@ type A {
 Parameters used by options must be defined in the the type definition. This
 parameter was not defined in the type definition:
 
-   ┌ ./spec/errors/type_definition_not_defined_parameter:2:5
-   ├────────────────────────────────────────────────────────
+   ┌ errors/type_definition_not_defined_parameter:2:5
+   ├─────────────────────────────────────────────────
   1│ type A {
   2│   B(a)
    │     ⌃

--- a/spec/errors/type_definition_unused_parameter
+++ b/spec/errors/type_definition_unused_parameter
@@ -8,8 +8,8 @@ type A(a, b, c) {
 Type parameters must be used by at least one option. This parameter was not used
 by any of the options:
 
-   ┌ ./spec/errors/type_definition_unused_parameter:1:8
-   ├───────────────────────────────────────────────────
+   ┌ errors/type_definition_unused_parameter:1:8
+   ├────────────────────────────────────────────
   1│ type A(a, b, c) {
    │        ⌃
   2│   B

--- a/spec/errors/type_destructuring_expected_closing_parenthesis
+++ b/spec/errors/type_destructuring_expected_closing_parenthesis
@@ -8,11 +8,10 @@ module Test {
 I was expecting the closing parenthesis of an type destructuring but I found "a
 space" instead:
 
-   ┌ ./spec/errors/type_destructuring_expected_closing_parenthesis:4:10
-   ├───────────────────────────────────────────────────────────────────
+   ┌ errors/type_destructuring_expected_closing_parenthesis:4:10
+   ├────────────────────────────────────────────────────────────
   1│ module Test {
   2│   fun toString (status : Status) : String {
   3│     case (status) {
   4│       A.B(
    │           ⌃⌃⌃⌃
-

--- a/spec/errors/type_destructuring_expected_variant
+++ b/spec/errors/type_destructuring_expected_variant
@@ -7,8 +7,8 @@ module Test {
 
 I was expecting the type of an type destructuring but I found "a space" instead:
 
-   ┌ ./spec/errors/type_destructuring_expected_variant:4:9
-   ├──────────────────────────────────────────────────────
+   ┌ errors/type_destructuring_expected_variant:4:9
+   ├───────────────────────────────────────────────
   1│ module Test {
   2│   fun toString (status : Status) : String {
   3│     case (status) {

--- a/spec/errors/type_expected_closing_parenthesis
+++ b/spec/errors/type_expected_closing_parenthesis
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the closing parenthesis of a type but I found "a space" instead:
 
-   ┌ ./spec/errors/type_expected_closing_parenthesis:2:18
-   ├─────────────────────────────────────────────────────
+   ┌ errors/type_expected_closing_parenthesis:2:18
+   ├──────────────────────────────────────────────
   1│ component Main {
   2│   fun render : X(Y
    │                   ⌃⌃⌃⌃

--- a/spec/errors/type_expected_type_or_type_variable
+++ b/spec/errors/type_expected_type_or_type_variable
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting a type or a type variable but I found "a space" instead:
 
-   ┌ ./spec/errors/type_expected_type_or_type_variable:2:17
-   ├───────────────────────────────────────────────────────
+   ┌ errors/type_expected_type_or_type_variable:2:17
+   ├────────────────────────────────────────────────
   1│ component Main {
   2│   fun render : X(
    │                  ⌃⌃⌃⌃

--- a/spec/errors/type_variant_expected_closing_parenthesis
+++ b/spec/errors/type_variant_expected_closing_parenthesis
@@ -6,8 +6,8 @@ type Test {
 I was expecting the closing parenthesis of an type variant but I found "a space"
 instead:
 
-   ┌ ./spec/errors/type_variant_expected_closing_parenthesis:2:4
-   ├────────────────────────────────────────────────────────────
+   ┌ errors/type_variant_expected_closing_parenthesis:2:4
+   ├─────────────────────────────────────────────────────
   1│ type Test {
   2│   A(
    │     ⌃⌃⌃⌃

--- a/spec/errors/unary_minus_not_number
+++ b/spec/errors/unary_minus_not_number
@@ -14,8 +14,8 @@ An unary minuses expression must evaluate to number. Instead it is:
 
 The unary minus in question is here:
 
-   ┌ ./spec/errors/unary_minus_not_number:3:5
-   ├─────────────────────────────────────────
+   ┌ errors/unary_minus_not_number:3:5
+   ├──────────────────────────────────
   1│ component Main {
   2│   fun render : String {
   3│     -"ASD"

--- a/spec/errors/unkown_builtin
+++ b/spec/errors/unkown_builtin
@@ -10,8 +10,8 @@ component Main {
 
 There is no builtin with the name: wtf
 
-   ┌ ./spec/errors/unkown_builtin:3:8
-   ├─────────────────────────────────
+   ┌ errors/unkown_builtin:3:8
+   ├──────────────────────────
   1│ component Main {
   2│   fun render : Html {
   3│     `#{%wtf%}`

--- a/spec/errors/use_condition_mismatch
+++ b/spec/errors/use_condition_mismatch
@@ -31,8 +31,8 @@ it is:
 
 The condition in question is here:
 
-    ┌ ./spec/errors/use_condition_mismatch:17:5
-    ├──────────────────────────────────────────
+    ┌ errors/use_condition_mismatch:17:5
+    ├───────────────────────────────────
   13│   use Provider {
   14│     a: "Hello",
   15│     b: "Blah"

--- a/spec/errors/use_expected_condition
+++ b/spec/errors/use_expected_condition
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the condition of a use but I found "a space" instead:
 
-   ┌ ./spec/errors/use_expected_condition:2:24
-   ├──────────────────────────────────────────
+   ┌ errors/use_expected_condition:2:24
+   ├───────────────────────────────────
   1│ component Main {
   2│   use A { a: "" } when {
    │                         ⌃⌃⌃⌃

--- a/spec/errors/use_expected_condition_closing_bracket
+++ b/spec/errors/use_expected_condition_closing_bracket
@@ -6,8 +6,8 @@ component Main {
 I was expecting the closing bracket of a use condition but I found "a space"
 instead:
 
-   ┌ ./spec/errors/use_expected_condition_closing_bracket:2:29
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/use_expected_condition_closing_bracket:2:29
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   use A { a: "" } when { true
    │                              ⌃⌃⌃⌃

--- a/spec/errors/use_expected_condition_opening_bracket
+++ b/spec/errors/use_expected_condition_opening_bracket
@@ -6,8 +6,8 @@ component Main {
 I was expecting the opening bracket of a use condition but I found "a space"
 instead:
 
-   ┌ ./spec/errors/use_expected_condition_opening_bracket:2:22
-   ├──────────────────────────────────────────────────────────
+   ┌ errors/use_expected_condition_opening_bracket:2:22
+   ├───────────────────────────────────────────────────
   1│ component Main {
   2│   use A { a: "" } when
    │                       ⌃⌃⌃⌃

--- a/spec/errors/use_expected_provider
+++ b/spec/errors/use_expected_provider
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the provider of a use but I found "a space" instead:
 
-   ┌ ./spec/errors/use_expected_provider:2:5
-   ├────────────────────────────────────────
+   ┌ errors/use_expected_provider:2:5
+   ├─────────────────────────────────
   1│ component Main {
   2│   use
    │      ⌃⌃⌃⌃

--- a/spec/errors/use_expected_record
+++ b/spec/errors/use_expected_record
@@ -5,8 +5,8 @@ component Main {
 
 I was expecting the record of a use but I found "a space" instead:
 
-   ┌ ./spec/errors/use_expected_record:2:7
-   ├──────────────────────────────────────
+   ┌ errors/use_expected_record:2:7
+   ├───────────────────────────────
   1│ component Main {
   2│   use A
    │        ⌃⌃⌃⌃

--- a/spec/errors/use_not_found_provider
+++ b/spec/errors/use_not_found_provider
@@ -15,8 +15,8 @@ component Main {
 
 I could not find a provider:
 
-   ┌ ./spec/errors/use_not_found_provider:2:7
-   ├─────────────────────────────────────────
+   ┌ errors/use_not_found_provider:2:7
+   ├──────────────────────────────────
   1│ component Main {
   2│   use Provider {
    │       ⌃⌃⌃⌃⌃⌃⌃⌃

--- a/spec/errors/use_subscription_mismatch
+++ b/spec/errors/use_subscription_mismatch
@@ -41,8 +41,8 @@ Instead it is:
 
 The provider in question is here:
 
-    ┌ ./spec/errors/use_subscription_mismatch:18:3
-    ├─────────────────────────────────────────────
+    ┌ errors/use_subscription_mismatch:18:3
+    ├──────────────────────────────────────
   14│   }
   15│ }
   16│

--- a/spec/errors/variable_missing
+++ b/spec/errors/variable_missing
@@ -18,8 +18,8 @@ I can't find the entity with the name:
 
 Here is where it is referenced:
 
-   ┌ ./spec/errors/variable_missing:3:5
-   ├───────────────────────────────────
+   ┌ errors/variable_missing:3:5
+   ├─────────────────────────────
   1│ module Test {
   2│   fun b : Function(String) {
   3│     XTest.a

--- a/spec/errors/variable_reserved
+++ b/spec/errors/variable_reserved
@@ -12,7 +12,7 @@ component Main {
 
 This name for a variable is a reserved word please use something else:
 
-   ┌ ./spec/errors/variable_reserved:3:5
+   ┌ errors/variable_reserved:3:5
    ├─────────────────────────────────────
   1│ component Main {
   2│   fun b(default : String) : String {

--- a/src/errorable.cr
+++ b/src/errorable.cr
@@ -83,13 +83,13 @@ module Mint
         in Parser
           SnippetData.new(
             to: value.position.offset + value.word.to_s.size,
+            filename: value.file.relative_path,
             from: value.position.offset,
-            input: value.file.contents,
-            filename: value.file.path)
+            input: value.file.contents)
         in Ast::Node
           SnippetData.new(
+            filename: value.file.relative_path,
             input: value.file.contents,
-            filename: value.file.path,
             from: value.from.offset,
             to: value.to.offset)
         in SnippetData


### PR DESCRIPTION
This PR changes the paths of the snippets in error messages to be relative to the project root - the directory where `mint.json` file is. This makes it easier to find since we don't need to read the whole path.

From this:
```
   ┌ /path/to/project/source/Main.mint:3:7
   ├──────────────────────────────────────
```

To this:
```
   ┌ source/Main.mint:3:7
   ├──────────────────────────────────────
```

--------------------------

The only relevant change is in `src/errorable.cr`, the other ones are just snapshot updates for tests.