### PR TITLE
Fix `mint start` dependency installation answer detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .vscode
 node_modules
 coverage
+.aider*
+.env

--- a/src/command.cr
+++ b/src/command.cr
@@ -88,10 +88,12 @@ module Mint
           terminal.puts " ↳ Not all dependencies in your mint.json file are installed."
           terminal.puts "   Would you like to install them now? (Y/n)"
 
-          answer = gets.to_s.downcase
+          # Accept 'Y', 'y' or empty string (Enter) as affirmative response
+          # Empty string is treated as 'Y' since Y is the default option
+          answer = gets.to_s.strip.downcase
           terminal.puts AnsiEscapes::Erase.lines(2)
 
-          if answer == "y"
+          if answer.empty? || answer == "y"
             Installer.new
             break
           else


### PR DESCRIPTION
The current code for `mint start` does not allow usage of return/enter to select the default option of Y(es).
Example run with current mint when pressing Return to select Y
```
➜  ui git:(feature/mint-prototype) mint tool clean
Mint - Removing directories
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Nothing to delete.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
All done in 25μs!
➜  ui git:(feature/mint-prototype) mint start
Mint - Running the development server
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
⚙ Ensuring dependencies...
 ↳ Not all dependencies in your mint.json file are installed.
   Would you like to install them now? (Y/n)


⚠ Missing dependencies...━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
There was an error, exiting...
```

Example run with this fix when pressing Return to select Y
```
➜  ui git:(feature/mint-prototype) ~/Projects/mint/bin/mint tool clean
Mint - Removing directories
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Nothing to delete.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
All done in 31μs!
➜  ui git:(feature/mint-prototype) ~/Projects/mint/bin/mint start
Mint - Running the development server
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
⚙ Ensuring dependencies...
 ↳ Not all dependencies in your mint.json file are installed.
   Would you like to install them now? (Y/n)

⚙ Constructing dependency tree...
  ✔ Updated mint-ui (https://github.com/mint-lang/mint-ui.git)
  ✔ Updated mint-color (https://github.com/mint-lang/mint-color.git)

⚙ Resolving dependency tree...
  ◈ mint-ui ➔ 8.0.0
  ◈ mint-color ➔ 0.9.0

⚙ Copying packages...
⚙ Development server started on http://0.0.0.0:3000/
^C
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Aborted! Exiting...
```