### PR TITLE
Allow comments in things.

### DIFF
--- a/spec/examples/array_literal
+++ b/spec/examples/array_literal
@@ -53,3 +53,14 @@ component Main {
     <div/>
   }
 }
+-------------------------------------------------------------------------------
+module Test {
+  fun test : Array(String) {
+    [
+      // Start Comment
+      "Item 1",
+      // End comment
+      "Item 2"
+    ] of String
+  }
+}

--- a/spec/examples/operation
+++ b/spec/examples/operation
@@ -151,3 +151,10 @@ component Main {
     "Hello" + "There"
   }
 }
+-------------------------------------------------------------------------------
+component Main {
+  fun render : String {
+    "Hello" // Some comment
+    + "There"
+  }
+}

--- a/spec/examples/pipe
+++ b/spec/examples/pipe
@@ -76,3 +76,17 @@ component Main {
     <div/>
   }
 }
+-------------------------------------------------------------------------------
+component Main {
+  fun test (value : String) {
+    value
+  }
+
+  fun render : Html {
+    "test"
+    // Some comment
+    |> test
+
+    <div/>
+  }
+}

--- a/spec/formatters/array_with_comments
+++ b/spec/formatters/array_with_comments
@@ -1,0 +1,21 @@
+module Test {
+  fun test : Array(String) {
+    [
+      // Item 1 Comment
+      "Item 1",
+      // Item 2 comment
+      "Item 2"
+    ] of String
+  }
+}
+--------------------------------------------------------------------------------
+module Test {
+  fun test : Array(String) {
+    [
+      // Item 1 Comment
+      "Item 1",
+      // Item 2 comment
+      "Item 2"
+    ] of String
+  }
+}

--- a/spec/formatters/array_with_comments
+++ b/spec/formatters/array_with_comments
@@ -5,6 +5,7 @@ module Test {
       "Item 1",
       // Item 2 comment
       "Item 2"
+      // End comment
     ] of String
   }
 }
@@ -16,6 +17,7 @@ module Test {
       "Item 1",
       // Item 2 comment
       "Item 2"
+      // End comment
     ] of String
   }
 }

--- a/spec/formatters/operation_with_comment
+++ b/spec/formatters/operation_with_comment
@@ -1,0 +1,13 @@
+component Main {
+  fun render : String {
+    "Hello" // Some comment
+    + "There"
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun render : String {
+    "Hello" // Some comment
+     + "There"
+  }
+}

--- a/spec/formatters/pipe_with_comment
+++ b/spec/formatters/pipe_with_comment
@@ -1,0 +1,27 @@
+component Main {
+  fun test (value : String) {
+    value
+  }
+
+  fun render : Html {
+    "test"
+    // Some comment
+    |> test
+
+    <div/>
+  }
+}
+--------------------------------------------------------------------------------
+component Main {
+  fun test (value : String) {
+    value
+  }
+
+  fun render : Html {
+    "test"
+    // Some comment
+    |> test
+
+    <div/>
+  }
+}

--- a/spec/formatters/record_update_with_comments
+++ b/spec/formatters/record_update_with_comments
@@ -1,0 +1,33 @@
+type A {
+  a : String
+}
+
+module Test {
+  fun test : A {
+    let x =
+      { a : "Blah" }
+
+    { x|
+      // Comment
+      a:"Hello"
+      // End Comment
+    }
+  }
+}
+--------------------------------------------------------------------------------
+type A {
+  a : String
+}
+
+module Test {
+  fun test : A {
+    let x =
+      { a: "Blah" }
+
+    { x |
+      // Comment
+      a: "Hello"
+      // End Comment
+    }
+  }
+}

--- a/spec/formatters/record_with_comments
+++ b/spec/formatters/record_with_comments
@@ -1,0 +1,27 @@
+type A {
+  a : String
+}
+
+module Test {
+  fun test : A {
+    {
+      // Comment
+      a:"Hello"
+      // End Comment
+    }
+  }
+}
+--------------------------------------------------------------------------------
+type A {
+  a : String
+}
+
+module Test {
+  fun test : A {
+    {
+      // Comment
+      a: "Hello"
+      // End Comment
+    }
+  }
+}

--- a/spec/formatters/tuple_with_comments
+++ b/spec/formatters/tuple_with_comments
@@ -5,6 +5,7 @@ module Test {
       "Blah",
       // Comment for "Joe"
       "Joe"
+      // End comment
     }
   }
 }
