### PR TITLE
Fix typo in docstring

### DIFF
--- a/core/source/Maybe.mint
+++ b/core/source/Maybe.mint
@@ -54,7 +54,7 @@ module Maybe {
   /*
   Returns whether the maybe is nothing.
 
-    Maybe.isNothing(Maybe.Nothing("A")) == false
+    Maybe.isNothing(Maybe.Nothing) == true
     Maybe.isNothing(Maybe.Just("A")) == false
   */
   fun isNothing (maybe : Maybe(value)) : Bool {


### PR DESCRIPTION
This PR fixes a typo in a docstring.

See this associated issue:

https://github.com/mint-lang/mint-website/issues/24