### PR TITLE
Extend `Set` module

### DIFF
--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -137,4 +137,23 @@ module Set {
   ) {
     `#{set}.reduce(#{function}, #{initial})`
   }
+
+  /*
+  Returns a set containing all items in the two input sets.
+
+    let left =
+      [1, 2, 3]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5]
+      |> Set.fromArray
+
+    (Set.union(left, right)
+    |> Set.toArray
+    |> Array.sort((a : Number, b : Number) { a - b })) == [1, 2, 3, 4, 5]
+  */
+  fun union (left : Set(item), right : Set(item)) : Set(item) {
+    reduce(left, right, Set.add)
+  }
 }

--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -205,4 +205,22 @@ module Set {
         }
       })
   }
+
+  /*
+  Returns true if the input sets contain no elements in common.
+
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [0, 5, -1, 6]
+      |> Set.fromArray
+
+    Set.isDisjoint(left, right) == true
+  */
+  fun isDisjoint (left : Set(item), right : Set(item)) : Bool {
+    reduce(left, true,
+      (memo : Bool, value : item) { memo && !Set.has(right, value) })
+  }
 }

--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -180,4 +180,29 @@ module Set {
         }
       })
   }
+
+  /*
+  Returns a set containing elements from the first input set which are not in
+    the second input set.
+
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5, 6]
+      |> Set.fromArray
+
+    Set.difference(left, right) == Set.fromArray([1, 2])
+  */
+  fun difference (left : Set(item), right : Set(item)) : Set(item) {
+    reduce(left, Set.empty(),
+      (memo : Set(item), value : item) {
+        if Set.has(right, value) {
+          memo
+        } else {
+          Set.add(memo, value)
+        }
+      })
+  }
 }

--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -156,4 +156,28 @@ module Set {
   fun union (left : Set(item), right : Set(item)) : Set(item) {
     reduce(left, right, Set.add)
   }
+
+  /*
+  Returns a set containing all those elements shared by the two input sets.
+
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5, 6]
+      |> Set.fromArray
+
+    Set.union(left, right) == Set.fromArray([3, 4])
+  */
+  fun intersection (left : Set(item), right : Set(item)) : Set(item) {
+    reduce(left, Set.empty(),
+      (memo : Set(item), value : item) {
+        if Set.has(right, value) {
+          Set.add(memo, value)
+        } else {
+          memo
+        }
+      })
+  }
 }

--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -223,4 +223,23 @@ module Set {
     reduce(left, true,
       (memo : Bool, value : item) { memo && !Set.has(right, value) })
   }
+
+  /*
+  Returns true if the first input set contains every element in the second input
+  set.
+
+    let inner =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let outer =
+      [3, 4, 5, 6, 1, 2]
+      |> Set.fromArray
+
+    Set.isSuperset(outer, inner) == true
+  */
+  fun isSuperset (outer : Set(item), inner : Set(item)) : Bool {
+    reduce(inner, true,
+      (memo : Bool, value : item) { memo && Set.has(outer, value) })
+  }
 }

--- a/core/source/Set.mint
+++ b/core/source/Set.mint
@@ -120,4 +120,21 @@ module Set {
   fun toArray (set : Set(item)) : Array(item) {
     `#{set}`
   }
+
+  /*
+  Applies the function against an accumulator and each element in the set (in
+    insertion order, according to the set's underlying array representation) to
+    reduce it to a single value.
+
+    ([1, 2, 3]
+      |> Set.fromArray
+      |> Set.reduce(0, (memo : Number, item : Number) : Number { memo + item })) == 6
+  */
+  fun reduce (
+    set : Set(item),
+    initial : memo,
+    function : Function(memo, item, memo)
+  ) {
+    `#{set}.reduce(#{function}, #{initial})`
+  }
 }

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -82,3 +82,11 @@ suite "Set.size" {
     Set.size(Set.fromArray([0, 1, 2])) == 3
   }
 }
+
+suite "Set.reduce" {
+  test "it reduces a set to a single value" {
+    ([1, 2, 3]
+    |> Set.fromArray
+    |> Set.reduce(0, (memo : Number, item : Number) : Number { memo + item })) == 6
+  }
+}

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -148,3 +148,17 @@ suite "Set.isDisjoint" {
     Set.isDisjoint(left, right)
   }
 }
+
+suite "Set.isSuperset" {
+  test "it returns true if outer set contains all elements in inner set" {
+    let inner =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let outer =
+      [3, 4, 5, 6, 1, 2]
+      |> Set.fromArray
+
+    Set.isSuperset(outer, inner)
+  }
+}

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -134,3 +134,17 @@ suite "Set.difference" {
     Set.difference(left, right) == Set.fromArray([1, 2])
   }
 }
+
+suite "Set.isDisjoint" {
+  test "it returns true if the two input sets contain no elements in common" {
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [0, 5, -1, 6]
+      |> Set.fromArray
+
+    Set.isDisjoint(left, right)
+  }
+}

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -106,3 +106,17 @@ suite "Set.union" {
     |> Array.sort((a : Number, b : Number) { a - b })) == [1, 2, 3, 4, 5]
   }
 }
+
+suite "Set.intersection" {
+  test "it returns a set containing the shared elements of two sets" {
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5, 6]
+      |> Set.fromArray
+
+    Set.intersection(left, right) == Set.fromArray([3, 4])
+  }
+}

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -90,3 +90,19 @@ suite "Set.reduce" {
     |> Set.reduce(0, (memo : Number, item : Number) : Number { memo + item })) == 6
   }
 }
+
+suite "Set.union" {
+  test "it returns a set which is the union of two sets" {
+    let left =
+      [1, 2, 3]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5]
+      |> Set.fromArray
+
+    (Set.union(left, right)
+    |> Set.toArray
+    |> Array.sort((a : Number, b : Number) { a - b })) == [1, 2, 3, 4, 5]
+  }
+}

--- a/core/tests/tests/Set.mint
+++ b/core/tests/tests/Set.mint
@@ -120,3 +120,17 @@ suite "Set.intersection" {
     Set.intersection(left, right) == Set.fromArray([3, 4])
   }
 }
+
+suite "Set.difference" {
+  test "it returns a set containing elements of one set which are not in the other" {
+    let left =
+      [1, 2, 3, 4]
+      |> Set.fromArray
+
+    let right =
+      [3, 4, 5, 6]
+      |> Set.fromArray
+
+    Set.difference(left, right) == Set.fromArray([1, 2])
+  }
+}


### PR DESCRIPTION
This PR extends the Set module with more functions that you might typically use with sets:
- reduce
- set union, intersection & difference
- disjoint and superset predicates

It also contains minimal unit tests for these.