@@ -16,6 +17,7 @@ module Test {
       "Blah",
       // Comment for "Joe"
       "Joe"
+      // End comment
     }
   }
 }

--- a/spec/formatters/tuple_with_comments
+++ b/spec/formatters/tuple_with_comments
@@ -1,0 +1,21 @@
+module Test {
+  fun test : Tuple(String, String) {
+    {
+      // Comment for "Blah"
+      "Blah",
+      // Comment for "Joe"
+      "Joe"
+    }
+  }
+}
+--------------------------------------------------------------------------------
+module Test {
+  fun test : Tuple(String, String) {
+    {
+      // Comment for "Blah"
+      "Blah",
+      // Comment for "Joe"
+      "Joe"
+    }
+  }
+}

--- a/spec/formatters/type_definition_with_comments
+++ b/spec/formatters/type_definition_with_comments
@@ -1,4 +1,6 @@
-/*A*/typeTest{/*B*/a:String,/*C*/b:Blah}
+/*A*/typeTest{
+  /*B*/a:String,/*C*/b:Blah// End comment
+}
 --------------------------------------------------------------------------------
 /* A */
 type Test {
@@ -7,4 +9,6 @@ type Test {
 
   /* C */
   b : Blah
+
+  // End comment
 }

--- a/src/ast/array_literal.cr
+++ b/src/ast/array_literal.cr
@@ -1,12 +1,13 @@
 module Mint
   class Ast
     class ArrayLiteral < Node
-      getter items, type
+      getter comment, items, type
 
       def initialize(@items : Array(CommentedExpression),
                      @from : Parser::Location,
                      @to : Parser::Location,
                      @file : Parser::File,
+                     @comment : Comment?,
                      @type : Node?)
       end
     end

--- a/src/ast/array_literal.cr
+++ b/src/ast/array_literal.cr
@@ -3,10 +3,10 @@ module Mint
     class ArrayLiteral < Node
       getter items, type
 
-      def initialize(@from : Parser::Location,
+      def initialize(@items : Array(CommentedExpression),
+                     @from : Parser::Location,
                      @to : Parser::Location,
                      @file : Parser::File,
-                     @items : Array(Node),
                      @type : Node?)
       end
     end

--- a/src/ast/commented_expression.cr
+++ b/src/ast/commented_expression.cr
@@ -1,0 +1,14 @@
+module Mint
+  class Ast
+    class CommentedExpression < Node
+      getter expression, comment
+
+      def initialize(@from : Parser::Location,
+                     @to : Parser::Location,
+                     @file : Parser::File,
+                     @comment : Comment?,
+                     @expression : Node)
+      end
+    end
+  end
+end

--- a/src/ast/operation.cr
+++ b/src/ast/operation.cr
@@ -1,11 +1,12 @@
 module Mint
   class Ast
     class Operation < Node
-      getter operator, right, left
+      getter operator, comment, right, left
 
       def initialize(@from : Parser::Location,
                      @to : Parser::Location,
                      @file : Parser::File,
+                     @comment : Comment?,
                      @operator : String,
                      @right : Node,
                      @left : Node)

--- a/src/ast/pipe.cr
+++ b/src/ast/pipe.cr
@@ -1,11 +1,12 @@
 module Mint
   class Ast
     class Pipe < Node
-      getter expression, argument
+      getter expression, argument, comment
 
       def initialize(@from : Parser::Location,
                      @to : Parser::Location,
                      @file : Parser::File,
+                     @comment : Comment?,
                      @expression : Node,
                      @argument : Node)
       end

--- a/src/ast/record.cr
+++ b/src/ast/record.cr
@@ -1,12 +1,13 @@
 module Mint
   class Ast
     class Record < Node
-      getter fields
+      getter fields, comment
 
       def initialize(@from : Parser::Location,
                      @to : Parser::Location,
                      @fields : Array(Field),
-                     @file : Parser::File)
+                     @file : Parser::File,
+                     @comment : Comment?)
       end
     end
   end

--- a/src/ast/record_update.cr
+++ b/src/ast/record_update.cr
@@ -1,13 +1,14 @@
 module Mint
   class Ast
     class RecordUpdate < Node
-      getter expression, fields
+      getter expression, fields, comment
 
       def initialize(@from : Parser::Location,
                      @expression : Ast::Node,
                      @to : Parser::Location,
                      @fields : Array(Field),
-                     @file : Parser::File)
+                     @file : Parser::File,
+                     @comment : Comment?)
       end
     end
   end

