### PR TITLE
Fix mint compilation with Crystal version between 1.8.X & 1.10.X

### DIFF
--- a/src/ast/directives/file_based.cr
+++ b/src/ast/directives/file_based.cr
@@ -1,3 +1,5 @@
+require "digest/md5"
+
 module Mint
   class Ast
     module Directives

--- a/src/compilers/here_document.cr
+++ b/src/compilers/here_document.cr
@@ -1,3 +1,5 @@
+require "digest/md5"
+
 module Mint
   class Compiler
     def compile(node : Ast::HereDocument) : Compiled


### PR DESCRIPTION
Since crystal version 1.8.0, Digest::MD5 require an explicit import, so to allow compilation of mint with newer version of crystal i submit this PR with this import addition

This import doesn't break compatibility with current crystal version declared in shard.yml (Because we can use this import since version 0.21.0 of crystal)

Some precision : Atm we can compile project with newer version of crystal but any version between 1.8 & 1.11 (excluded) can't build mint due of this lack of import. Any version since 1.11 can compile without this explicit import because uuid of crystal import md5 explicitly (Cf here : https://github.com/crystal-lang/crystal/commit/008d76a15778772fb4b8bca2a38d834985dd44a8)

Cf :
 * https://crystal-lang.org/api/1.8.0/Digest/MD5.html
 * https://crystal-lang.org/api/1.7.3/Digest/MD5.html
 * https://crystal-lang.org/api/1.7.0/Digest/MD5.html
 * https://github.com/crystal-lang/crystal/blob/0.21.0/src/digest/md5.cr
 * https://github.com/crystal-lang/crystal/blob/1.8.0/src/digest/md5.cr