### PR TITLE
Add command line switch to display browser output during mint test

### DIFF
--- a/spec_cli/test_spec.cr
+++ b/spec_cli/test_spec.cr
@@ -31,6 +31,7 @@ context "test" do
         --port, -p (default: (ENV["PORT"]? || "3001").to_i)                  # Port to serve the tests on.
         --reporter, -r (default: "dot")                                      # Which reporter to use (dot, documentation),
         --runtime                                                            # If specified, the supplied runtime will be used instead of the default.
+        --show-browser-output                                                # If specified, output (stdio & stderr) of browser are displayed.
         --watch, -w                                                          # Watch files for changes and rerun tests.
 
       Arguments:

--- a/src/commands/test.cr
+++ b/src/commands/test.cr
@@ -13,6 +13,10 @@ module Mint
         default: "chrome",
         short: "b"
 
+      define_flag show_browser_output : Bool,
+        description: "If specified, output (stdio & stderr) of browser are displayed.",
+        default: false
+
       define_flag browser_host : String,
         description: "Target host, useful when hosted on another machine.",
         default: ENV["BROWSER_HOST"]? || "127.0.0.1",

--- a/src/test_runner.cr
+++ b/src/test_runner.cr
@@ -18,7 +18,7 @@ module Mint
 
     def initialize(flags : Cli::Test::Flags, @arguments : Cli::Test::Arguments)
       @reporter = resolve_reporter(flags.reporter.downcase)
-      @browser = Browser.new(flags.browser.downcase)
+      @browser = Browser.new(flags.browser.downcase, flags.show_browser_output)
       @watch = flags.watch || flags.manual
 
       Workspace.new(


### PR DESCRIPTION
In some case (e.g. during CI build for example), it can be useful to show output of browser invoked by mint (For example when browser crash or exits with an error due of some configuration error)

So i propose to add following command line switch (--show-browser-output) for this purpose