--- a/src/ast/tuple_literal.cr
+++ b/src/ast/tuple_literal.cr
@@ -1,12 +1,13 @@
 module Mint
   class Ast
     class TupleLiteral < Node
-      getter items
+      getter comment, items
 
       def initialize(@items : Array(CommentedExpression),
                      @from : Parser::Location,
                      @to : Parser::Location,
-                     @file : Parser::File)
+                     @file : Parser::File,
+                     @comment : Comment?)
       end
     end
   end

--- a/src/ast/tuple_literal.cr
+++ b/src/ast/tuple_literal.cr
@@ -3,10 +3,10 @@ module Mint
     class TupleLiteral < Node
       getter items
 
-      def initialize(@from : Parser::Location,
+      def initialize(@items : Array(CommentedExpression),
+                     @from : Parser::Location,
                      @to : Parser::Location,
-                     @file : Parser::File,
-                     @items : Array(Node))
+                     @file : Parser::File)
       end
     end
   end

--- a/src/ast/type_definition.cr
+++ b/src/ast/type_definition.cr
@@ -1,11 +1,12 @@
 module Mint
   class Ast
     class TypeDefinition < Node
-      getter parameters, comment, fields, name
+      getter parameters, end_comment, comment, fields, name
 
       def initialize(@fields : Array(TypeDefinitionField) | Array(TypeVariant),
                      @parameters : Array(TypeVariable),
                      @from : Parser::Location,
+                     @end_comment : Comment?,
                      @to : Parser::Location,
                      @file : Parser::File,
                      @comment : Comment?,

--- a/src/compilers/commented_expression.cr
+++ b/src/compilers/commented_expression.cr
@@ -1,0 +1,9 @@
+module Mint
+  class Compiler
+    def compile(node : Ast::CommentedExpression) : Compiled
+      compile node do
+        compile(node.expression)
+      end
+    end
+  end
+end

--- a/src/formatter.cr
+++ b/src/formatter.cr
@@ -47,7 +47,8 @@ module Mint
     #
     record List,
       items : Array(Tuple(Ast::Node, Nodes)),
-      separator : String? = nil
+      separator : String? = nil,
+      comment : Nodes? = nil
 
     # Describes a group of nodes, with start and end characters and a separator
     # character (or characters). The layout of the nodes are determined during
@@ -83,7 +84,8 @@ module Mint
       items : Array(Nodes),
       behavior : Behavior,
       separator : String,
-      pad : Bool
+      pad : Bool,
+      comment : Nodes = [] of Node
 
     # The possibilities on how to format groups.
     enum Behavior
@@ -131,10 +133,6 @@ module Mint
 
     def group(**params)
       [Group.new(**params)] of Node
-    end
-
-    def list(**params)
-      [List.new(**params)] of Node
     end
 
     # Actuall formatting things as strings...

--- a/src/formatters/array_literal.cr
+++ b/src/formatters/array_literal.cr
@@ -12,6 +12,7 @@ module Mint
         else
           group(
             items: node.items.map(&->format(Ast::Node)),
+            comment: format(node.comment),
             behavior: Behavior::BreakAll,
             ends: {"[", "]"},
             separator: ",",

--- a/src/formatters/commented_expression.cr
+++ b/src/formatters/commented_expression.cr
@@ -1,0 +1,13 @@
+module Mint
+  class Formatter
+    def format(node : Ast::CommentedExpression) : Nodes
+      comment =
+        format_documentation_comment node.comment
+
+      expression =
+        format node.expression
+
+      comment + expression
+    end
+  end
+end

--- a/src/formatters/list.cr
+++ b/src/formatters/list.cr
@@ -1,9 +1,16 @@
 module Mint
   class Formatter
-    def list(nodes : Array(Ast::Node), delimeter : String? = nil) : Nodes
-      list(
-        items: nodes.map(&.as(Ast::Node)).zip(nodes.map(&->format(Ast::Node))),
-        separator: delimeter)
+    def list(
+      nodes : Array(Ast::Node),
+      separator : String? = nil,
+      comment : Nodes? = nil
+    ) : Nodes
+      [
+        List.new(
+          items: nodes.map(&.as(Ast::Node)).zip(nodes.map(&->format(Ast::Node))),
+          separator: separator,
+          comment: comment),
+      ] of Node
     end
   end
 end

--- a/src/formatters/operation.cr
+++ b/src/formatters/operation.cr
@@ -1,17 +1,18 @@
 module Mint
   class Formatter
     def format(node : Ast::Operation) : Nodes
+      comment =
+        format_documentation_comment(node.comment).tap do |item|
+          item.unshift(" ") if item.size > 0
+        end
+
       left =
         format node.left
 
       right =
         format node.right
 
-      if node.right.is_a?(Ast::Operation)
-        left + [" #{node.operator} "] + right
-      else
-        left + [" #{node.operator} "] + right
-      end
+      left + comment + [" #{node.operator} "] + right
     end
   end
 end

--- a/src/formatters/pipe.cr
+++ b/src/formatters/pipe.cr
@@ -1,13 +1,16 @@
 module Mint
   class Formatter
     def format(node : Ast::Pipe) : Nodes
+      comment =
+        format_documentation_comment node.comment
+
       argument =
         format node.argument
 
       expression =
         format node.expression
 
-      argument + [Line.new(1), "|> "] of Node + expression
+      argument + ([Line.new(1)] of Node) + comment + (["|> "] of Node) + expression
     end
   end
 end

--- a/src/formatters/record.cr
+++ b/src/formatters/record.cr
@@ -6,6 +6,7 @@ module Mint
       else
         group(
           items: node.fields.map(&->format(Ast::Node)),
+          comment: format(node.comment),
           behavior: Behavior::BreakAll,
           ends: {"{", "}"},
           separator: ",",

--- a/src/formatters/record_update.cr
+++ b/src/formatters/record_update.cr
@@ -7,6 +7,7 @@ module Mint
       ["{ "] + expression + [" |"] +
         group(
           items: node.fields.map(&->format(Ast::Node)),
+          comment: format(node.comment),
           behavior: Behavior::BreakAll,
           ends: {"", "}"},
           separator: ",",

--- a/src/formatters/tuple_literal.cr
+++ b/src/formatters/tuple_literal.cr
@@ -3,6 +3,7 @@ module Mint
     def format(node : Ast::TupleLiteral) : Nodes
       group(
         items: node.items.map(&->format(Ast::Node)),
+        comment: format(node.comment),
         behavior: Behavior::BreakAll,
         ends: {"{", "}"},
         separator: ",",

--- a/src/formatters/type_definition.cr
+++ b/src/formatters/type_definition.cr
@@ -10,17 +10,20 @@ module Mint
       name =
         format node.name
 
+      end_comment =
+        node.end_comment.try(&->format(Ast::Comment))
+
       comment + ["type "] + name + parameters + [" "] +
         if node.fields.is_a?(Array(Ast::TypeVariant))
           group(
+            items: [list(nodes: node.fields, comment: end_comment)],
             behavior: Behavior::Block,
-            items: [list(node.fields)],
             ends: {"{", "}"},
             separator: "",
             pad: false)
         else
           group(
-            items: [list(node.fields, ",")],
+            items: [list(nodes: node.fields, separator: ",", comment: end_comment)],
             behavior: Behavior::Block,
             ends: {"{", "}"},
             separator: ",",

--- a/src/parsers/array_literal.cr
+++ b/src/parsers/array_literal.cr
@@ -8,7 +8,7 @@ module Mint
         items = list(
           terminator: ']',
           separator: ','
-        ) { expression }
+        ) { commented_expression }
         whitespace
 
         next error :array_expected_closing_bracket do

--- a/src/parsers/array_literal.cr
+++ b/src/parsers/array_literal.cr
@@ -11,6 +11,9 @@ module Mint
         ) { commented_expression }
         whitespace
 
+        comment = self.comment
+        whitespace
+
         next error :array_expected_closing_bracket do
           expected "the closing bracket of an array", word
           snippet self
@@ -41,6 +44,7 @@ module Mint
 
         Ast::ArrayLiteral.new(
           from: start_position,
+          comment: comment,
           items: items,
           to: position,
           type: type,

--- a/src/parsers/commented_expression.cr
+++ b/src/parsers/commented_expression.cr
@@ -1,0 +1,19 @@
+module Mint
+  class Parser
+    def commented_expression : Ast::CommentedExpression?
+      parse do |start_position|
+        comment = self.comment
+        whitespace
+
+        return unless expression = self.expression
+
+        Ast::CommentedExpression.new(
+          expression: expression,
+          from: start_position,
+          comment: comment,
+          to: position,
+          file: file)
+      end
+    end
+  end
+end

--- a/src/parsers/expression.cr
+++ b/src/parsers/expression.cr
@@ -3,8 +3,11 @@ module Mint
     def expression : Ast::Node?
       return unless expression = base_expression
 
-      if operator = self.operator
-        pipe operation(expression, operator)
+      if item = self.operator
+        operator, comment =
+          item
+
+        pipe operation(expression, operator, comment)
       else
         expression
       end

--- a/src/parsers/operation.cr
+++ b/src/parsers/operation.cr
@@ -5,26 +5,35 @@ module Mint
     # found in the operator parser file.
     #
     # Operations can be chained recursively with this method as seen below.
-    def operation(left : Ast::Node, operator : String) : Ast::Operation?
+    def operation(
+      left : Ast::Node,
+      operator : String,
+      comment : Ast::Comment?
+    ) : Ast::Operation?
       parse do
         next error :operation_expected_expression do
           expected "the right side expression of an operation", word
           snippet self
         end unless right = base_expression
 
-        if next_operator = self.operator
+        if item = self.operator
+          next_operator, next_comment =
+            item
+
           if OPERATORS[next_operator] > OPERATORS[operator]
-            right = operation(right, next_operator)
+            right = operation(right, next_operator, next_comment)
           else
             return operation(
               Ast::Operation.new(
                 operator: operator,
+                comment: comment,
                 from: left.from,
                 to: right.to,
                 right: right,
                 file: file,
                 left: left),
-              next_operator)
+              next_operator,
+              next_comment)
           end
         end
 
@@ -32,6 +41,7 @@ module Mint
 
         Ast::Operation.new(
           operator: operator,
+          comment: comment,
           from: left.from,
           to: right.to,
           right: right,

--- a/src/parsers/operator.cr
+++ b/src/parsers/operator.cr
@@ -26,8 +26,11 @@ module Mint
       "!"  => 16,
     }
 
-    def operator : String?
+    def operator : Tuple(String, Ast::Comment?)?
       parse do |start_position|
+        whitespace
+
+        comment = self.comment
         whitespace
 
         saved_position =
@@ -90,7 +93,7 @@ module Mint
         end
 
         whitespace
-        operator
+        {operator, comment}
       end
     end
   end

--- a/src/parsers/pipe.cr
+++ b/src/parsers/pipe.cr
@@ -17,6 +17,7 @@ module Mint
         end
 
       Ast::Pipe.new(
+        comment: operation.comment,
         expression: expression,
         from: argument.from,
         argument: argument,

--- a/src/parsers/record.cr
+++ b/src/parsers/record.cr
@@ -8,7 +8,11 @@ module Mint
 
         unless char! '}'
           whitespace
+
           fields = list(terminator: '}', separator: ',') { field }
+          whitespace
+
+          comment = self.comment
           whitespace
 
           next unless char! '}'
@@ -18,6 +22,7 @@ module Mint
 
         Ast::Record.new(
           from: start_position,
+          comment: comment,
           fields: fields,
           to: position,
           file: file)

--- a/src/parsers/record_update.cr
+++ b/src/parsers/record_update.cr
@@ -31,6 +31,8 @@ module Mint
         end if fields.empty?
 
         whitespace
+        comment = self.comment
+        whitespace
 
         next error :record_update_expected_closing_bracket do
           expected "the closing bracket of a record update", word
@@ -40,6 +42,7 @@ module Mint
         Ast::RecordUpdate.new(
           expression: expression,
           from: start_position,
+          comment: comment,
           fields: fields,
           to: position,
           file: file)

--- a/src/parsers/tuple_literal.cr
+++ b/src/parsers/tuple_literal.cr
@@ -5,13 +5,13 @@ module Mint
         next unless char! '{'
 
         whitespace
-        next unless head = expression
+        next unless head = commented_expression
 
         whitespace
         next unless char! ','
 
         items =
-          list(terminator: '}', separator: ',') { expression }
+          list(terminator: '}', separator: ',') { commented_expression }
 
         whitespace
         next unless char! '}'

--- a/src/parsers/tuple_literal.cr
+++ b/src/parsers/tuple_literal.cr
@@ -14,12 +14,16 @@ module Mint
           list(terminator: '}', separator: ',') { commented_expression }
 
         whitespace
+        comment = self.comment
+        whitespace
+
         next unless char! '}'
 
         items.unshift(head)
 
         Ast::TupleLiteral.new(
           from: start_position,
+          comment: comment,
           to: position,
           items: items,
           file: file)

--- a/src/parsers/type_definition.cr
+++ b/src/parsers/type_definition.cr
@@ -30,7 +30,7 @@ module Mint
 
         whitespace
 
-        fields = begin
+        fields, end_comment = begin
           if char! '{'
             variants =
               list(separator: ',', terminator: '}') { type_definition_field }
@@ -43,16 +43,20 @@ module Mint
               end
 
             whitespace
+            fields_comment = self.comment
+            whitespace
+
             next error :type_definition_expected_closing_bracket do
               expected "the closing bracket of a type definition", word
               snippet self
             end unless char! '}'
 
-            items
-          end || [] of Ast::TypeDefinitionField
+            {items, fields_comment}
+          end || {[] of Ast::TypeDefinitionField, nil}
         end
 
         Ast::TypeDefinition.new(
+          end_comment: end_comment,
           parameters: parameters,
           from: start_position,
           comment: comment,

--- a/src/scope.cr
+++ b/src/scope.cr
@@ -229,6 +229,7 @@ module Mint
            Ast::Js
         build(node.value.select(Ast::Interpolation), node)
       when Ast::ParenthesizedExpression,
+           Ast::CommentedExpression,
            Ast::NegatedExpression,
            Ast::Interpolation,
            Ast::UnaryMinus,

--- a/src/type_checkers/commented_expression.cr
+++ b/src/type_checkers/commented_expression.cr
@@ -1,0 +1,7 @@
+module Mint
+  class TypeChecker
+    def check(node : Ast::CommentedExpression) : Checkable
+      resolve node.expression
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it so that comments are parsed in previously not allowed places:
- Between array and tuple items
- At the end of arrays, tuples, records and type definitions
- Before operators (mostly for pipes)

Fixes #634 #635
See also: https://discord.com/channels/698214718241767445/701755309307199508/1308863613062221965