### PR TITLE
Fix parsing of parenthesized expression and inline function.

### DIFF
--- a/spec/examples/argument
+++ b/spec/examples/argument
@@ -48,4 +48,9 @@ component Main {
     test()
   }
 }
-
+-------------------------------------------------------------------------------
+component Main {
+  fun render : String {
+    (value: String) { value }("")
+  }
+}

--- a/src/parsers/base_expression.cr
+++ b/src/parsers/base_expression.cr
@@ -10,7 +10,8 @@ module Mint
       left =
         case char
         when '('
-          parenthesized_expression || inline_function
+          # TODO: Remove `oneof` when `:` deprecation ends.
+          oneof { parenthesized_expression || inline_function }
         when '-', .ascii_number?
           state_setter || number_literal || unary_minus
         when '!'


### PR DESCRIPTION
Related to #717 In it, `(err: String)` is incorrectly getting parsed as a parenthesized expression and errors out. This PR fixes it by trying to parse both and return the one that succeeds.