### PR TITLE
Fix typo when unable to find file

### DIFF
--- a/src/ast/directives/file_based.cr
+++ b/src/ast/directives/file_based.cr
@@ -34,7 +34,7 @@ module Mint
         # file will not be cached.
         def filename(*, build : Bool) : String?
           error! :file_not_found do
-            snippet "I cloudn't find a file:", self
+            snippet "I couldn't find a file:", self
           end unless exists?
 
           hash_base =


### PR DESCRIPTION
`Ast::Directives::FileBased` had a typo in the error message when it couldn't find a file. This fixes that.