### PR TITLE
Implement function captures.

### DIFF
--- a/spec/compilers/call_captured
+++ b/spec/compilers/call_captured
@@ -1,0 +1,20 @@
+component Main {
+  fun test (argument1 : String, argument2: Number) : Html {
+    <div/>
+  }
+
+  fun render : Html {
+    test(_, _)("A", 0)
+  }
+}
+--------------------------------------------------------------------------------
+import { createElement as A } from "./runtime.js";
+
+export const B = () => {
+  const a = (b, c) => {
+    return A(`div`, {})
+  };
+  return ((d, e) => {
+    a(d, e)
+  })(`A`, 0)
+};

--- a/spec/compilers/call_labelled_captured
+++ b/spec/compilers/call_labelled_captured
@@ -1,0 +1,18 @@
+component Main {
+  fun test (argument1 : String, argument2: Number) : String {
+    ""
+  }
+
+  fun render : String {
+    test(argument2: 0, argument1: _)("")
+  }
+}
+--------------------------------------------------------------------------------
+export const A = () => {
+  const a = (b, c) => {
+    return ``
+  };
+  return ((d) => {
+    a(d, 0)
+  })(``)
+};

--- a/spec/examples/call
+++ b/spec/examples/call
@@ -161,6 +161,36 @@ component Main {
   }
 }
 -------------------------------------------------------------------------------
+component Main {
+  fun test (argument1 : String, argument2: Number) : Html {
+    <div/>
+  }
+
+  fun render : Html {
+    test(_, _)("A", 0)
+  }
+}
+-------------------------------------------------------------------------------
+component Main {
+  fun test (argument1 : String, argument2: Number) : Html {
+    <div/>
+  }
+
+  fun render : Html {
+    test("A", _)(0)
+  }
+}
+-------------------------------------------------------------------------------
+component Main {
+  fun test (argument1 : String, argument2: Number) : Html {
+    <div/>
+  }
+
+  fun render : Html {
+    test(_, 0)("A")
+  }
+}
+-------------------------------------------------------------------------------
 module Test {
   fun a (x : Bool, value : String) : String {
     value

--- a/src/parsers/call.cr
+++ b/src/parsers/call.cr
@@ -8,7 +8,7 @@ module Mint
         arguments = list(
           terminator: ')',
           separator: ','
-        ) { field(key_required: false) }
+        ) { field(key_required: false, discard: true) }
 
         whitespace
         next error :call_expected_closing_parenthesis do

--- a/src/parsers/field.cr
+++ b/src/parsers/field.cr
@@ -1,6 +1,6 @@
 module Mint
   class Parser
-    def field(*, key_required : Bool = true) : Ast::Field?
+    def field(*, key_required : Bool = true, discard : Bool = false) : Ast::Field?
       parse do |start_position|
         comment = self.comment
         whitespace
@@ -17,7 +17,13 @@ module Mint
           end
 
         next if key_required && !key
-        next unless value = expression
+
+        next unless value =
+                      if discard
+                        self.discard || expression
+                      else
+                        expression
+                      end
 
         Ast::Field.new(
           from: start_position,


### PR DESCRIPTION
This PR implements function captures, which is a way to have partial application:

```mint
fun add(a: Number, b: Number) : Number {
  a + b
}

// All of them are the same:
let addOne = (c: Number) { add(c, 1) }
let addOne = add(a: _, b: 1)
let addOne = add(_, 1)
```