### PR TITLE
Make sure we try destructure the right thing.

### DIFF
--- a/spec/examples/access
+++ b/spec/examples/access
@@ -151,3 +151,27 @@ component Main {
     Test.print("a")
   }
 }
+-------------------------------------------------------------------------------
+store Settings {
+  state settings : String = ""
+}
+
+module App.Page {
+  fun test {
+    ""
+  }
+}
+
+enum App.Page {
+  Settings
+  Page
+}
+
+component Main {
+  fun render : Html {
+    case App.Page.Settings {
+      App.Page.Settings => <div></div>
+      App.Page.Page => <div></div>
+    }
+  }
+}


### PR DESCRIPTION
Currently, if we have a type and a module with the same name and try to match on a value of the type will find the module first, which can lead to errors:

```mint
module App.Page {
  fun test {
    ""
  }
}

enum App.Page {
  Settings
  Page
}

component Main {
  fun render : Html {
    case App.Page.Settings {
      App.Page.Settings => <div></div>
      App.Page.Page => <div></div>
    }
  }
}
```

It would `App.Page.Settings` would resolve the `App.Page` module instead of the type it errors out since there is no `Settings` in the module.

This PR fixes that by checking if there is a type and a variant before checking the module and it's entities.