### PR TITLE
Highlight single character errors.

### DIFF
--- a/spec/errors/access_expected_field_2
+++ b/spec/errors/access_expected_field_2
@@ -1,0 +1,14 @@
+component Main {
+  fun render : String {
+    "". word
+--------------------------------------------------------------------------------
+░ ERROR (ACCESS_EXPECTED_FIELD) ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+I was expecting the name of the accessed entity but I found "a space" instead:
+
+   ┌ errors/access_expected_field_2:3:8
+   ├───────────────────────────────────
+  1│ component Main {
+  2│   fun render : String {
+  3│     "". word
+   │        ⌃

--- a/src/errorable.cr
+++ b/src/errorable.cr
@@ -81,8 +81,11 @@ module Mint
       target =
         case value
         in Parser
+          min =
+            value.char == '\0' ? 0 : 1
+
           SnippetData.new(
-            to: value.position.offset + value.word.to_s.size,
+            to: value.position.offset + [min, value.word.to_s.size].max,
             filename: value.file.relative_path,
             from: value.position.offset,
             input: value.file.contents)

--- a/src/parsers/connect_variable.cr
+++ b/src/parsers/connect_variable.cr
@@ -5,23 +5,27 @@ module Mint
         next unless name = variable_constant(track: false) ||
                            variable(track: false)
 
-        whitespace
-        if keyword! "as"
-          whitespace
+        target =
+          parse do
+            whitespace
+            next unless keyword! "as"
+            whitespace
 
-          next error :connect_variable_expected_as do
-            block do
-              text "The"
-              bold "exposed name"
-              text "of a connection"
-              bold "must be specified, here is an example:"
-            end
+            next error :connect_variable_expected_as do
+              block do
+                text "The"
+                bold "exposed name"
+                text "of a connection"
+                bold "must be specified, here is an example:"
+              end
 
-            snippet "connect Store exposing { item as name }"
-            expected "the exposed name", word
-            snippet self
-          end unless target = variable
-        end
+              snippet "connect Store exposing { item as name }"
+              expected "the exposed name", word
+              snippet self
+            end unless variable = self.variable
+
+            variable
+          end
 
         Ast::ConnectVariable.new(
           from: start_position,

--- a/src/utils/terminal_snippet.cr
+++ b/src/utils/terminal_snippet.cr
@@ -34,16 +34,16 @@ module Mint
           self[0, diff_from]
 
         center =
-          self[diff_from, diff_to].colorize.on(:white).fore(:red).to_s
+          self[diff_from, diff_to]
 
         right =
           self[diff_to, contents.size]
 
         highlighted =
-          left + center + right
+          left + center.colorize.on(:white).fore(:red).to_s + right
 
         arrows =
-          (" " * left.size) + ("⌃" * center.uncolorize.size)
+          (" " * left.size) + ("⌃" * center.size)
 
         {highlighted, arrows}
       end


### PR DESCRIPTION
Fixes #717 Also contains a change related to this: connect variable eats trailing whitespace if there is no `as name` part, which with the changes in the PR would highlight the whitespace.