### PR TITLE
Feature/git error hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .vscode
 node_modules
 coverage
+.aider*
+.env

--- a/src/installer/repository.cr
+++ b/src/installer/repository.cr
@@ -63,6 +63,12 @@ module Mint
           block do
             bold error.to_s.strip
           end
+
+          block do
+            text "Hint: Run "
+            bold "mint tool clean; mint tool clean --package-cache"
+            text " to reset local state, and then try again."
+          end
         end unless status.success?
 
         output
@@ -138,6 +144,12 @@ module Mint
           block do
             bold error.to_s.strip
           end
+
+          block do
+            text "Hint: Run "
+            bold "mint tool clean; mint tool clean --package-cache"
+            text " to reset local state, and then try again."
+          end
         end unless status.success?
 
         terminal.puts "  #{CHECKMARK} Updated #{id}"
@@ -157,6 +169,12 @@ module Mint
 
           block do
             bold error.to_s.strip
+          end
+
+          block do
+            text "Hint: Run "
+            bold "mint tool clean; mint tool clean --package-cache"
+            text " to reset local state, and then try again."
           end
         end unless status.success?
 


### PR DESCRIPTION
Provide a hint for the user to run a cleanup to avoid the errors in https://github.com/mint-lang/mint/issues/709 if the package state is corrupt for some reason.