### PR TITLE
URI  decode the request path.

### DIFF
--- a/src/reactor.cr
+++ b/src/reactor.cr
@@ -45,11 +45,14 @@ module Mint
           HTTP::CompressHandler.new,
           websocket_handler,
         ]) do |context|
+          path =
+            URI.decode(context.request.path)
+
           # Handle the request depending on the result.
           content_type, content =
-            if file = @files[context.request.path]?
+            if file = @files[path]?
               {
-                MIME.from_filename?(context.request.path).to_s || "text/plain",
+                MIME.from_filename?(path).to_s || "text/plain",
                 file.call,
               }
             else

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -97,14 +97,15 @@ module Mint
         end
 
       @server =
-        HTTP::Server.new([
-          websocket_handler,
-        ]) do |context|
+        HTTP::Server.new([websocket_handler]) do |context|
+          path =
+            URI.decode(context.request.path)
+
           # Handle the request depending on the result.
           content_type, content =
-            if file = @files[context.request.path]?
+            if file = @files[path]?
               {
-                MIME.from_filename?(context.request.path).to_s || "text/plain",
+                MIME.from_filename?(path).to_s || "text/plain",
                 file.call,
               }
             else


### PR DESCRIPTION
The path of files which are served are not URI encoded, but the request path is, so we need to decode the request path so it can match the proper file.